### PR TITLE
 add MINT_LND_REST_CERT_VERIFY env bool that when set to False allow to skip certificate validation for LND api call

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,7 +69,7 @@ MINT_LNBITS_KEY=yourkeyasdasdasd
 MINT_LND_REST_ENDPOINT=https://127.0.0.1:8086
 MINT_LND_REST_CERT="/home/lnd/.lnd/tls.cert"
 MINT_LND_REST_MACAROON="/home/lnd/.lnd/data/chain/bitcoin/regtest/admin.macaroon"
-MINT_LND_REST_CERT_VERIFY=False
+MINT_LND_REST_CERT_VERIFY=True
 
 # Use with CoreLightningRestWallet
 MINT_CORELIGHTNING_REST_URL=https://localhost:3001

--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,7 @@ MINT_LNBITS_KEY=yourkeyasdasdasd
 MINT_LND_REST_ENDPOINT=https://127.0.0.1:8086
 MINT_LND_REST_CERT="/home/lnd/.lnd/tls.cert"
 MINT_LND_REST_MACAROON="/home/lnd/.lnd/data/chain/bitcoin/regtest/admin.macaroon"
+MINT_LND_REST_CERT_VERIFY=False
 
 # Use with CoreLightningRestWallet
 MINT_CORELIGHTNING_REST_URL=https://localhost:3001

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -168,6 +168,7 @@ class WalletSettings(CashuSettings):
 class LndRestFundingSource(MintSettings):
     mint_lnd_rest_endpoint: Optional[str] = Field(default=None)
     mint_lnd_rest_cert: Optional[str] = Field(default=None)
+    mint_lnd_rest_cert_verify: bool = Field(default=True)
     mint_lnd_rest_macaroon: Optional[str] = Field(default=None)
     mint_lnd_rest_admin_macaroon: Optional[str] = Field(default=None)
     mint_lnd_rest_invoice_macaroon: Optional[str] = Field(default=None)

--- a/cashu/lightning/lndrest.py
+++ b/cashu/lightning/lndrest.py
@@ -35,6 +35,7 @@ class LndRestWallet(LightningBackend):
         self.unit = unit
         endpoint = settings.mint_lnd_rest_endpoint
         cert = settings.mint_lnd_rest_cert
+        cert_verify = settings.mint_lnd_rest_cert_verify
 
         macaroon = (
             settings.mint_lnd_rest_macaroon
@@ -54,6 +55,12 @@ class LndRestWallet(LightningBackend):
                 " publicly issued certificate"
             )
 
+        if not cert_verify:
+            logger.warning(
+                "certificate validation will be disabled for lndrest"
+            )
+
+
         endpoint = endpoint[:-1] if endpoint.endswith("/") else endpoint
         endpoint = (
             f"https://{endpoint}" if not endpoint.startswith("http") else endpoint
@@ -65,6 +72,11 @@ class LndRestWallet(LightningBackend):
         # and it will still check for validity of certificate and fail if its not valid
         # even on startup
         self.cert = cert or True
+
+        # disable cert verify if choosen
+        if not cert_verify:
+            self.cert = False
+
 
         self.auth = {"Grpc-Metadata-macaroon": self.macaroon}
         self.client = httpx.AsyncClient(


### PR DESCRIPTION
 - Add MINT_LND_REST_CERT_VERIFY bool variable that when set to False allows verify=False for httpx and ignore LND selfsigned certificate validation

 On branch main
 Your branch is up to date with 'origin/main'.

 Changes to be committed:
	modified:   .env.example
	modified:   cashu/core/settings.py
	modified:   cashu/lightning/lndrest.py