### PR TITLE
Add checkout latest tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ source ~/.bashrc
 # install cashu
 git clone https://github.com/cashubtc/nutshell.git cashu
 cd cashu
+git checkout <latest_tag>
 pyenv local 3.10.4
 poetry install
 ```


### PR DESCRIPTION
This pull request adds a step to checkout the latest tag in the `cashu` repository before installing the dependencies. This ensures that the latest stable version of the code is used for the installation process.