### PR TITLE
Use integer division for fee calculation

### DIFF
--- a/cashu/mint/verification.py
+++ b/cashu/mint/verification.py
@@ -1,4 +1,3 @@
-import math
 from typing import Dict, List, Literal, Optional, Tuple, Union
 
 from loguru import logger
@@ -256,7 +255,7 @@ class LedgerVerification(
     def get_fees_for_proofs(self, proofs: List[Proof]) -> int:
         if not len(set([self.keysets[p.id].unit for p in proofs])) == 1:
             raise TransactionUnitError("inputs have different units.")
-        fee = math.ceil(sum([self.keysets[p.id].input_fee_ppk for p in proofs]) / 1000)
+        fee = (sum([self.keysets[p.id].input_fee_ppk for p in proofs]) + 999) // 1000
         return fee
 
     def _verify_equation_balanced(

--- a/cashu/wallet/transactions.py
+++ b/cashu/wallet/transactions.py
@@ -1,4 +1,3 @@
-import math
 import uuid
 from typing import Dict, List, Tuple, Union
 
@@ -24,13 +23,13 @@ class WalletTransactions(SupportsDb, SupportsKeysets):
     unit: Unit
 
     def get_fees_for_keyset(self, amounts: List[int], keyset: WalletKeyset) -> int:
-        fees = max(math.ceil(sum([keyset.input_fee_ppk for a in amounts]) / 1000), 0)
+        fees = max((sum([keyset.input_fee_ppk for a in amounts]) + 999) // 1000, 0)
         return fees
 
     def get_fees_for_proofs(self, proofs: List[Proof]) -> int:
         # for each proof, find the keyset with the same id and sum the fees
         fees = max(
-            math.ceil(sum([self.keysets[p.id].input_fee_ppk for p in proofs]) / 1000), 0
+            (sum([self.keysets[p.id].input_fee_ppk for p in proofs]) + 999) // 1000, 0
         )
         return fees
 


### PR DESCRIPTION
The pull request updates the fee calculation in two places to use integer division instead of `math.ceil()`. This change ensures that the fees are rounded up to the nearest whole number. The previous implementation used `math.ceil()` which rounded up to the nearest integer, but we want to round up to the nearest whole number. This change improves the accuracy of the fee calculation.