### PR TITLE
Update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,7 +56,7 @@ MINT_DERIVATION_PATH="m/0'/0'/0'"
 MINT_DATABASE=data/mint
 
 # Lightning
-# Supported: FakeWallet, LndRestWallet, CoreLightningRestWallet, BlinkWallet, LNbitsWallet, StrikeWallet
+# Supported: FakeWallet, LndRestWallet, CoreLightningRestWallet, BlinkWallet, LNbitsWallet, StrikeUSDWallet
 MINT_LIGHTNING_BACKEND=FakeWallet
 
 # for use with LNbitsWallet
@@ -76,7 +76,7 @@ MINT_CORELIGHTNING_REST_CERT="./clightning-2-rest/certificate.pem"
 # Use with BlinkWallet
 MINT_BLINK_KEY=blink_abcdefgh
 
-# Use with StrikeWallet
+# Use with StrikeUSDWallet (usd only, does not currently support sats/msats)
 MINT_STRIKE_KEY=ABC123
 
 # fee to reserve in percent of the amount


### PR DESCRIPTION
StrikeWallet is StrikeUSDWallet, changed in 2 places, and added that it's usd only (in case it's not obvious).