### PR TITLE
Fix loading b64 keysets and add option to set b64 inactive in WalletSettings

### DIFF
--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -728,6 +728,13 @@ class MintKeyset:
         assert self.seed, "seed not set"
         assert self.derivation_path, "derivation path not set"
 
+        # BEGIN: BACKWARDS COMPATIBILITY < 0.15.0
+        # we overwrite keyset id only if it isn't already set in the database
+        # loaded from the database. This is to allow for backwards compatibility
+        # with old keysets with new id's and vice versa. This code and successive
+        # `id_in_db or` parts can be removed if there are only new keysets in the mint (> 0.15.0)
+        id_in_db = self.id
+
         if self.version_tuple < (0, 12):
             # WARNING: Broken key derivation for backwards compatibility with < 0.12
             self.private_keys = derive_keys_backwards_compatible_insecure_pre_0_12(
@@ -738,7 +745,7 @@ class MintKeyset:
                 f"WARNING: Using weak key derivation for keyset {self.id} (backwards"
                 " compatibility < 0.12)"
             )
-            self.id = derive_keyset_id_deprecated(self.public_keys)  # type: ignore
+            self.id = id_in_db or derive_keyset_id_deprecated(self.public_keys)  # type: ignore
         elif self.version_tuple < (0, 15):
             self.private_keys = derive_keys_sha256(self.seed, self.derivation_path)
             logger.trace(
@@ -746,11 +753,11 @@ class MintKeyset:
                 " compatibility < 0.15)"
             )
             self.public_keys = derive_pubkeys(self.private_keys)  # type: ignore
-            self.id = derive_keyset_id_deprecated(self.public_keys)  # type: ignore
+            self.id = id_in_db or derive_keyset_id_deprecated(self.public_keys)  # type: ignore
         else:
             self.private_keys = derive_keys(self.seed, self.derivation_path)
             self.public_keys = derive_pubkeys(self.private_keys)  # type: ignore
-            self.id = derive_keyset_id(self.public_keys)  # type: ignore
+            self.id = id_in_db or derive_keyset_id(self.public_keys)  # type: ignore
 
 
 # ------- TOKEN -------

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -184,6 +184,14 @@ class WalletSettings(CashuSettings):
     wallet_target_amount_count: int = Field(default=3)
 
 
+class WalletFeatures(CashuSettings):
+    wallet_inactivate_legacy_keysets: bool = Field(
+        default=False,
+        title="Inactivate legacy base64 keysets",
+        description="If you turn on this flag, old bas64 keysets will be ignored and the wallet will ony use new keyset versions.",
+    )
+
+
 class LndRestFundingSource(MintSettings):
     mint_lnd_rest_endpoint: Optional[str] = Field(default=None)
     mint_lnd_rest_cert: Optional[str] = Field(default=None)
@@ -218,6 +226,7 @@ class Settings(
     MintSettings,
     MintInformation,
     WalletSettings,
+    WalletFeatures,
     CashuSettings,
 ):
     version: str = Field(default=VERSION)

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -262,7 +262,7 @@ class Wallet(
                         continue
 
                     logger.warning(
-                        f"Keyset {keyset.id} is base64 and has nex hex counterpart, setting inactive."
+                        f"Keyset {keyset.id} is base64 and has a hex counterpart, setting inactive."
                     )
                     keyset.active = False
                     await update_keyset(keyset=keyset, db=self.db)

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -1068,6 +1068,7 @@ class Wallet(
         *,
         secret_lock: Optional[Secret] = None,
         set_reserved: bool = False,
+        include_fees: bool = True,
     ) -> Tuple[List[Proof], List[Proof]]:
         """
         Swaps a set of proofs with the mint to get a set that sums up to a desired amount that can be sent. The remaining

--- a/tests/test_mint_fees.py
+++ b/tests/test_mint_fees.py
@@ -192,7 +192,7 @@ async def test_melt_internal(wallet1: Wallet, ledger: Ledger):
     assert not melt_quote_pre_payment.paid, "melt quote should not be paid"
 
     # let's first try to melt without enough funds
-    send_proofs, fees = await wallet1.select_to_send(wallet1.proofs, 63)
+    send_proofs, fees = await wallet1.select_to_send(wallet1.proofs, 64)
     # this should fail because we need 64 + 1 sat fees
     assert sum_proofs(send_proofs) == 64
     await assert_err(
@@ -201,7 +201,9 @@ async def test_melt_internal(wallet1: Wallet, ledger: Ledger):
     )
 
     # the wallet respects the fees for coin selection
-    send_proofs, fees = await wallet1.select_to_send(wallet1.proofs, 64)
+    send_proofs, fees = await wallet1.select_to_send(
+        wallet1.proofs, 64, include_fees=True
+    )
     # includes 1 sat fees
     assert sum_proofs(send_proofs) == 65
     await ledger.melt(proofs=send_proofs, quote=melt_quote.quote)

--- a/tests/test_mint_fees.py
+++ b/tests/test_mint_fees.py
@@ -229,7 +229,9 @@ async def test_melt_external_with_fees(wallet1: Wallet, ledger: Ledger):
 
     mint_quote = await wallet1.melt_quote(invoice_payment_request)
     total_amount = mint_quote.amount + mint_quote.fee_reserve
-    send_proofs, fee = await wallet1.select_to_send(wallet1.proofs, total_amount)
+    send_proofs, fee = await wallet1.select_to_send(
+        wallet1.proofs, total_amount, include_fees=True
+    )
     melt_quote = await ledger.melt_quote(
         PostMeltQuoteRequest(request=invoice_payment_request, unit="sat")
     )


### PR DESCRIPTION
This pull request fixes the loading of b64 keysets in the Mint module and adds a new option to set b64 keysets as inactive in the WalletSettings module. The changes ensure backwards compatibility with old keysets and allow the wallet to only use new keyset versions.