### PR TITLE
Join mint URL and endpoint in a safe way

### DIFF
--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -8,6 +8,7 @@ import uuid
 from datetime import datetime, timedelta
 from itertools import groupby
 from typing import Dict, List, Optional, Tuple, Union
+from urllib.parse import urljoin
 
 import requests
 from bip32 import BIP32
@@ -350,7 +351,7 @@ class LedgerAPI(object):
             Exception: If no keys are received from the mint
         """
         resp = self.s.get(
-            url + "/keys",
+            urljoin(url, "keys"),
         )
         self.raise_on_error(resp)
         keys: dict = resp.json()
@@ -379,7 +380,7 @@ class LedgerAPI(object):
         """
         keyset_id_urlsafe = keyset_id.replace("+", "-").replace("/", "_")
         resp = self.s.get(
-            url + f"/keys/{keyset_id_urlsafe}",
+            urljoin(url, f"keys/{keyset_id_urlsafe}"),
         )
         self.raise_on_error(resp)
         keys = resp.json()
@@ -405,7 +406,7 @@ class LedgerAPI(object):
             Exception: If no keysets are received from the mint
         """
         resp = self.s.get(
-            url + "/keysets",
+            urljoin(url, "keysets"),
         )
         self.raise_on_error(resp)
         keysets_dict = resp.json()
@@ -427,7 +428,7 @@ class LedgerAPI(object):
             Exception: If the mint info request fails
         """
         resp = self.s.get(
-            url + "/info",
+            urljoin(url, "info"),
         )
         self.raise_on_error(resp)
         data: dict = resp.json()
@@ -448,7 +449,7 @@ class LedgerAPI(object):
             Exception: If the mint request fails
         """
         logger.trace("Requesting mint: GET /mint")
-        resp = self.s.get(self.url + "/mint", params={"amount": amount})
+        resp = self.s.get(urljoin(self.url, "mint"), params={"amount": amount})
         self.raise_on_error(resp)
         return_dict = resp.json()
         mint_response = GetMintResponse.parse_obj(return_dict)
@@ -479,7 +480,7 @@ class LedgerAPI(object):
         outputs_payload = PostMintRequest(outputs=outputs)
         logger.trace("Checking Lightning invoice. POST /mint")
         resp = self.s.post(
-            self.url + "/mint",
+            urljoin(self.url, "mint"),
             json=outputs_payload.dict(),
             params={
                 "hash": hash,
@@ -517,7 +518,7 @@ class LedgerAPI(object):
             }
 
         resp = self.s.post(
-            self.url + "/split",
+            urljoin(self.url, "split"),
             json=split_payload.dict(include=_splitrequest_include_fields(proofs)),  # type: ignore
         )
         self.raise_on_error(resp)
@@ -544,7 +545,7 @@ class LedgerAPI(object):
             }
 
         resp = self.s.post(
-            self.url + "/check",
+            urljoin(self.url, "check"),
             json=payload.dict(include=_check_proof_state_include_fields(proofs)),  # type: ignore
         )
         self.raise_on_error(resp)
@@ -558,7 +559,7 @@ class LedgerAPI(object):
         """Checks whether the Lightning payment is internal."""
         payload = CheckFeesRequest(pr=payment_request)
         resp = self.s.post(
-            self.url + "/checkfees",
+            urljoin(self.url, "checkfees"),
             json=payload.dict(),
         )
         self.raise_on_error(resp)
@@ -586,7 +587,7 @@ class LedgerAPI(object):
             }
 
         resp = self.s.post(
-            self.url + "/melt",
+            urljoin(self.url, "melt"),
             json=payload.dict(include=_meltrequest_include_fields(proofs)),  # type: ignore
         )
         self.raise_on_error(resp)
@@ -602,7 +603,7 @@ class LedgerAPI(object):
         Asks the mint to restore promises corresponding to outputs.
         """
         payload = PostMintRequest(outputs=outputs)
-        resp = self.s.post(self.url + "/restore", json=payload.dict())
+        resp = self.s.post(urljoin(self.url, "restore"), json=payload.dict())
         self.raise_on_error(resp)
         reponse_dict = resp.json()
         returnObj = PostRestoreResponse.parse_obj(reponse_dict)

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -7,8 +7,8 @@ import time
 import uuid
 from datetime import datetime, timedelta
 from itertools import groupby
+from posixpath import join
 from typing import Dict, List, Optional, Tuple, Union
-from urllib.parse import urljoin
 
 import requests
 from bip32 import BIP32
@@ -351,7 +351,7 @@ class LedgerAPI(object):
             Exception: If no keys are received from the mint
         """
         resp = self.s.get(
-            urljoin(url, "keys"),
+            join(url, "keys"),
         )
         self.raise_on_error(resp)
         keys: dict = resp.json()
@@ -380,7 +380,7 @@ class LedgerAPI(object):
         """
         keyset_id_urlsafe = keyset_id.replace("+", "-").replace("/", "_")
         resp = self.s.get(
-            urljoin(url, f"keys/{keyset_id_urlsafe}"),
+            join(url, f"keys/{keyset_id_urlsafe}"),
         )
         self.raise_on_error(resp)
         keys = resp.json()
@@ -406,7 +406,7 @@ class LedgerAPI(object):
             Exception: If no keysets are received from the mint
         """
         resp = self.s.get(
-            urljoin(url, "keysets"),
+            join(url, "keysets"),
         )
         self.raise_on_error(resp)
         keysets_dict = resp.json()
@@ -428,7 +428,7 @@ class LedgerAPI(object):
             Exception: If the mint info request fails
         """
         resp = self.s.get(
-            urljoin(url, "info"),
+            join(url, "info"),
         )
         self.raise_on_error(resp)
         data: dict = resp.json()
@@ -449,7 +449,7 @@ class LedgerAPI(object):
             Exception: If the mint request fails
         """
         logger.trace("Requesting mint: GET /mint")
-        resp = self.s.get(urljoin(self.url, "mint"), params={"amount": amount})
+        resp = self.s.get(join(self.url, "mint"), params={"amount": amount})
         self.raise_on_error(resp)
         return_dict = resp.json()
         mint_response = GetMintResponse.parse_obj(return_dict)
@@ -480,7 +480,7 @@ class LedgerAPI(object):
         outputs_payload = PostMintRequest(outputs=outputs)
         logger.trace("Checking Lightning invoice. POST /mint")
         resp = self.s.post(
-            urljoin(self.url, "mint"),
+            join(self.url, "mint"),
             json=outputs_payload.dict(),
             params={
                 "hash": hash,
@@ -518,7 +518,7 @@ class LedgerAPI(object):
             }
 
         resp = self.s.post(
-            urljoin(self.url, "split"),
+            join(self.url, "split"),
             json=split_payload.dict(include=_splitrequest_include_fields(proofs)),  # type: ignore
         )
         self.raise_on_error(resp)
@@ -545,7 +545,7 @@ class LedgerAPI(object):
             }
 
         resp = self.s.post(
-            urljoin(self.url, "check"),
+            join(self.url, "check"),
             json=payload.dict(include=_check_proof_state_include_fields(proofs)),  # type: ignore
         )
         self.raise_on_error(resp)
@@ -559,7 +559,7 @@ class LedgerAPI(object):
         """Checks whether the Lightning payment is internal."""
         payload = CheckFeesRequest(pr=payment_request)
         resp = self.s.post(
-            urljoin(self.url, "checkfees"),
+            join(self.url, "checkfees"),
             json=payload.dict(),
         )
         self.raise_on_error(resp)
@@ -587,7 +587,7 @@ class LedgerAPI(object):
             }
 
         resp = self.s.post(
-            urljoin(self.url, "melt"),
+            join(self.url, "melt"),
             json=payload.dict(include=_meltrequest_include_fields(proofs)),  # type: ignore
         )
         self.raise_on_error(resp)
@@ -603,7 +603,7 @@ class LedgerAPI(object):
         Asks the mint to restore promises corresponding to outputs.
         """
         payload = PostMintRequest(outputs=outputs)
-        resp = self.s.post(urljoin(self.url, "restore"), json=payload.dict())
+        resp = self.s.post(join(self.url, "restore"), json=payload.dict())
         self.raise_on_error(resp)
         reponse_dict = resp.json()
         returnObj = PostRestoreResponse.parse_obj(reponse_dict)


### PR DESCRIPTION
Solves issue in #286 by joining mint URL and endpoint safely with `urllib.parse.urljoin`.