### PR TITLE
Mint: refactor melt quote

### DIFF
--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -616,18 +616,15 @@ class Ledger(LedgerVerification, LedgerSpendingConditions):
             expiry=quote.expiry,
         )
 
-    async def get_melt_quote(
-        self, quote_id: str, check_quote_with_backend: bool = False
-    ) -> MeltQuote:
+    async def get_melt_quote(self, quote_id: str) -> MeltQuote:
         """Returns a melt quote.
 
-        If melt quote is not paid yet and `check_quote_with_backend` is set to `True`,
+        If melt quote is not paid yet and no internal mint quote is associated with it,
         checks with the backend for the state of the payment request. If the backend
         says that the quote has been paid, updates the melt quote in the database.
 
         Args:
             quote_id (str): ID of the melt quote.
-            check_quote_with_backend (bool, optional): Whether to check the state of the payment request with the backend. Defaults to False.
 
         Raises:
             Exception: Quote not found.
@@ -649,7 +646,7 @@ class Ledger(LedgerVerification, LedgerSpendingConditions):
             request=melt_quote.request, db=self.db
         )
 
-        if not melt_quote.paid and not mint_quote and check_quote_with_backend:
+        if not melt_quote.paid and not mint_quote:
             logger.trace(
                 "Lightning: checking outgoing Lightning payment"
                 f" {melt_quote.checking_id}"

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -258,7 +258,7 @@ async def mint(
     response_description="Melt tokens for a payment on a supported payment method.",
 )
 @limiter.limit(f"{settings.mint_transaction_rate_limit_per_minute}/minute")
-async def get_melt_quote(
+async def melt_quote(
     request: Request, payload: PostMeltQuoteRequest
 ) -> PostMeltQuoteResponse:
     """
@@ -277,7 +277,7 @@ async def get_melt_quote(
     response_description="Get an existing melt quote to check its status.",
 )
 @limiter.limit(f"{settings.mint_transaction_rate_limit_per_minute}/minute")
-async def melt_quote(request: Request, quote: str) -> PostMeltQuoteResponse:
+async def get_melt_quote(request: Request, quote: str) -> PostMeltQuoteResponse:
     """
     Get melt quote state.
     """

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -738,7 +738,7 @@ async def invoices(ctx, paid: bool, unpaid: bool, pending: bool, mint: bool):
         return
 
     if mint:
-      await wallet.load_mint()
+        await wallet.load_mint()
 
     paid_arg = None
     if unpaid:


### PR DESCRIPTION
Remove option to skip checking payment state in `get_melt_quote` and always check it if unpaid.

Todo: check if the melt routine assumed that it would skip the check in order to avoid double-checking. If so, remove duplicate check in melt routine.