### PR TITLE
Add blink key to startup

### DIFF
--- a/cashu/mint/startup.py
+++ b/cashu/mint/startup.py
@@ -28,6 +28,7 @@ for key, value in settings.dict().items():
         "mint_seed_decryption_key",
         "nostr_private_key",
         "mint_lnbits_key",
+        "mint_blink_key",
         "mint_strike_key",
         "mint_lnd_rest_macaroon",
         "mint_lnd_rest_admin_macaroon",


### PR DESCRIPTION
I think the blink key is missing here:
for key, value in settings.dict().items():
    if key in [
        "mint_private_key",
        "mint_seed_decryption_key",
        "nostr_private_key",
        "mint_lnbits_key",
        "mint_strike_key",