### PR TITLE
Issue #313: allow checking pending invoices

### DIFF
--- a/cashu/mint/conditions.py
+++ b/cashu/mint/conditions.py
@@ -255,9 +255,9 @@ class LedgerSpendingConditions:
         # check if all secrets are P2PK
         # NOTE: This is redundant, because P2PKSecret.from_secret() already checks for the kind
         # Leaving it in for explicitness
-        if not all([
-            SecretKind(secret.kind) == SecretKind.P2PK for secret in p2pk_secrets
-        ]):
+        if not all(
+            [SecretKind(secret.kind) == SecretKind.P2PK for secret in p2pk_secrets]
+        ):
             # not all secrets are P2PK
             return True
 

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -3,7 +3,7 @@
 import asyncio
 import os
 import time
-from datetime import datetime
+import datetime
 from functools import wraps
 from itertools import groupby, islice
 from operator import itemgetter
@@ -124,7 +124,7 @@ async def cli(ctx: Context, host: str, walletname: str, unit: str, tests: bool):
             env_path = settings.env_file
         else:
             error_str += (
-                "Ceate a new Cashu config file here:"
+                "Create a new Cashu config file here:"
                 f" {os.path.join(settings.cashu_dir, '.env')}"
             )
             env_path = os.path.join(settings.cashu_dir, ".env")
@@ -158,7 +158,6 @@ async def cli(ctx: Context, host: str, walletname: str, unit: str, tests: bool):
 
     assert wallet, "Wallet not found."
     ctx.obj["WALLET"] = wallet
-    # await init_wallet(ctx.obj["WALLET"], load_proofs=False)
 
     # only if a command is one of a subset that needs to specify a mint host
     # if a mint host is already specified as an argument `host`, use it
@@ -166,7 +165,7 @@ async def cli(ctx: Context, host: str, walletname: str, unit: str, tests: bool):
         return
     # ------ MULTIUNIT ------- : Select a unit
     ctx.obj["WALLET"] = await get_unit_wallet(ctx)
-    # ------ MUTLIMINT ------- : Select a wallet
+    # ------ MULTIMINT ------- : Select a wallet
     # else: we ask the user to select one
     ctx.obj["WALLET"] = await get_mint_wallet(
         ctx
@@ -637,8 +636,8 @@ async def pending(ctx: Context, legacy, number: int, offset: int):
             mint = [t.mint for t in tokenObj.token][0]
             # token_hidden_secret = await wallet.serialize_proofs(grouped_proofs)
             assert grouped_proofs[0].time_reserved
-            reserved_date = datetime.utcfromtimestamp(
-                int(grouped_proofs[0].time_reserved)
+            reserved_date = datetime.datetime.fromtimestamp(
+                int(grouped_proofs[0].time_reserved), datetime.UTC
             ).strftime("%Y-%m-%d %H:%M:%S")
             print(
                 f"#{i} Amount:"
@@ -710,14 +709,14 @@ async def invoices(ctx):
             if invoice.preimage:
                 print(f"Preimage: {invoice.preimage}")
             if invoice.time_created:
-                d = datetime.utcfromtimestamp(
-                    int(float(invoice.time_created))
+                d = datetime.datetime.fromtimestamp(
+                    int(float(invoice.time_created)), datetime.UTC
                 ).strftime("%Y-%m-%d %H:%M:%S")
                 print(f"Created: {d}")
             if invoice.time_paid:
-                d = datetime.utcfromtimestamp(int(float(invoice.time_paid))).strftime(
-                    "%Y-%m-%d %H:%M:%S"
-                )
+                d = datetime.datetime.fromtimestamp(
+                    (int(float(invoice.time_paid))), datetime.UTC
+                ).strftime("%Y-%m-%d %H:%M:%S")
                 print(f"Paid: {d}")
             print("")
             print(f"Payment request: {invoice.bolt11}")

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -691,12 +691,54 @@ async def locks(ctx):
     return True
 
 
-@cli.command("invoices", help="List of all pending invoices.")
+@cli.command("invoices", help="List of all invoices.")
+@click.option(
+    "-op",
+    "--only-paid",
+    "paid",
+    default=False,
+    is_flag=True,
+    help="Show only paid invoices.",
+    type=bool,
+)
+@click.option(
+    "-ou",
+    "--only-unpaid",
+    "unpaid",
+    default=False,
+    is_flag=True,
+    help="Show only unpaid invoices.",
+    type=bool,
+)
+@click.option(
+    "-p",
+    "--pending",
+    "pending",
+    default=False,
+    is_flag=True,
+    help="Show all pending invoices",
+    type=bool,
+)
 @click.pass_context
 @coro
-async def invoices(ctx):
+async def invoices(ctx, paid: bool, unpaid: bool, pending: bool):
     wallet: Wallet = ctx.obj["WALLET"]
-    invoices = await get_lightning_invoices(db=wallet.db)
+
+    if paid and unpaid:
+        print("You should only choose one option: either --only-paid or --only-unpaid")
+        return
+    
+    paid_arg = None
+    if unpaid:
+        paid_arg = False
+    elif paid:
+        paid_arg = True
+
+    invoices = await get_lightning_invoices(
+        db=wallet.db,
+        paid=paid_arg,
+        pending=pending or None,
+    )
     if len(invoices):
         print("")
         print("--------------------------\n")

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import asyncio
-import datetime
+from datetime import datetime, timezone
 import os
 import time
 from functools import wraps
@@ -636,8 +636,8 @@ async def pending(ctx: Context, legacy, number: int, offset: int):
             mint = [t.mint for t in tokenObj.token][0]
             # token_hidden_secret = await wallet.serialize_proofs(grouped_proofs)
             assert grouped_proofs[0].time_reserved
-            reserved_date = datetime.datetime.fromtimestamp(
-                int(grouped_proofs[0].time_reserved), datetime.UTC
+            reserved_date = datetime.fromtimestamp(
+                int(grouped_proofs[0].time_reserved), timezone.utc
             ).strftime("%Y-%m-%d %H:%M:%S")
             print(
                 f"#{i} Amount:"
@@ -751,13 +751,13 @@ async def invoices(ctx, paid: bool, unpaid: bool, pending: bool):
             if invoice.preimage:
                 print(f"Preimage: {invoice.preimage}")
             if invoice.time_created:
-                d = datetime.datetime.fromtimestamp(
-                    int(float(invoice.time_created)), datetime.UTC
+                d = datetime.fromtimestamp(
+                    int(float(invoice.time_created)), timezone.utc
                 ).strftime("%Y-%m-%d %H:%M:%S")
                 print(f"Created: {d}")
             if invoice.time_paid:
-                d = datetime.datetime.fromtimestamp(
-                    (int(float(invoice.time_paid))), datetime.UTC
+                d = datetime.fromtimestamp(
+                    (int(float(invoice.time_paid))), timezone.utc
                 ).strftime("%Y-%m-%d %H:%M:%S")
                 print(f"Paid: {d}")
             print("")

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 import asyncio
-from datetime import datetime, timezone
 import os
 import time
+from datetime import datetime, timezone
 from functools import wraps
 from itertools import groupby, islice
 from operator import itemgetter
@@ -727,7 +727,7 @@ async def invoices(ctx, paid: bool, unpaid: bool, pending: bool):
     if paid and unpaid:
         print("You should only choose one option: either --only-paid or --only-unpaid")
         return
-    
+
     paid_arg = None
     if unpaid:
         paid_arg = False

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -722,22 +722,23 @@ async def locks(ctx):
     type=bool,
 )
 @click.option(
-    "--tests",
-    "-t",
+    "--mint",
+    "-m",
     is_flag=True,
     default=False,
-    help="Run in test mode (do not try to mint pending invoices)",
+    help="Try to mint pending invoices",
 )
 @click.pass_context
 @coro
-async def invoices(ctx, paid: bool, unpaid: bool, pending: bool, tests: bool):
+async def invoices(ctx, paid: bool, unpaid: bool, pending: bool, mint: bool):
     wallet: Wallet = ctx.obj["WALLET"]
 
     if paid and unpaid:
         print("You should only choose one option: either --only-paid or --only-unpaid")
         return
 
-    await wallet.load_mint()
+    if mint:
+      await wallet.load_mint()
 
     paid_arg = None
     if unpaid:
@@ -786,9 +787,9 @@ async def invoices(ctx, paid: bool, unpaid: bool, pending: bool, tests: bool):
 
     invoices_printed_count = 0
     for invoice in invoices:
-        # Tries to mint pending invoice
         is_pending_invoice = invoice.out is False and invoice.paid is False
-        if is_pending_invoice and not tests:
+        if is_pending_invoice and mint:
+            # Tries to mint pending invoice
             updated_invoice = await _try_to_mint_pending_invoice(
                 invoice.amount, invoice.id
             )

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 import asyncio
+import datetime
 import os
 import time
-import datetime
 from functools import wraps
 from itertools import groupby, islice
 from operator import itemgetter

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -246,7 +246,7 @@ async def invoice(ctx: Context, amount: float, id: str, split: int, no_check: bo
     await wallet.load_mint()
     await print_balance(ctx)
     amount = int(amount * 100) if wallet.unit == Unit.usd else int(amount)
-    print(f"Requesting invoice for {wallet.unit.str(amount)} {wallet.unit}.")
+    print(f"Requesting invoice for {wallet.unit.str(amount)}.")
     # in case the user wants a specific split, we create a list of amounts
     optional_split = None
     if split:

--- a/cashu/wallet/crud.py
+++ b/cashu/wallet/crud.py
@@ -67,10 +67,12 @@ async def get_reserved_proofs(
     db: Database,
     conn: Optional[Connection] = None,
 ) -> List[Proof]:
-    rows = await (conn or db).fetchall("""
+    rows = await (conn or db).fetchall(
+        """
         SELECT * from proofs
         WHERE reserved
-        """)
+        """
+    )
     return [Proof.from_dict(dict(r)) for r in rows]
 
 

--- a/cashu/wallet/crud.py
+++ b/cashu/wallet/crud.py
@@ -279,14 +279,21 @@ async def get_lightning_invoice(
 async def get_lightning_invoices(
     db: Database,
     paid: Optional[bool] = None,
+    pending: Optional[bool] = None,
     conn: Optional[Connection] = None,
 ) -> List[Invoice]:
     clauses: List[Any] = []
     values: List[Any] = []
 
-    if paid is not None:
+    if paid is not None and not pending:
         clauses.append("paid = ?")
         values.append(paid)
+
+    if pending:
+        clauses.append("paid = ?")
+        values.append(False)
+        clauses.append("out = ?")
+        values.append(False)
 
     where = ""
     if clauses:

--- a/cashu/wallet/migrations.py
+++ b/cashu/wallet/migrations.py
@@ -2,17 +2,20 @@ from ..core.db import Connection, Database
 
 
 async def m000_create_migrations_table(conn: Connection):
-    await conn.execute("""
+    await conn.execute(
+        """
     CREATE TABLE IF NOT EXISTS dbversions (
         db TEXT PRIMARY KEY,
         version INT NOT NULL
     )
-    """)
+    """
+    )
 
 
 async def m001_initial(db: Database):
     async with db.connect() as conn:
-        await conn.execute(f"""
+        await conn.execute(
+            f"""
                 CREATE TABLE IF NOT EXISTS proofs (
                     amount {db.big_int} NOT NULL,
                     C TEXT NOT NULL,
@@ -21,9 +24,11 @@ async def m001_initial(db: Database):
                     UNIQUE (secret)
 
                 );
-            """)
+            """
+        )
 
-        await conn.execute(f"""
+        await conn.execute(
+            f"""
                 CREATE TABLE IF NOT EXISTS proofs_used (
                     amount {db.big_int} NOT NULL,
                     C TEXT NOT NULL,
@@ -32,25 +37,30 @@ async def m001_initial(db: Database):
                     UNIQUE (secret)
 
                 );
-            """)
+            """
+        )
 
-        await conn.execute("""
+        await conn.execute(
+            """
             CREATE VIEW IF NOT EXISTS balance AS
             SELECT COALESCE(SUM(s), 0) AS balance FROM (
                 SELECT SUM(amount) AS s
                 FROM proofs
                 WHERE amount > 0
             );
-        """)
+        """
+        )
 
-        await conn.execute("""
+        await conn.execute(
+            """
             CREATE VIEW IF NOT EXISTS balance_used AS
             SELECT COALESCE(SUM(s), 0) AS used FROM (
                 SELECT SUM(amount) AS s
                 FROM proofs_used
                 WHERE amount > 0
             );
-        """)
+        """
+        )
 
 
 async def m002_add_proofs_reserved(db: Database):
@@ -96,7 +106,8 @@ async def m005_wallet_keysets(db: Database):
     Stores mint keysets from different mints and epochs.
     """
     async with db.connect() as conn:
-        await conn.execute(f"""
+        await conn.execute(
+            f"""
                 CREATE TABLE IF NOT EXISTS keysets (
                     id TEXT,
                     mint_url TEXT,
@@ -108,7 +119,8 @@ async def m005_wallet_keysets(db: Database):
                     UNIQUE (id, mint_url)
 
                 );
-            """)
+            """
+        )
 
         await conn.execute("ALTER TABLE proofs ADD COLUMN id TEXT")
         await conn.execute("ALTER TABLE proofs_used ADD COLUMN id TEXT")
@@ -119,7 +131,8 @@ async def m006_invoices(db: Database):
     Stores Lightning invoices.
     """
     async with db.connect() as conn:
-        await conn.execute(f"""
+        await conn.execute(
+            f"""
             CREATE TABLE IF NOT EXISTS invoices (
                 amount INTEGER NOT NULL,
                 pr TEXT NOT NULL,
@@ -132,7 +145,8 @@ async def m006_invoices(db: Database):
                 UNIQUE (hash)
 
             );
-        """)
+        """
+        )
 
 
 async def m007_nostr(db: Database):
@@ -140,12 +154,14 @@ async def m007_nostr(db: Database):
     Stores timestamps of nostr operations.
     """
     async with db.connect() as conn:
-        await conn.execute("""
+        await conn.execute(
+            """
             CREATE TABLE IF NOT EXISTS nostr (
                 type TEXT NOT NULL,
                 last TIMESTAMP DEFAULT NULL
             )
-            """)
+            """
+        )
         await conn.execute(
             """
             INSERT INTO nostr
@@ -172,14 +188,16 @@ async def m009_privatekey_and_determinstic_key_derivation(db: Database):
         await conn.execute("ALTER TABLE keysets ADD COLUMN counter INTEGER DEFAULT 0")
         await conn.execute("ALTER TABLE proofs ADD COLUMN derivation_path TEXT")
         await conn.execute("ALTER TABLE proofs_used ADD COLUMN derivation_path TEXT")
-        await conn.execute("""
+        await conn.execute(
+            """
                 CREATE TABLE IF NOT EXISTS seed (
                 seed TEXT NOT NULL,
                 mnemonic TEXT NOT NULL,
 
                 UNIQUE (seed, mnemonic)
                 );
-            """)
+            """
+        )
         # await conn.execute("INSERT INTO secret_derivation (counter) VALUES (0)")
 
 

--- a/cashu/wallet/p2pk.py
+++ b/cashu/wallet/p2pk.py
@@ -133,9 +133,12 @@ class WalletP2PK(SupportsPrivateKey, SupportsDb):
             return outputs
 
         # if any of the proofs provided require SIG_ALL, we must provide it
-        if any([
-            P2PKSecret.deserialize(p.secret).sigflag == SigFlags.SIG_ALL for p in proofs
-        ]):
+        if any(
+            [
+                P2PKSecret.deserialize(p.secret).sigflag == SigFlags.SIG_ALL
+                for p in proofs
+            ]
+        ):
             outputs = await self.add_p2pk_witnesses_to_outputs(outputs)
         return outputs
 
@@ -181,9 +184,9 @@ class WalletP2PK(SupportsPrivateKey, SupportsDb):
             return proofs
         logger.debug("Spending conditions detected.")
         # P2PK signatures
-        if all([
-            Secret.deserialize(p.secret).kind == SecretKind.P2PK.value for p in proofs
-        ]):
+        if all(
+            [Secret.deserialize(p.secret).kind == SecretKind.P2PK.value for p in proofs]
+        ):
             logger.debug("P2PK redemption detected.")
             proofs = await self.add_p2pk_witnesses_to_proofs(proofs)
 

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -1488,7 +1488,7 @@ class Wallet(LedgerAPI, WalletP2PK, WalletHTLC, WalletSecrets):
 
         Args:
             proofs (List[Proof]): Which proofs to delete
-            check_spendable (bool, optional): Asks the mint to check whether proofs are already spent before deleting them. Defaults to True.
+            check_spendable (bool, optional): Asks the mint to check whether proofs are already spent before deleting them. Defaults to False.
 
         Returns:
             List[Proof]: List of proofs that are still spendable.

--- a/tests/test_mint_lightning_blink.py
+++ b/tests/test_mint_lightning_blink.py
@@ -4,7 +4,7 @@ from httpx import Response
 
 from cashu.core.base import Amount, MeltQuote, Unit
 from cashu.core.settings import settings
-from cashu.lightning.blink import MINIMUM_FEE_MSAT, BlinkWallet
+from cashu.lightning.blink import MINIMUM_FEE_MSAT, BlinkWallet  # type: ignore
 
 settings.mint_blink_key = "123"
 blink = BlinkWallet(unit=Unit.sat)

--- a/tests/test_wallet_cli.py
+++ b/tests/test_wallet_cli.py
@@ -27,6 +27,21 @@ def get_bolt11_and_invoice_id_from_invoice_command(output: str) -> Tuple[str, st
     ][0]
     return invoice, invoice_id
 
+def get_invoice_from_invoices_command(output: str) -> dict[str, str]:
+    splitted = output.split("\n")
+    removed_empty_and_hiphens = [
+        value for value in splitted if value and not value.startswith("-----")
+    ]
+    dict_output = {
+        f"{value.split(': ')[0]}": value.split(": ")[1]
+        for value in removed_empty_and_hiphens
+    }
+
+    return dict_output
+
+async def reset_invoices(wallet: Wallet):
+    await wallet.db.execute("DELETE FROM invoices")
+
 
 async def init_wallet():
     settings.debug = False
@@ -157,6 +172,107 @@ def test_invoice_with_split(mint, cli_prefix):
     assert result.exception is None
     wallet = asyncio.run(init_wallet())
     assert wallet.proof_amounts.count(1) >= 10
+
+
+def test_invoices(cli_prefix):
+    # arrange
+    wallet1 = asyncio.run(init_wallet())
+    asyncio.run(reset_invoices(wallet=wallet1))
+    invoice = asyncio.run(wallet1.request_mint(64))
+
+    # act
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "invoices"],
+    )
+
+    # assert
+    print("INVOICES")
+    assert result.exception is None
+    assert result.exit_code == 0
+    assert "No invoices found." not in result.output
+    assert "ID" in result.output
+    assert get_invoice_from_invoices_command(result.output)["ID"] == invoice.id
+
+
+def test_invoices_with_onlypaid(cli_prefix):
+    # arrange
+    wallet1 = asyncio.run(init_wallet())
+    asyncio.run(reset_invoices(wallet=wallet1))
+    asyncio.run(wallet1.request_mint(64))
+
+    # act
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "invoices", "--only-paid"],
+    )
+
+    # assert
+    print("INVOICES --only-paid")
+    assert result.exception is None
+    assert result.exit_code == 0
+    assert "No invoices found." in result.output
+
+
+def test_invoices_with_onlyunpaid(cli_prefix):
+    # arrange
+    wallet1 = asyncio.run(init_wallet())
+    asyncio.run(reset_invoices(wallet=wallet1))
+    invoice = asyncio.run(wallet1.request_mint(64))
+
+    # act
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "invoices", "--only-unpaid"],
+    )
+
+    # assert
+    print("INVOICES --only-unpaid")
+    assert result.exception is None
+    assert result.exit_code == 0
+    assert "No invoices found." not in result.output
+    assert "ID" in result.output
+    assert get_invoice_from_invoices_command(result.output)["ID"] == invoice.id
+
+
+def test_invoices_with_both_onlypaid_and_onlyunpaid(cli_prefix):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "invoices", "--only-paid", "--only-unpaid"],
+    )
+    assert result.exception is None
+    print("INVOICES --only-paid --only-unpaid")
+    assert result.exit_code == 0
+    assert (
+        "You should only choose one option: either --only-paid or --only-unpaid"
+        in result.output
+    )
+
+
+def test_invoices_with_pending(cli_prefix):
+    # arrange
+    wallet1 = asyncio.run(init_wallet())
+    asyncio.run(reset_invoices(wallet=wallet1))
+    invoice = asyncio.run(wallet1.request_mint(64))
+
+    # act
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "invoices", "--pending"],
+    )
+
+    # assert
+    print("INVOICES --pending")
+    assert result.exception is None
+    assert result.exit_code == 0
+    assert "No invoices found." not in result.output
+    assert "ID" in result.output
+    assert get_invoice_from_invoices_command(result.output)["ID"] == invoice.id
 
 
 def test_wallets(cli_prefix):

--- a/tests/test_wallet_cli.py
+++ b/tests/test_wallet_cli.py
@@ -193,10 +193,35 @@ def test_invoices(cli_prefix):
     assert result.exit_code == 0
     assert "No invoices found." not in result.output
     assert "ID" in result.output
+    assert "Paid" in result.output
     assert get_invoice_from_invoices_command(result.output)["ID"] == invoice.id
+    assert get_invoice_from_invoices_command(result.output)["Paid"] == "True"
+
+def test_invoices_without_minting(cli_prefix):
+    # arrange
+    wallet1 = asyncio.run(init_wallet())
+    asyncio.run(reset_invoices(wallet=wallet1))
+    invoice = asyncio.run(wallet1.request_mint(64))
+
+    # act
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "invoices", "--tests"],
+    )
+
+    # assert
+    print("INVOICES --tests")
+    assert result.exception is None
+    assert result.exit_code == 0
+    assert "No invoices found." not in result.output
+    assert "ID" in result.output
+    assert "Paid" in result.output
+    assert get_invoice_from_invoices_command(result.output)["ID"] == invoice.id
+    assert get_invoice_from_invoices_command(result.output)["Paid"] == str(invoice.paid)
 
 
-def test_invoices_with_onlypaid(cli_prefix):
+def test_invoices_with_onlypaid_option(cli_prefix):
     # arrange
     wallet1 = asyncio.run(init_wallet())
     asyncio.run(reset_invoices(wallet=wallet1))
@@ -213,14 +238,33 @@ def test_invoices_with_onlypaid(cli_prefix):
     print("INVOICES --only-paid")
     assert result.exception is None
     assert result.exit_code == 0
-    assert "No invoices found." in result.output
+    assert "No invoices found." in result.output  
 
-
-def test_invoices_with_onlyunpaid(cli_prefix):
+def test_invoices_with_onlypaid_option_without_minting(cli_prefix):
     # arrange
     wallet1 = asyncio.run(init_wallet())
     asyncio.run(reset_invoices(wallet=wallet1))
-    invoice = asyncio.run(wallet1.request_mint(64))
+    asyncio.run(wallet1.request_mint(64))
+
+    # act
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "invoices", "--only-paid", "--tests"],
+    )
+
+    # assert
+    print("INVOICES --only-paid --tests")
+    assert result.exception is None
+    assert result.exit_code == 0
+    assert "No invoices found." in result.output    
+
+
+def test_invoices_with_onlyunpaid_option(cli_prefix):
+    # arrange
+    wallet1 = asyncio.run(init_wallet())
+    asyncio.run(reset_invoices(wallet=wallet1))
+    asyncio.run(wallet1.request_mint(64))
 
     # act
     runner = CliRunner()
@@ -233,12 +277,33 @@ def test_invoices_with_onlyunpaid(cli_prefix):
     print("INVOICES --only-unpaid")
     assert result.exception is None
     assert result.exit_code == 0
+    assert "No invoices found." in result.output
+
+def test_invoices_with_onlyunpaid_option_without_minting(cli_prefix):
+    # arrange
+    wallet1 = asyncio.run(init_wallet())
+    asyncio.run(reset_invoices(wallet=wallet1))
+    invoice = asyncio.run(wallet1.request_mint(64))
+
+    # act
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "invoices", "--only-unpaid", "--tests"],
+    )
+
+    # assert
+    print("INVOICES --only-unpaid --tests")
+    assert result.exception is None
+    assert result.exit_code == 0
     assert "No invoices found." not in result.output
     assert "ID" in result.output
+    assert "Paid" in result.output
     assert get_invoice_from_invoices_command(result.output)["ID"] == invoice.id
+    assert get_invoice_from_invoices_command(result.output)["Paid"] == str(invoice.paid)
 
 
-def test_invoices_with_both_onlypaid_and_onlyunpaid(cli_prefix):
+def test_invoices_with_both_onlypaid_and_onlyunpaid_options(cli_prefix):
     runner = CliRunner()
     result = runner.invoke(
         cli,
@@ -253,11 +318,11 @@ def test_invoices_with_both_onlypaid_and_onlyunpaid(cli_prefix):
     )
 
 
-def test_invoices_with_pending(cli_prefix):
+def test_invoices_with_pending_option(cli_prefix):
     # arrange
     wallet1 = asyncio.run(init_wallet())
     asyncio.run(reset_invoices(wallet=wallet1))
-    invoice = asyncio.run(wallet1.request_mint(64))
+    asyncio.run(wallet1.request_mint(64))
 
     # act
     runner = CliRunner()
@@ -270,9 +335,30 @@ def test_invoices_with_pending(cli_prefix):
     print("INVOICES --pending")
     assert result.exception is None
     assert result.exit_code == 0
+    assert "No invoices found." in result.output
+
+def test_invoices_with_pending_option_without_minting(cli_prefix):
+    # arrange
+    wallet1 = asyncio.run(init_wallet())
+    asyncio.run(reset_invoices(wallet=wallet1))
+    invoice = asyncio.run(wallet1.request_mint(64))
+
+    # act
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "invoices", "--pending", "--tests"],
+    )
+
+    # assert
+    print("INVOICES --pending --tests")
+    assert result.exception is None
+    assert result.exit_code == 0
     assert "No invoices found." not in result.output
     assert "ID" in result.output
+    assert "Paid" in result.output
     assert get_invoice_from_invoices_command(result.output)["ID"] == invoice.id
+    assert get_invoice_from_invoices_command(result.output)["Paid"] == str(invoice.paid)
 
 
 def test_wallets(cli_prefix):

--- a/tests/test_wallet_cli.py
+++ b/tests/test_wallet_cli.py
@@ -27,6 +27,7 @@ def get_bolt11_and_invoice_id_from_invoice_command(output: str) -> Tuple[str, st
     ][0]
     return invoice, invoice_id
 
+
 def get_invoice_from_invoices_command(output: str) -> dict[str, str]:
     splitted = output.split("\n")
     removed_empty_and_hiphens = [
@@ -38,6 +39,7 @@ def get_invoice_from_invoices_command(output: str) -> dict[str, str]:
     }
 
     return dict_output
+
 
 async def reset_invoices(wallet: Wallet):
     await wallet.db.execute("DELETE FROM invoices")
@@ -197,6 +199,7 @@ def test_invoices(cli_prefix):
     assert get_invoice_from_invoices_command(result.output)["ID"] == invoice.id
     assert get_invoice_from_invoices_command(result.output)["Paid"] == "True"
 
+
 def test_invoices_without_minting(cli_prefix):
     # arrange
     wallet1 = asyncio.run(init_wallet())
@@ -238,7 +241,8 @@ def test_invoices_with_onlypaid_option(cli_prefix):
     print("INVOICES --only-paid")
     assert result.exception is None
     assert result.exit_code == 0
-    assert "No invoices found." in result.output  
+    assert "No invoices found." in result.output
+
 
 def test_invoices_with_onlypaid_option_without_minting(cli_prefix):
     # arrange
@@ -257,7 +261,7 @@ def test_invoices_with_onlypaid_option_without_minting(cli_prefix):
     print("INVOICES --only-paid --tests")
     assert result.exception is None
     assert result.exit_code == 0
-    assert "No invoices found." in result.output    
+    assert "No invoices found." in result.output
 
 
 def test_invoices_with_onlyunpaid_option(cli_prefix):
@@ -278,6 +282,7 @@ def test_invoices_with_onlyunpaid_option(cli_prefix):
     assert result.exception is None
     assert result.exit_code == 0
     assert "No invoices found." in result.output
+
 
 def test_invoices_with_onlyunpaid_option_without_minting(cli_prefix):
     # arrange
@@ -336,6 +341,7 @@ def test_invoices_with_pending_option(cli_prefix):
     assert result.exception is None
     assert result.exit_code == 0
     assert "No invoices found." in result.output
+
 
 def test_invoices_with_pending_option_without_minting(cli_prefix):
     # arrange

--- a/tests/test_wallet_p2pk.py
+++ b/tests/test_wallet_p2pk.py
@@ -231,9 +231,9 @@ async def test_p2pk_locktime_with_second_refund_pubkey(
     secret_lock = await wallet1.create_p2pk_lock(
         garbage_pubkey.serialize().hex(),  # create lock to unspendable pubkey
         locktime_seconds=2,  # locktime
-        tags=Tags([
-            ["refund", pubkey_wallet2, pubkey_wallet1]
-        ]),  # multiple refund pubkeys
+        tags=Tags(
+            [["refund", pubkey_wallet2, pubkey_wallet1]]
+        ),  # multiple refund pubkeys
     )  # sender side
     _, send_proofs = await wallet1.split_to_send(
         wallet1.proofs, 8, secret_lock=secret_lock
@@ -388,9 +388,9 @@ async def test_p2pk_multisig_with_wrong_first_private_key(
 
 
 def test_tags():
-    tags = Tags([
-        ["key1", "value1"], ["key2", "value2", "value2_1"], ["key2", "value3"]
-    ])
+    tags = Tags(
+        [["key1", "value1"], ["key2", "value2", "value2_1"], ["key2", "value3"]]
+    )
     assert tags.get_tag("key1") == "value1"
     assert tags["key1"] == "value1"
     assert tags.get_tag("key2") == "value2"


### PR DESCRIPTION
- Updates deprecated `datetime.utcfromtimestamp` in the `cashu/wallet/cli/cli.py` file;
- Adds new options to the `invoices` CLI command:
  - `--only-paid` (`-op`): retrieve only paid invoices;
  - `--only-unpaid` (`-ou`): retrieve only unpaid invoices;
  - `--pending` (`-p`): retrieve only pending invoices.

Pending invoice was defined as invoices with `paid = False` and `out = False` (not sure if this is right).

Closes #313 .
