### PR TITLE
Allow to show tx history via CLI and API

### DIFF
--- a/cashu/wallet/api/responses.py
+++ b/cashu/wallet/api/responses.py
@@ -80,3 +80,7 @@ class InfoResponse(BaseModel):
     nostr_public_key: Optional[str] = None
     nostr_relays: List[str] = []
     socks_proxy: Optional[str] = None
+
+
+class HistoryResponse(BaseModel):
+    txs: List

--- a/cashu/wallet/crud.py
+++ b/cashu/wallet/crud.py
@@ -444,3 +444,21 @@ async def store_seed_and_mnemonic(
             mnemonic,
         ),
     )
+
+
+async def store_tx(
+    db: Database,
+    type: str,
+    amount: int,
+    token: str,
+    time: int,
+    conn: Optional[Connection] = None,
+):
+    await (conn or db).execute(
+        """
+        INSERT INTO tx_history
+          (type, amount, token, time)
+        VALUES (?, ?, ?, ?)
+        """,
+        (type, amount, token, time),
+    )

--- a/cashu/wallet/crud.py
+++ b/cashu/wallet/crud.py
@@ -451,14 +451,26 @@ async def store_tx(
     type: str,
     amount: int,
     token: str,
+    hash: str,
+    preimage: str,
     time: int,
     conn: Optional[Connection] = None,
 ):
     await (conn or db).execute(
         """
         INSERT INTO tx_history
-          (type, amount, token, time)
-        VALUES (?, ?, ?, ?)
+          (type, amount, token, hash, preimage, time)
+        VALUES (?, ?, ?, ?, ?, ?)
         """,
-        (type, amount, token, time),
+        (type, amount, token, hash, preimage, time),
     )
+
+
+async def get_tx_history(
+    db: Database,
+    conn: Optional[Connection] = None,
+):
+    rows = await (conn or db).fetchall("""
+            SELECT * from tx_history
+            """)
+    return rows

--- a/cashu/wallet/crud.py
+++ b/cashu/wallet/crud.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, Union
 
 from ..core.base import Invoice, P2SHScript, Proof, WalletKeyset
 from ..core.db import Connection, Database
@@ -452,7 +452,7 @@ async def store_tx(
     amount: int,
     token: str,
     hash: str,
-    preimage: str,
+    preimage: Union[str, None],
     time: int,
     conn: Optional[Connection] = None,
 ):

--- a/cashu/wallet/helpers.py
+++ b/cashu/wallet/helpers.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import os
+import time
 
 from loguru import logger
 
@@ -10,7 +11,7 @@ from ..core.helpers import sum_proofs
 from ..core.migrations import migrate_databases
 from ..core.settings import settings
 from ..wallet import migrations
-from ..wallet.crud import get_keyset
+from ..wallet.crud import get_keyset, store_tx
 from ..wallet.wallet import Wallet
 
 
@@ -40,6 +41,7 @@ async def redeem_TokenV3_multimint(wallet: Wallet, token: TokenV3):
     Helper function to iterate thruogh a token with multiple mints and redeem them from
     these mints one keyset at a time.
     """
+    amount = 0
     for t in token.token:
         assert t.mint, Exception(
             "redeem_TokenV3_multimint: multimint redeem without URL"
@@ -56,6 +58,8 @@ async def redeem_TokenV3_multimint(wallet: Wallet, token: TokenV3):
             redeem_proofs = [p for p in t.proofs if p.id == keyset]
             _, _ = await mint_wallet.redeem(redeem_proofs)
             print(f"Received {sum_proofs(redeem_proofs)} sats")
+            amount += sum_proofs(redeem_proofs)
+    return amount
 
 
 def serialize_TokenV2_to_TokenV3(tokenv2: TokenV2):
@@ -130,7 +134,7 @@ async def receive(
 
     if includes_mint_info:
         # redeem tokens with new wallet instances
-        await redeem_TokenV3_multimint(
+        amount = await redeem_TokenV3_multimint(
             wallet,
             tokenObj,
         )
@@ -151,7 +155,10 @@ async def receive(
         )
         await mint_wallet.load_mint(keyset_in_token)
         _, _ = await mint_wallet.redeem(proofs)
-        print(f"Received {sum_proofs(proofs)} sats")
+        amount = sum_proofs(proofs)
+        print(f"Received {amount} sats")
+
+    await store_tx(wallet.db, "receive", amount, tokenObj.serialize(), int(time.time()))
 
     # reload main wallet so the balance updates
     await wallet.load_proofs(reload=True)
@@ -214,6 +221,8 @@ async def send(
         include_mints=True,
     )
     print(token)
+
+    await store_tx(wallet.db, "send", -amount, token, int(time.time()))
 
     if legacy:
         print("")

--- a/cashu/wallet/helpers.py
+++ b/cashu/wallet/helpers.py
@@ -158,7 +158,9 @@ async def receive(
         amount = sum_proofs(proofs)
         print(f"Received {amount} sats")
 
-    await store_tx(wallet.db, "receive", amount, tokenObj.serialize(), int(time.time()))
+    await store_tx(
+        wallet.db, "ecash", amount, tokenObj.serialize(), "NA", "NA", int(time.time())
+    )
 
     # reload main wallet so the balance updates
     await wallet.load_proofs(reload=True)
@@ -222,7 +224,7 @@ async def send(
     )
     print(token)
 
-    await store_tx(wallet.db, "send", -amount, token, int(time.time()))
+    await store_tx(wallet.db, "ecash", -amount, token, "NA", "NA", int(time.time()))
 
     if legacy:
         print("")

--- a/cashu/wallet/migrations.py
+++ b/cashu/wallet/migrations.py
@@ -173,3 +173,18 @@ async def m009_privatekey_and_determinstic_key_derivation(db: Database):
             );
         """)
     # await db.execute("INSERT INTO secret_derivation (counter) VALUES (0)")
+
+
+async def m010_tx_history(db: Database):
+    """
+    Stores Lightning invoices.
+    """
+    await db.execute(f"""
+        CREATE TABLE IF NOT EXISTS tx_history (
+            type TEXT NOT NULL,
+            amount INTEGER NOT NULL,
+            token TEXT NOT NULL,
+            time TIMESTAMP DEFAULT {db.timestamp_now}
+
+        );
+    """)

--- a/cashu/wallet/migrations.py
+++ b/cashu/wallet/migrations.py
@@ -184,6 +184,8 @@ async def m010_tx_history(db: Database):
             type TEXT NOT NULL,
             amount INTEGER NOT NULL,
             token TEXT NOT NULL,
+            hash TEXT NOT NULL,
+            preimage TEXT NOT NULL,
             time TIMESTAMP DEFAULT {db.timestamp_now}
 
         );

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -1162,12 +1162,13 @@ class Wallet(LedgerAPI):
         if status.paid:
             # the payment was successful
             await self.invalidate(proofs)
+            time_paid = int(time.time())
             invoice_obj = Invoice(
                 amount=-sum_proofs(proofs),
                 pr=invoice,
                 preimage=status.preimage,
                 paid=True,
-                time_paid=time.time(),
+                time_paid=time_paid,
                 hash="",
             )
             # we have a unique constraint on the hash, so we generate a random one if it doesn't exist
@@ -1180,8 +1181,8 @@ class Wallet(LedgerAPI):
                 -sum_proofs(proofs),
                 token,
                 invoice_obj.hash,
-                invoice_obj.preimage,
-                invoice_obj.time_paid,
+                status.preimage,
+                time_paid,
             )
 
             # handle change and produce proofs

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -157,6 +157,13 @@ async def test_info():
 
 
 @pytest.mark.asyncio
+async def test_history():
+    with TestClient(app) as client:
+        response = client.get("/history")
+        assert response.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_flow(wallet: Wallet):
     with TestClient(app) as client:
         if not settings.lightning:


### PR DESCRIPTION
Stores all transactions in wallet database. 
Adds command/endpoint `history` to CLI and API to show tx history.
Closes #173.