### PR TITLE
[Mint] default setting for `mint_derivation_path_list`

### DIFF
--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -52,7 +52,7 @@ class MintSettings(CashuSettings):
     mint_private_key: str = Field(default=None)
     mint_seed_decryption_key: Optional[str] = Field(default=None)
     mint_derivation_path: str = Field(default="m/0'/0'/0'")
-    mint_derivation_path_list: List[str] = Field(default=[""])
+    mint_derivation_path_list: List[str] = Field(default=[])
     mint_listen_host: str = Field(default="127.0.0.1")
     mint_listen_port: int = Field(default=3338)
 


### PR DESCRIPTION
The default setting was `[""]` which caused a startup failure.