### PR TITLE
Use a valid derivation path in example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@ MINT_INFO_MOTD="Message to users"
 
 MINT_PRIVATE_KEY=supersecretprivatekey
 # increment derivation path to rotate to a new keyset
-MINT_DERIVATION_PATH="0/0/0/0"
+MINT_DERIVATION_PATH="m/27/1/2/3"
 
 MINT_DATABASE=data/mint
 


### PR DESCRIPTION
adding in a valid derivation path in the .env.example will help eliminate errors for those trying out for the first time