### PR TITLE
Mint: add expiry to quotes, closes #385

### DIFF
--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -230,6 +230,7 @@ class MeltQuote(BaseModel):
     paid_time: Union[int, None] = None
     fee_paid: int = 0
     proof: str = ""
+    expiry: int = 0
 
     @classmethod
     def from_row(cls, row: Row):
@@ -417,6 +418,7 @@ class PostMeltQuoteResponse(BaseModel):
     amount: int  # input amount
     fee_reserve: int  # input fee reserve
     paid: bool  # whether the request has been paid
+    expiry: int  # expiry of the quote
 
 
 # ------- API: MELT -------

--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -230,7 +230,7 @@ class MeltQuote(BaseModel):
     paid_time: Union[int, None] = None
     fee_paid: int = 0
     proof: str = ""
-    expiry: int = 0
+    expiry: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: Row):
@@ -270,7 +270,7 @@ class MintQuote(BaseModel):
     issued: bool
     created_time: Union[int, None] = None
     paid_time: Union[int, None] = None
-    expiry: int = 0
+    expiry: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: Row):
@@ -296,7 +296,6 @@ class MintQuote(BaseModel):
             issued=row["issued"],
             created_time=created_time,
             paid_time=paid_time,
-            expiry=0,
         )
 
 
@@ -371,7 +370,7 @@ class PostMintQuoteResponse(BaseModel):
     quote: str  # quote id
     request: str  # input payment request
     paid: bool  # whether the request has been paid
-    expiry: int  # expiry of the quote
+    expiry: Optional[int]  # expiry of the quote
 
 
 # ------- API: MINT -------
@@ -418,7 +417,7 @@ class PostMeltQuoteResponse(BaseModel):
     amount: int  # input amount
     fee_reserve: int  # input fee reserve
     paid: bool  # whether the request has been paid
-    expiry: int  # expiry of the quote
+    expiry: Optional[int]  # expiry of the quote
 
 
 # ------- API: MELT -------

--- a/cashu/lightning/fake.py
+++ b/cashu/lightning/fake.py
@@ -66,8 +66,7 @@ class FakeWallet(LightningBackend):
         else:
             tags.add(TagChar.description, memo or "")
 
-        if expiry:
-            tags.add(TagChar.expire_time, expiry)
+        tags.add(TagChar.expire_time, expiry or 3600)
 
         if payment_secret:
             secret = payment_secret.hex()

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -507,6 +507,7 @@ class Ledger(LedgerVerification, LedgerSpendingConditions):
             paid=False,
             fee_reserve=payment_quote.fee.to(unit).amount,
             created_time=int(time.time()),
+            expiry=invoice_obj.expiry or 0,
         )
         await self.crud.store_melt_quote(quote=quote, db=self.db)
         return PostMeltQuoteResponse(
@@ -514,6 +515,7 @@ class Ledger(LedgerVerification, LedgerSpendingConditions):
             amount=quote.amount,
             fee_reserve=quote.fee_reserve,
             paid=quote.paid,
+            expiry=quote.expiry,
         )
 
     async def get_melt_quote(self, quote_id: str) -> MeltQuote:

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -353,7 +353,7 @@ class Ledger(LedgerVerification, LedgerSpendingConditions):
             issued=False,
             paid=False,
             created_time=int(time.time()),
-            expiry=invoice_obj.expiry or 0,
+            expiry=invoice_obj.expiry,
         )
         await self.crud.store_mint_quote(
             quote=quote,
@@ -507,7 +507,7 @@ class Ledger(LedgerVerification, LedgerSpendingConditions):
             paid=False,
             fee_reserve=payment_quote.fee.to(unit).amount,
             created_time=int(time.time()),
-            expiry=invoice_obj.expiry or 0,
+            expiry=invoice_obj.expiry,
         )
         await self.crud.store_melt_quote(quote=quote, db=self.db)
         return PostMeltQuoteResponse(

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -262,6 +262,7 @@ async def melt_quote(quote: str) -> PostMeltQuoteResponse:
         amount=melt_quote.amount,
         fee_reserve=melt_quote.fee_reserve,
         paid=melt_quote.paid,
+        expiry=melt_quote.expiry,
     )
     logger.trace(f"< GET /v1/melt/quote/bolt11/{quote}")
     return resp

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -543,7 +543,7 @@ class LedgerAPI(LedgerAPIDeprecated, object):
                 amount=invoice_obj.amount_msat // 1000,
                 fee_reserve=ret.fee or 0,
                 paid=False,
-                expiry=invoice_obj.expiry or 0,
+                expiry=invoice_obj.expiry,
             )
         # END backwards compatibility < 0.15.0
         self.raise_on_error_request(resp)

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -543,6 +543,7 @@ class LedgerAPI(LedgerAPIDeprecated, object):
                 amount=invoice_obj.amount_msat // 1000,
                 fee_reserve=ret.fee or 0,
                 paid=False,
+                expiry=invoice_obj.expiry or 0,
             )
         # END backwards compatibility < 0.15.0
         self.raise_on_error_request(resp)

--- a/tests/test_mint_api.py
+++ b/tests/test_mint_api.py
@@ -182,6 +182,7 @@ async def test_mint_quote(ledger: Ledger):
     assert result["request"]
     invoice = bolt11.decode(result["request"])
     assert invoice.amount_msat == 100 * 1000
+    assert result["expiry"] == invoice.expiry
 
     # get mint quote again from api
     response = httpx.get(
@@ -243,6 +244,8 @@ async def test_melt_quote_internal(ledger: Ledger, wallet: Wallet):
     assert result["amount"] == 64
     # TODO: internal invoice, fee should be 0
     assert result["fee_reserve"] == 0
+    invoice_obj = bolt11.decode(request)
+    assert result["expiry"] == invoice_obj.expiry
 
     # get melt quote again from api
     response = httpx.get(


### PR DESCRIPTION
@ngutech21 we're now returning the expiry, in case it is not present or doesn't apply, it returns `0`. We should probably defined that in the NUT.