### PR TITLE
Redirect users to mint home website url if the router path is only "/"

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,9 @@ MINT_INFO_MOTD="Message to users"
 
 MINT_PRIVATE_KEY=supersecretprivatekey
 
+# Mint default home website
+MINT_HOME_URL=https://mint.home
+
 # Increment derivation path to rotate to a new keyset
 # Example: m/0'/0'/0' -> m/0'/0'/1'
 MINT_DERIVATION_PATH="m/0'/0'/0'"

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -69,7 +69,7 @@ class MintBackends(MintSettings):
     mint_lnbits_key: str = Field(default=None)
     mint_strike_key: str = Field(default=None)
     mint_blink_key: str = Field(default=None)
-
+    mint_home_url: str = Field(default=None)
 
 class MintLimits(MintSettings):
     mint_rate_limit: bool = Field(

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List
 
 from fastapi import APIRouter, Request
+from fastapi.responses import RedirectResponse
 from loguru import logger
 
 from ..core.base import (
@@ -31,6 +32,18 @@ from ..mint.startup import ledger
 from .limit import limiter
 
 router: APIRouter = APIRouter()
+
+@router.get("/", 
+       name="Mint home website",     
+       summary="Redirect users to Mint homepage where they can get more information about the mint",                 
+)
+async def redirect_to_website():
+    website_url = settings.mint_home_url  # Get the URL from the environment variable
+    if website_url:
+        return RedirectResponse(url=website_url)
+    else:
+        # Handle the case where the environment variable is not set
+        return {"message": "WEBSITE_URL environment variable not set"}
 
 
 @router.get(


### PR DESCRIPTION
Users typically try to access mint url by putting the mint url on the web browser. e.g. https://mint.minibits.cash/Bitcoin returns this in the browser {"detail":"Not Found"} which is a bad user experience. Instead, if it is mint url without /v1 then redirect the users to a home website page where they can find more info about the mint. e.g. https://stablenut.umint.cash now redirects to https://umint.cash where the user can find more info about the mint. 

This is optional and only works when the env parameter is set. 