### PR TITLE
Lnbits backend with multiple units support

### DIFF
--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -606,6 +606,7 @@ class Unit(Enum):
     sat = 0
     msat = 1
     usd = 2
+    eur = 4
 
     def str(self, amount: int) -> str:
         if self == Unit.sat:
@@ -614,6 +615,8 @@ class Unit(Enum):
             return f"{amount} msat"
         elif self == Unit.usd:
             return f"${amount/100:.2f} USD"
+        elif self == Unit.eur:
+            return f"${amount/100:.2f} EUR"            
         else:
             raise Exception("Invalid unit")
 

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -64,6 +64,7 @@ class MintBackends(MintSettings):
     mint_lightning_backend: str = Field(default="")  # deprecated
     mint_backend_bolt11_sat: str = Field(default="")
     mint_backend_bolt11_usd: str = Field(default="")
+    mint_backend_bolt11_eur: str = Field(default="")
 
     mint_lnbits_endpoint: str = Field(default=None)
     mint_lnbits_key: str = Field(default=None)

--- a/cashu/lightning/fake.py
+++ b/cashu/lightning/fake.py
@@ -29,7 +29,8 @@ from .base import (
 
 
 class FakeWallet(LightningBackend):
-    fake_btc_price = 1e8 / 1337
+    fake_btcusd_price = 1e8 / 1556
+    fake_btceur_price = 1e8 / 1672
     queue: asyncio.Queue[Bolt11] = asyncio.Queue(0)
     payment_secrets: Dict[str, str] = dict()
     paid_invoices: Set[str] = set()

--- a/cashu/lightning/fake.py
+++ b/cashu/lightning/fake.py
@@ -42,7 +42,7 @@ class FakeWallet(LightningBackend):
         32,
     ).hex()
 
-    supported_units = set([Unit.sat, Unit.msat, Unit.usd])
+        supported_units = set([Unit.sat, Unit.msat, Unit.usd, Unit.eur])
     unit = Unit.sat
 
     def __init__(self, unit: Unit = Unit.sat, **kwargs):
@@ -87,13 +87,16 @@ class FakeWallet(LightningBackend):
         tags.add(TagChar.payment_hash, payment_hash)
 
         self.payment_secrets[payment_hash] = secret
-
         amount_msat = 0
         if self.unit == Unit.sat:
             amount_msat = MilliSatoshi(amount.to(Unit.msat, round="up").amount)
         elif self.unit == Unit.usd:
             amount_msat = MilliSatoshi(
-                math.ceil(amount.amount / self.fake_btc_price * 1e9)
+                math.ceil(amount.amount / self.fake_btcusd_price * 1e9)
+            )
+        elif self.unit == Unit.eur:
+            amount_msat = MilliSatoshi(
+                math.ceil(amount.amount / self.fake_btceur_price * 1e9)
             )
         else:
             raise NotImplementedError()
@@ -162,9 +165,14 @@ class FakeWallet(LightningBackend):
             fees = Amount(unit=Unit.msat, amount=fees_msat)
             amount = Amount(unit=Unit.msat, amount=amount_msat)
         elif self.unit == Unit.usd:
-            amount_usd = math.ceil(invoice_obj.amount_msat / 1e9 * self.fake_btc_price)
+            amount_usd = math.ceil(invoice_obj.amount_msat / 1e9 * self.fake_btcusd_price)
             amount = Amount(unit=Unit.usd, amount=amount_usd)
             fees = Amount(unit=Unit.usd, amount=2)
+        elif self.unit == Unit.eur:
+            amount_eur = math.ceil(invoice_obj.amount_msat / 1e9 * self.fake_btceur_price)
+            amount = Amount(unit=Unit.eur, amount=amount_eur)
+            fees = Amount(unit=Unit.eur, amount=2)
+
         else:
             raise NotImplementedError()
 

--- a/cashu/lightning/fake.py
+++ b/cashu/lightning/fake.py
@@ -43,7 +43,7 @@ class FakeWallet(LightningBackend):
         32,
     ).hex()
 
-        supported_units = set([Unit.sat, Unit.msat, Unit.usd, Unit.eur])
+    supported_units = set([Unit.sat, Unit.msat, Unit.usd, Unit.eur])
     unit = Unit.sat
 
     def __init__(self, unit: Unit = Unit.sat, **kwargs):

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -553,8 +553,8 @@ class Ledger(LedgerVerification, LedgerSpendingConditions):
         if mint_quote:
             if not request == mint_quote.request:
                 raise TransactionError("bolt11 requests do not match")
-            if not mint_quote.unit == melt_quote.unit:
-                raise TransactionError("units do not match")
+            # if not mint_quote.unit == melt_quote.unit:
+            #     raise TransactionError("units do not match")
             if not mint_quote.method == method.name:
                 raise TransactionError("methods do not match")
             if mint_quote.paid:
@@ -562,13 +562,20 @@ class Ledger(LedgerVerification, LedgerSpendingConditions):
             if mint_quote.issued:
                 raise TransactionError("mint quote already issued")
             if not mint_quote.checking_id:
-                raise TransactionError("mint quote has no checking id")
-
-            payment_quote = PaymentQuoteResponse(
-                checking_id=mint_quote.checking_id,
-                amount=Amount(unit, mint_quote.amount),
-                fee=Amount(unit, amount=0),
-            )
+                raise TransactionError("mint quote has no checking id")            
+            
+            if mint_quote.unit == melt_quote.unit:
+                # return payment quote based on mint quote data
+                payment_quote = PaymentQuoteResponse(
+                    checking_id=mint_quote.checking_id,
+                    amount=Amount(unit, mint_quote.amount),
+                    fee=Amount(unit, amount=0),
+                )
+            else:
+                # if quote requires unit conversion get payment quote by backend
+                payment_quote = await self.backends[method][unit].get_payment_quote(
+                    melt_quote=melt_quote
+                )
             logger.info(
                 f"Issuing internal melt quote: {request} ->"
                 f" {mint_quote.quote} ({mint_quote.amount} {mint_quote.unit})"
@@ -697,12 +704,12 @@ class Ledger(LedgerVerification, LedgerSpendingConditions):
 
         if not invoice_obj.amount_msat:
             raise TransactionError("invoice has no amount.")
-        if not mint_quote.amount == melt_quote.amount:
-            raise TransactionError("amounts do not match")
+        # if not mint_quote.amount == melt_quote.amount:
+        #     raise TransactionError("amounts do not match")
         if not bolt11_request == mint_quote.request:
             raise TransactionError("bolt11 requests do not match")
-        if not mint_quote.unit == melt_quote.unit:
-            raise TransactionError("units do not match")
+        # if not mint_quote.unit == melt_quote.unit:
+        #     raise TransactionError("units do not match")
         if not mint_quote.method == melt_quote.method:
             raise TransactionError("methods do not match")
         if mint_quote.paid:

--- a/cashu/mint/startup.py
+++ b/cashu/mint/startup.py
@@ -51,6 +51,11 @@ if settings.mint_backend_bolt11_usd:
         unit=Unit.usd
     )
     backends.setdefault(Method.bolt11, {})[Unit.usd] = backend_bolt11_usd
+if settings.mint_backend_bolt11_eur:
+    backend_bolt11_eur = getattr(wallets_module, settings.mint_backend_bolt11_eur)(
+        unit=Unit.eur
+    )
+    backends.setdefault(Method.bolt11, {})[Unit.eur] = backend_bolt11_eur    
 if not backends:
     raise Exception("No backends are set.")
 


### PR DESCRIPTION
This PR enables Lnbits backend to be used to issue invoices and settle them using msats, usd and eur currency units. Backing of non-sats ecash issued that way is not in scope of Lnbits and needs to be solved using additional infrastructure and processes, e.g. by holding and managing swap positions at exchanges.

PR allows to Nutshell configured with Lnbits backend to:
- Accept mint quote requests in other then sat unit (msat, usd, eur) and issue bolt11 invoices with amount calculated according to Lnbits rates conversion service
- Accept melt quote requests with bolt11 invoice where melt quote is requested by wallet in other then sat unit. Amount of non-sat ecash to settle such invoice is calculated using the Lnbits rates conversion service. If ecash is provided in subsequent melt request, invoice is internally settled (if issued by the same mint) or paid over lightning.

To-do: Extend nutshell .env config with option to set dedicated Lnbits wallet for each currency unit.

This is experimental, requires testing and careful analysis of attack vectors. Only settlement of internal invoices has been successfully tested.