### PR TITLE
Add "MINT_ICON_URL" Field for Mint Profile Images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@ MINT_INFO_DESCRIPTION="The short mint description"
 MINT_INFO_DESCRIPTION_LONG="A long mint description that can be a long piece of text."
 MINT_INFO_CONTACT=[["email","contact@me.com"], ["twitter","@me"], ["nostr",  "npub..."]]
 MINT_INFO_MOTD="Message to users"
-MINT_PROFILE_ICON="https://icon-example.jpg"
+MINT_ICON_URL="https://icon-example.jpg"
 
 MINT_PRIVATE_KEY=supersecretprivatekey
 

--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,7 @@ MINT_INFO_DESCRIPTION="The short mint description"
 MINT_INFO_DESCRIPTION_LONG="A long mint description that can be a long piece of text."
 MINT_INFO_CONTACT=[["email","contact@me.com"], ["twitter","@me"], ["nostr",  "npub..."]]
 MINT_INFO_MOTD="Message to users"
+MINT_PROFILE_ICON="https://icon-example.jpg"
 
 MINT_PRIVATE_KEY=supersecretprivatekey
 


### PR DESCRIPTION
I have added the `MINT_ICON_URL` field to allow mint operators to include a profile image. This feature enables applications to index and display the image, making it easier for users to identify the mint.

The Fedimint protocol provides a similar feature with the `federation_icon_url`. Following their naming convention, I propose `MINT_ICON_URL` as the metadata field.

Below is a visual example of how an app might index and display the mint metadata fields. The profile icon can be a useful addition to the existing options.
![mint-profile-example](https://github.com/cashubtc/nutshell/assets/78821053/7220256a-1fd2-4672-a35c-0f90a65edcf8)


