### PR TITLE
Mint: check that test db is different from main db

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
         mint-cache-secrets: ["false", "true"]
         mint-only-deprecated: ["false", "true"]
         mint-database: ["./test_data/test_mint", "postgres://cashu:cashu@localhost:5432/cashu"]
-        # mint-database: [""]
         backend-wallet-class: ["FakeWallet"]
     uses: ./.github/workflows/tests.yml
     with:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ settings.mint_lightning_backend = settings.mint_lightning_backend or "FakeWallet
 settings.fakewallet_brr = True
 settings.fakewallet_delay_payment = False
 settings.fakewallet_stochastic_invoice = False
+assert settings.mint_test_database != settings.mint_database, "Test database is the same as the main database"
 settings.mint_database = settings.mint_test_database
 settings.mint_derivation_path = "m/0'/0'/0'"
 settings.mint_derivation_path_list = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,9 @@ settings.mint_lightning_backend = settings.mint_lightning_backend or "FakeWallet
 settings.fakewallet_brr = True
 settings.fakewallet_delay_payment = False
 settings.fakewallet_stochastic_invoice = False
-assert settings.mint_test_database != settings.mint_database, "Test database is the same as the main database"
+assert (
+    settings.mint_test_database != settings.mint_database
+), "Test database is the same as the main database"
 settings.mint_database = settings.mint_test_database
 settings.mint_derivation_path = "m/0'/0'/0'"
 settings.mint_derivation_path_list = []


### PR DESCRIPTION
For safety, so we don't accidentally wipe any production db with the tests.