### PR TITLE
add missing disabled-flag to nut4

### DIFF
--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -1,4 +1,3 @@
-from gc import disable
 from typing import Any, Dict, List
 
 from fastapi import APIRouter

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -1,3 +1,4 @@
+from gc import disable
 from typing import Any, Dict, List
 
 from fastapi import APIRouter
@@ -50,6 +51,7 @@ async def info() -> GetInfoResponse:
     mint_features: Dict[int, Dict[str, Any]] = {
         4: dict(
             methods=method_unit_pairs,
+            disabled=False,
         ),
         5: dict(
             methods=method_unit_pairs,


### PR DESCRIPTION
According to the current spec the nut4 info-response provided by nutshell is missing the disabled-flag
https://github.com/cashubtc/nuts/blob/main/04.md

BTW nutshell is providing a disabled flag for nut5, which is not part of the spec. This is not a problem for a client, because additional information in the json is ignored, but I think this is an error in the spec. The mint runner should have the option to disable minting and melting.
