### PR TITLE
Discrete Log Contracts on E-Cash

### DIFF
--- a/cashu/core/crypto/dlc.py
+++ b/cashu/core/crypto/dlc.py
@@ -1,0 +1,34 @@
+from hashlib import sha256
+from typing import Optional, Tuple
+from secp256k1 import PrivateKey, PublicKey
+
+def sorted_merkle_hash(left: bytes, right: bytes) -> bytes:
+    '''Sorts `left` and `right` in non-ascending order and
+        computes the hash of their concatenation
+    '''
+    if int.from_bytes(left, 'big') < int.from_bytes(right, 'big'):
+        left, right = right, left
+    return sha256(left+right).digest()
+
+
+def merkle_root(leaf_hashes: List[bytes]) -> bytes:
+    '''Computes the root of a list of merkle proofs
+    '''
+    if len(leaf_hashes) == 0:
+        return b""
+    elif len(leaf_hashes) == 1:
+        return leaf_hashes[0]
+    else:
+        split = len(leaf_hashes) // 2
+        left = merkle_root(leaf_hashes[:split])
+        right = merkle_root(leaf_hashes[split:])
+        return sorted_merkle_hash(left, right)
+
+def merkle_verify(root: bytes, leaf_hash: bytes, proof: List[bytes]) -> bool:
+    '''Verifies that `leaf_hash` belongs to a merkle tree
+        that has `root` as root
+    '''
+    h = leaf_hash
+    for branch_hash in proof:
+        h = sorted_merkle_hash(h, branch_hash)
+    return h == root

--- a/cashu/core/models.py
+++ b/cashu/core/models.py
@@ -10,6 +10,11 @@ from .base import (
     MintQuote,
     Proof,
     ProofState,
+    DlcFundingProof,
+    DiscreteLogContract,
+    DlcSettlement,
+    DlcPayoutForm,
+    DlcPayout
 )
 from .settings import settings
 
@@ -304,3 +309,39 @@ class PostRestoreResponse(BaseModel):
     def __init__(self, **data):
         super().__init__(**data)
         self.promises = self.signatures
+
+
+# ------- API: DLC REGISTRATION -------
+
+class PostDlcRegistrationRequest(BaseModel):
+    atomic: Optional[bool]
+    registrations: List[DiscreteLogContract]
+
+class PostDlcRegistrationResponse(BaseModel):
+    funded: List[DlcFundingProof] = []
+    errors: Optional[List[DlcFundingProof]] = None
+
+# ------- API: DLC SETTLEMENT -------
+
+class PostDlcSettleRequest(BaseModel):
+    settlements: List[DlcSettlement]
+
+class PostDlcSettleResponse(BaseModel):
+    settled: List[DlcSettlement] = []
+    errors: Optional[List[DlcSettlement]] = None
+
+# ------- API: DLC PAYOUT -------
+class PostDlcPayoutRequest(BaseModel):
+    atomic: Optional[bool]
+    payouts: List[DlcPayoutForm]
+
+class PostDlcPayoutResponse(BaseModel):
+    paid: List[DlcPayout]
+    errors: Optional[List[DlcPayout]]
+
+# ------- API: DLC STATUS -------
+
+class GetDlcStatusResponse(BaseModel):
+    settled: bool
+    funding_amount: Optional[int]
+    debts: Optional[Dict[str, int]]

--- a/cashu/core/secret.py
+++ b/cashu/core/secret.py
@@ -11,6 +11,7 @@ from .crypto.secp import PrivateKey
 class SecretKind(Enum):
     P2PK = "P2PK"
     HTLC = "HTLC"
+    SCT = "SCT"
 
 
 class Tags(BaseModel):

--- a/cashu/mint/conditions.py
+++ b/cashu/mint/conditions.py
@@ -197,6 +197,7 @@ class LedgerSpendingConditions:
         Verify spending conditions:
          Condition: P2PK - Checks if signature in proof.witness is valid for pubkey in proof.secret
          Condition: HTLC - Checks if preimage in proof.witness is valid for hash in proof.secret
+         Condition: SCT - Spending Condition Tree means this proof is DLC locked: DO NOT SPEND.
         """
 
         try:
@@ -214,6 +215,10 @@ class LedgerSpendingConditions:
         # HTLC
         if SecretKind(secret.kind) == SecretKind.HTLC:
             return self._verify_htlc_spending_conditions(proof, secret)
+        
+        # SCT
+        if SecretKind(secret.kind) == SecretKind.SCT:
+            return False
 
         # no spending condition present
         return True

--- a/cashu/mint/features.py
+++ b/cashu/mint/features.py
@@ -56,6 +56,19 @@ class LedgerFeatures(SupportsBackends):
             SCRIPT_NUT: supported_dict,
             P2PK_NUT: supported_dict,
             DLEQ_NUT: supported_dict,
+            # Hard coded values for now
+            DLC_NUT: dict(
+                supported=True,
+                funding_proof_pubkey='XXXXXX',
+                max_payous=30,
+                ttl=2629743, # 1 month
+                fees=dict(
+                    sat=dict(
+                        base=0,
+                        ppk=0
+                    )
+                )
+            )
         }
 
         # signal which method-unit pairs support MPP

--- a/tests/test_mint_dlc.py
+++ b/tests/test_mint_dlc.py
@@ -1,0 +1,13 @@
+import pytest
+import pytest_asyncio
+
+from cashu.core.crypto.dlc import sorted_merkle_hash
+
+@pytest.mark.asyncio
+async def test_sorted_merkle_hash():
+    data = [b'\x01', b'\x02']
+    target = '25dfd29c09617dcc9852281c030e5b3037a338a4712a42a21c907f259c6412a0'
+    h = sorted_merkle_hash(data[1], data[0])
+    assert h.hex() == target, f'sorted_merkle_hash test fail: {h.hex() = }'
+    h = sorted_merkle_hash(data[0], data[1])
+    assert h.hex() == target, f'sorted_merkle_hash test fail: {h.hex() = }'


### PR DESCRIPTION
Implementing @conduition 's (NUT-DLC)[https://github.com/cashubtc/nuts/pull/128] for discrete log contract execution on chaumian ecash mints.