### PR TITLE
Update PostRestoreResponse class to use "signatures" instead of "promises"

### DIFF
--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -530,7 +530,13 @@ class CheckFeesResponse_deprecated(BaseModel):
 
 class PostRestoreResponse(BaseModel):
     outputs: List[BlindedMessage] = []
-    promises: List[BlindedSignature] = []
+    signatures: List[BlindedSignature] = []
+    promises: Optional[List[BlindedSignature]] = []  # deprecated since 0.15.1
+
+    # duplicate value of "signatures" in "promises" for backwards compatibility with old clients < 0.15.1 upon initialization
+    def __init__(self, **data):
+        super().__init__(**data)
+        self.promises = self.signatures
 
 
 # ------- KEYSETS -------

--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -533,7 +533,7 @@ class PostRestoreResponse(BaseModel):
     signatures: List[BlindedSignature] = []
     promises: Optional[List[BlindedSignature]] = []  # deprecated since 0.15.1
 
-    # duplicate value of "signatures" in "promises" for backwards compatibility with old clients < 0.15.1 upon initialization
+    # duplicate value of "signatures" for backwards compatibility with old clients < 0.15.1
     def __init__(self, **data):
         super().__init__(**data)
         self.promises = self.signatures

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -355,4 +355,4 @@ async def check_state(
 async def restore(payload: PostMintRequest) -> PostRestoreResponse:
     assert payload.outputs, Exception("no outputs provided.")
     outputs, promises = await ledger.restore(payload.outputs)
-    return PostRestoreResponse(outputs=outputs, promises=promises)
+    return PostRestoreResponse(outputs=outputs, signatures=promises)

--- a/cashu/mint/router_deprecated.py
+++ b/cashu/mint/router_deprecated.py
@@ -360,4 +360,4 @@ async def check_spendable_deprecated(
 async def restore(payload: PostMintRequest_deprecated) -> PostRestoreResponse:
     assert payload.outputs, Exception("no outputs provided.")
     outputs, promises = await ledger.restore(payload.outputs)
-    return PostRestoreResponse(outputs=outputs, promises=promises)
+    return PostRestoreResponse(outputs=outputs, signatures=promises)

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -697,7 +697,14 @@ class LedgerAPI(LedgerAPIDeprecated, object):
         self.raise_on_error_request(resp)
         response_dict = resp.json()
         returnObj = PostRestoreResponse.parse_obj(response_dict)
-        return returnObj.outputs, returnObj.promises
+
+        # BEGIN backwards compatibility < 0.15.1
+        # if the mint returns promises, duplicate into signatures
+        if returnObj.promises:
+            returnObj.signatures = returnObj.promises
+        # END backwards compatibility < 0.15.1
+
+        return returnObj.outputs, returnObj.signatures
 
 
 class Wallet(LedgerAPI, WalletP2PK, WalletHTLC, WalletSecrets):

--- a/cashu/wallet/wallet_deprecated.py
+++ b/cashu/wallet/wallet_deprecated.py
@@ -408,7 +408,14 @@ class LedgerAPIDeprecated(SupportsHttpxClient, SupportsMintURL):
         self.raise_on_error(resp)
         response_dict = resp.json()
         returnObj = PostRestoreResponse.parse_obj(response_dict)
-        return returnObj.outputs, returnObj.promises
+
+        # BEGIN backwards compatibility < 0.15.1
+        # if the mint returns promises, duplicate into signatures
+        if returnObj.promises:
+            returnObj.signatures = returnObj.promises
+        # END backwards compatibility < 0.15.1
+
+        return returnObj.outputs, returnObj.signatures
 
     @async_set_httpx_client
     @async_ensure_mint_loaded_deprecated


### PR DESCRIPTION
This pull request updates the PostRestoreResponse class in order to use the "signatures" attribute instead of the deprecated "promises" attribute. This change ensures backwards compatibility with old clients and improves code clarity.

Implement change in https://github.com/cashubtc/nuts/pull/87