### PR TITLE
check lightning invoice in-flight

### DIFF
--- a/cashu/lightning/fake.py
+++ b/cashu/lightning/fake.py
@@ -76,6 +76,9 @@ class FakeWallet(Wallet):
         return InvoiceResponse(True, checking_id, payment_request)
 
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+        # artificial sleep
+        await asyncio.sleep(5)
+
         invoice = decode(bolt11)
 
         if invoice.payment_hash[:6] == self.privkey[:6] or BRR:

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -798,7 +798,7 @@ class Ledger:
             return_amounts_sorted = sorted(return_amounts, reverse=True)
             # we need to imprint these amounts into the blanket outputs
             for i in range(len(outputs)):
-                outputs[i].amount = return_amounts_sorted[i]
+                outputs[i].amount = return_amounts_sorted[i]  # type: ignore
             if not self._verify_no_duplicate_outputs(outputs):
                 raise TransactionError("duplicate promises.")
             return_promises = await self._generate_promises(outputs, keyset)


### PR DESCRIPTION
First draft of an async payment flow. Makes use of previous [changes to NUT-07](https://github.com/cashubtc/nuts/pull/21): add new field `pending`.

Closes https://github.com/cashubtc/cashu/issues/244

## Changes
- Adds a new parameter `blocking=False` to the `POST /melt` endpoint which makes it return immediately and pay the invoice in the background.
- The wallet then checks for proof states instead of waiting for the endpoint to return as it did before. 
- If the proof states indicate that the invoice is paid, wallet goes on as usual

## Todo
- [ ] `store_lightning_invoice` only stores the invoice after payment, should store before and update later
- [ ] need to come up with a way to check information about the invoice, otherwise we can't get the preimage of a paid invoice. If there should be a new endpoint to check an invoice state, it should be tied to the proofs used to mint for that invoice, otherwise other users can look up the preimage