### PR TITLE
fix: mint and melt quote expiry time

### DIFF
--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -343,6 +343,10 @@ class Ledger(LedgerVerification, LedgerSpendingConditions):
         # get invoice expiry time
         invoice_obj = bolt11.decode(invoice_response.payment_request)
 
+        expiry = None
+        if invoice_obj.expiry is not None:
+            expiry = invoice_obj.date + invoice_obj.expiry
+
         quote = MintQuote(
             quote=random_hash(),
             method=method.name,
@@ -353,7 +357,7 @@ class Ledger(LedgerVerification, LedgerSpendingConditions):
             issued=False,
             paid=False,
             created_time=int(time.time()),
-            expiry=invoice_obj.expiry,
+            expiry=expiry,
         )
         await self.crud.store_mint_quote(
             quote=quote,
@@ -499,6 +503,10 @@ class Ledger(LedgerVerification, LedgerSpendingConditions):
                 melt_quote.request
             )
             assert payment_quote.checking_id, "quote has no checking id"
+        
+        expiry = None
+        if invoice_obj.expiry is not None:
+            expiry = invoice_obj.date + invoice_obj.expiry
 
         quote = MeltQuote(
             quote=random_hash(),
@@ -510,7 +518,7 @@ class Ledger(LedgerVerification, LedgerSpendingConditions):
             paid=False,
             fee_reserve=payment_quote.fee.to(unit).amount,
             created_time=int(time.time()),
-            expiry=invoice_obj.expiry,
+            expiry=expiry,
         )
         await self.crud.store_melt_quote(quote=quote, db=self.db)
         return PostMeltQuoteResponse(

--- a/tests/test_mint_api.py
+++ b/tests/test_mint_api.py
@@ -182,7 +182,12 @@ async def test_mint_quote(ledger: Ledger):
     assert result["request"]
     invoice = bolt11.decode(result["request"])
     assert invoice.amount_msat == 100 * 1000
-    assert result["expiry"] == invoice.expiry
+    
+    expiry = None
+    if invoice.expiry is not None:
+        expiry = invoice.date + invoice.expiry
+        
+    assert result["expiry"] == expiry
 
     # get mint quote again from api
     response = httpx.get(
@@ -245,7 +250,12 @@ async def test_melt_quote_internal(ledger: Ledger, wallet: Wallet):
     # TODO: internal invoice, fee should be 0
     assert result["fee_reserve"] == 0
     invoice_obj = bolt11.decode(request)
-    assert result["expiry"] == invoice_obj.expiry
+    
+    expiry = None
+    if invoice_obj.expiry is not None:
+        expiry = invoice_obj.date + invoice_obj.expiry
+
+    assert result["expiry"] == expiry
 
     # get melt quote again from api
     response = httpx.get(


### PR DESCRIPTION
Per nut04 the expiry time should be unix time, but bolt11 invoices expiry are seconds since creation. The quote expiration should be creation timestamp plus the bolt11 expiry time.

fix https://github.com/cashubtc/nutshell/issues/448