### PR TITLE
Wallet: add CLI flag `--force-swap` flag and force swapping all inactive keysets

### DIFF
--- a/cashu/core/models.py
+++ b/cashu/core/models.py
@@ -222,19 +222,19 @@ class PostMeltRequest_deprecated(BaseModel):
 # ------- API: SPLIT -------
 
 
-class PostSplitRequest(BaseModel):
+class PostSwapRequest(BaseModel):
     inputs: List[Proof] = Field(..., max_items=settings.mint_max_request_length)
     outputs: List[BlindedMessage] = Field(
         ..., max_items=settings.mint_max_request_length
     )
 
 
-class PostSplitResponse(BaseModel):
+class PostSwapResponse(BaseModel):
     signatures: List[BlindedSignature]
 
 
 # deprecated since 0.13.0
-class PostSplitRequest_Deprecated(BaseModel):
+class PostSwapRequest_Deprecated(BaseModel):
     proofs: List[Proof] = Field(..., max_items=settings.mint_max_request_length)
     amount: Optional[int] = None
     outputs: List[BlindedMessage_Deprecated] = Field(
@@ -242,11 +242,11 @@ class PostSplitRequest_Deprecated(BaseModel):
     )
 
 
-class PostSplitResponse_Deprecated(BaseModel):
+class PostSwapResponse_Deprecated(BaseModel):
     promises: List[BlindedSignature] = []
 
 
-class PostSplitResponse_Very_Deprecated(BaseModel):
+class PostSwapResponse_Very_Deprecated(BaseModel):
     fst: List[BlindedSignature] = []
     snd: List[BlindedSignature] = []
     deprecated: str = "The amount field is deprecated since 0.13.0"

--- a/cashu/mint/router_deprecated.py
+++ b/cashu/mint/router_deprecated.py
@@ -22,9 +22,9 @@ from ..core.models import (
     PostMintResponse_deprecated,
     PostRestoreRequest_Deprecated,
     PostRestoreResponse,
-    PostSplitRequest_Deprecated,
-    PostSplitResponse_Deprecated,
-    PostSplitResponse_Very_Deprecated,
+    PostSwapRequest_Deprecated,
+    PostSwapResponse_Deprecated,
+    PostSwapResponse_Very_Deprecated,
 )
 from ..core.settings import settings
 from .limit import limiter
@@ -270,7 +270,7 @@ async def check_fees(
     name="Split",
     summary="Split proofs at a specified amount",
     # response_model=Union[
-    #     PostSplitResponse_Very_Deprecated, PostSplitResponse_Deprecated
+    #     PostSwapResponse_Very_Deprecated, PostSwapResponse_Deprecated
     # ],
     response_description=(
         "A list of blinded signatures that can be used to create proofs."
@@ -280,8 +280,8 @@ async def check_fees(
 @limiter.limit(f"{settings.mint_transaction_rate_limit_per_minute}/minute")
 async def split_deprecated(
     request: Request,
-    payload: PostSplitRequest_Deprecated,
-    # ) -> Union[PostSplitResponse_Very_Deprecated, PostSplitResponse_Deprecated]:
+    payload: PostSwapRequest_Deprecated,
+    # ) -> Union[PostSwapResponse_Very_Deprecated, PostSwapResponse_Deprecated]:
 ):
     """
     Requests a set of Proofs to be split into two a new set of BlindedSignatures.
@@ -297,7 +297,7 @@ async def split_deprecated(
         for o in payload.outputs
     ]
     # END BACKWARDS COMPATIBILITY < 0.14
-    promises = await ledger.split(proofs=payload.proofs, outputs=outputs)
+    promises = await ledger.swap(proofs=payload.proofs, outputs=outputs)
 
     if payload.amount:
         # BEGIN backwards compatibility < 0.13
@@ -319,10 +319,10 @@ async def split_deprecated(
             f" {sum([p.amount for p in frst_promises])} sat and send:"
             f" {len(scnd_promises)}: {sum([p.amount for p in scnd_promises])} sat"
         )
-        return PostSplitResponse_Very_Deprecated(fst=frst_promises, snd=scnd_promises)
+        return PostSwapResponse_Very_Deprecated(fst=frst_promises, snd=scnd_promises)
         # END backwards compatibility < 0.13
     else:
-        return PostSplitResponse_Deprecated(promises=promises)
+        return PostSwapResponse_Deprecated(promises=promises)
 
 
 @router_deprecated.post(

--- a/cashu/wallet/api/router.py
+++ b/cashu/wallet/api/router.py
@@ -194,7 +194,7 @@ async def swap(
     if outgoing_wallet.available_balance < total_amount:
         raise Exception("balance too low")
 
-    _, send_proofs = await outgoing_wallet.split_to_send(
+    _, send_proofs = await outgoing_wallet.swap_to_send(
         outgoing_wallet.proofs, total_amount, set_reserved=True
     )
     await outgoing_wallet.melt(

--- a/cashu/wallet/api/router.py
+++ b/cashu/wallet/api/router.py
@@ -433,7 +433,7 @@ async def restore(
     if to < 0:
         raise Exception("Counter must be positive")
     await wallet.load_mint()
-    await wallet.restore_promises_from_to(0, to)
+    await wallet.restore_promises_from_to(wallet.keyset_id, 0, to)
     await wallet.invalidate(wallet.proofs, check_spendable=True)
     return RestoreResponse(balance=wallet.available_balance)
 

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -548,6 +548,14 @@ async def balance(ctx: Context, verbose):
     help="Include fees for receiving token.",
     type=bool,
 )
+@click.option(
+    "--force-swap",
+    "-s",
+    default=False,
+    is_flag=True,
+    help="Force swap token.",
+    type=bool,
+)
 @click.pass_context
 @coro
 async def send_command(
@@ -562,6 +570,7 @@ async def send_command(
     yes: bool,
     offline: bool,
     include_fees: bool,
+    force_swap: bool,
 ):
     wallet: Wallet = ctx.obj["WALLET"]
     amount = int(amount * 100) if wallet.unit in [Unit.usd, Unit.eur] else int(amount)
@@ -575,6 +584,7 @@ async def send_command(
             include_dleq=dleq,
             include_fees=include_fees,
             memo=memo,
+            force_swap=force_swap,
         )
     else:
         await send_nostr(wallet, amount=amount, pubkey=nostr, verbose=verbose, yes=yes)

--- a/cashu/wallet/helpers.py
+++ b/cashu/wallet/helpers.py
@@ -116,6 +116,7 @@ async def send(
     include_dleq: bool = False,
     include_fees: bool = False,
     memo: Optional[str] = None,
+    force_swap: bool = False,
 ):
     """
     Prints token to send to stdout.
@@ -144,13 +145,12 @@ async def send(
     await wallet.load_proofs()
 
     await wallet.load_mint()
-    if secret_lock:
-        _, send_proofs = await wallet.split_to_send(
+    if secret_lock or force_swap:
+        _, send_proofs = await wallet.swap_to_send(
             wallet.proofs,
             amount,
             set_reserved=False,  # we set reserved later
             secret_lock=secret_lock,
-            include_fees=include_fees,
         )
     else:
         send_proofs, fees = await wallet.select_to_send(

--- a/cashu/wallet/lightning/lightning.py
+++ b/cashu/wallet/lightning/lightning.py
@@ -61,7 +61,7 @@ class LightningWallet(Wallet):
         if self.available_balance < total_amount:
             print("Error: Balance too low.")
             return PaymentResponse(ok=False)
-        _, send_proofs = await self.split_to_send(self.proofs, total_amount)
+        _, send_proofs = await self.swap_to_send(self.proofs, total_amount)
         try:
             resp = await self.melt(send_proofs, pr, quote.fee_reserve, quote.quote)
             if resp.change:

--- a/cashu/wallet/nostr.py
+++ b/cashu/wallet/nostr.py
@@ -62,7 +62,7 @@ async def send_nostr(
         pubkey = await nip5_to_pubkey(wallet, pubkey)
     await wallet.load_mint()
     await wallet.load_proofs()
-    _, send_proofs = await wallet.split_to_send(
+    _, send_proofs = await wallet.swap_to_send(
         wallet.proofs, amount, set_reserved=True, include_fees=False
     )
     token = await wallet.serialize_proofs(send_proofs, include_dleq=include_dleq)

--- a/cashu/wallet/proofs.py
+++ b/cashu/wallet/proofs.py
@@ -148,6 +148,7 @@ class WalletProofs(SupportsDb, SupportsKeysets):
         try:
             _ = [bytes.fromhex(p.id) for p in proofs]
         except ValueError:
+            logger.debug("Proof with base64 keyset, using legacy token serialization")
             legacy = True
 
         if legacy:

--- a/cashu/wallet/transactions.py
+++ b/cashu/wallet/transactions.py
@@ -36,44 +36,44 @@ class WalletTransactions(SupportsDb, SupportsKeysets):
     def get_fees_for_proofs_ppk(self, proofs: List[Proof]) -> int:
         return sum([self.keysets[p.id].input_fee_ppk for p in proofs])
 
-    # async def _select_proofs_to_send_legacy(
-    #     self, proofs: List[Proof], amount_to_send: int, tolerance: int = 0
-    # ) -> List[Proof]:
-    #     send_proofs: List[Proof] = []
-    #     NO_SELECTION: List[Proof] = []
+    async def _select_proofs_to_send_legacy(
+        self, proofs: List[Proof], amount_to_send: int, tolerance: int = 0
+    ) -> List[Proof]:
+        send_proofs: List[Proof] = []
+        NO_SELECTION: List[Proof] = []
 
-    #     logger.trace(f"proofs: {[p.amount for p in proofs]}")
-    #     # sort proofs by amount (descending)
-    #     sorted_proofs = sorted(proofs, key=lambda p: p.amount, reverse=True)
-    #     # only consider proofs smaller than the amount we want to send (+ tolerance) for coin selection
-    #     fee_for_single_proof = self.get_fees_for_proofs([sorted_proofs[0]])
-    #     sorted_proofs = [
-    #         p
-    #         for p in sorted_proofs
-    #         if p.amount <= amount_to_send + tolerance + fee_for_single_proof
-    #     ]
-    #     if not sorted_proofs:
-    #         logger.info(
-    #             f"no small-enough proofs to send. Have: {[p.amount for p in proofs]}"
-    #         )
-    #         return NO_SELECTION
+        logger.trace(f"proofs: {[p.amount for p in proofs]}")
+        # sort proofs by amount (descending)
+        sorted_proofs = sorted(proofs, key=lambda p: p.amount, reverse=True)
+        # only consider proofs smaller than the amount we want to send (+ tolerance) for coin selection
+        fee_for_single_proof = self.get_fees_for_proofs([sorted_proofs[0]])
+        sorted_proofs = [
+            p
+            for p in sorted_proofs
+            if p.amount <= amount_to_send + tolerance + fee_for_single_proof
+        ]
+        if not sorted_proofs:
+            logger.info(
+                f"no small-enough proofs to send. Have: {[p.amount for p in proofs]}"
+            )
+            return NO_SELECTION
 
-    #     target_amount = amount_to_send
+        target_amount = amount_to_send
 
-    #     # compose the target amount from the remaining_proofs
-    #     logger.debug(f"sorted_proofs: {[p.amount for p in sorted_proofs]}")
-    #     for p in sorted_proofs:
-    #         if sum_proofs(send_proofs) + p.amount <= target_amount + tolerance:
-    #             send_proofs.append(p)
-    #             target_amount = amount_to_send + self.get_fees_for_proofs(send_proofs)
+        # compose the target amount from the remaining_proofs
+        logger.debug(f"sorted_proofs: {[p.amount for p in sorted_proofs]}")
+        for p in sorted_proofs:
+            if sum_proofs(send_proofs) + p.amount <= target_amount + tolerance:
+                send_proofs.append(p)
+                target_amount = amount_to_send + self.get_fees_for_proofs(send_proofs)
 
-    #     if sum_proofs(send_proofs) < amount_to_send:
-    #         logger.info("could not select proofs to reach target amount (too little).")
-    #         return NO_SELECTION
+        if sum_proofs(send_proofs) < amount_to_send:
+            logger.info("could not select proofs to reach target amount (too little).")
+            return NO_SELECTION
 
-    #     fees = self.get_fees_for_proofs(send_proofs)
-    #     logger.debug(f"Selected sum of proofs: {sum_proofs(send_proofs)}, fees: {fees}")
-    #     return send_proofs
+        fees = self.get_fees_for_proofs(send_proofs)
+        logger.debug(f"Selected sum of proofs: {sum_proofs(send_proofs)}, fees: {fees}")
+        return send_proofs
 
     async def _select_proofs_to_send(
         self,
@@ -144,7 +144,7 @@ class WalletTransactions(SupportsDb, SupportsKeysets):
         )
         return selected_proofs
 
-    async def _select_proofs_to_split(
+    async def _select_proofs_to_swap(
         self, proofs: List[Proof], amount_to_send: int
     ) -> Tuple[List[Proof], int]:
         """
@@ -170,7 +170,7 @@ class WalletTransactions(SupportsDb, SupportsKeysets):
             Exception: If the balance is too low to send the amount
         """
         logger.debug(
-            f"_select_proofs_to_split - amounts we have: {amount_summary(proofs, self.unit)}"
+            f"_select_proofs_to_swap - amounts we have: {amount_summary(proofs, self.unit)}"
         )
         send_proofs: List[Proof] = []
 
@@ -198,7 +198,7 @@ class WalletTransactions(SupportsDb, SupportsKeysets):
             send_proofs.append(proof_to_add)
 
         logger.trace(
-            f"_select_proofs_to_split – selected proof amounts: {[p.amount for p in send_proofs]}"
+            f"_select_proofs_to_swap – selected proof amounts: {[p.amount for p in send_proofs]}"
         )
         fees = self.get_fees_for_proofs(send_proofs)
         return send_proofs, fees

--- a/cashu/wallet/v1_api.py
+++ b/cashu/wallet/v1_api.py
@@ -39,8 +39,8 @@ from ..core.models import (
     PostMintRequest,
     PostMintResponse,
     PostRestoreResponse,
-    PostSplitRequest,
-    PostSplitResponse,
+    PostSwapRequest,
+    PostSwapResponse,
 )
 from ..core.settings import settings
 from ..tor.tor import TorProxy
@@ -465,7 +465,7 @@ class LedgerAPI(LedgerAPIDeprecated, object):
     ) -> List[BlindedSignature]:
         """Consume proofs and create new promises based on amount split."""
         logger.debug("Calling split. POST /v1/swap")
-        split_payload = PostSplitRequest(inputs=proofs, outputs=outputs)
+        split_payload = PostSwapRequest(inputs=proofs, outputs=outputs)
 
         # construct payload
         def _splitrequest_include_fields(proofs: List[Proof]):
@@ -494,7 +494,7 @@ class LedgerAPI(LedgerAPIDeprecated, object):
         # END backwards compatibility < 0.15.0
         self.raise_on_error_request(resp)
         promises_dict = resp.json()
-        mint_response = PostSplitResponse.parse_obj(promises_dict)
+        mint_response = PostSwapResponse.parse_obj(promises_dict)
         promises = [BlindedSignature(**p.dict()) for p in mint_response.signatures]
 
         if len(promises) == 0:

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -1049,7 +1049,7 @@ class Wallet(
             if not offline:
                 logger.debug("Offline coin selection unsuccessful. Splitting proofs.")
                 # we set the proofs as reserved later
-                _, send_proofs = await self.split_to_send(
+                _, send_proofs = await self.swap_to_send(
                     proofs, amount, set_reserved=False
                 )
             else:
@@ -1061,7 +1061,7 @@ class Wallet(
             await self.set_reserved(send_proofs, reserved=True)
         return send_proofs, fees
 
-    async def split_to_send(
+    async def swap_to_send(
         self,
         proofs: List[Proof],
         amount: int,

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -1093,7 +1093,7 @@ class Wallet(
             raise Exception("balance too low.")
 
         # coin selection for swapping
-        # spendable_proofs, fees = await self._select_proofs_to_split(proofs, amount)
+        # spendable_proofs, fees = await self._select_proofs_to_swap(proofs, amount)
         swap_proofs = await self._select_proofs_to_send(
             proofs, amount, include_fees=True
         )

--- a/cashu/wallet/wallet_deprecated.py
+++ b/cashu/wallet/wallet_deprecated.py
@@ -31,8 +31,8 @@ from ..core.models import (
     PostMintRequest_deprecated,
     PostMintResponse_deprecated,
     PostRestoreResponse,
-    PostSplitRequest_Deprecated,
-    PostSplitResponse_Deprecated,
+    PostSwapRequest_Deprecated,
+    PostSwapResponse_Deprecated,
 )
 from ..core.settings import settings
 from ..tor.tor import TorProxy
@@ -348,7 +348,7 @@ class LedgerAPIDeprecated(SupportsHttpxClient, SupportsMintURL):
         """Consume proofs and create new promises based on amount split."""
         logger.warning("Using deprecated API call: Calling split. POST /split")
         outputs_deprecated = [BlindedMessage_Deprecated(**o.dict()) for o in outputs]
-        split_payload = PostSplitRequest_Deprecated(
+        split_payload = PostSwapRequest_Deprecated(
             proofs=proofs, outputs=outputs_deprecated
         )
 
@@ -373,7 +373,7 @@ class LedgerAPIDeprecated(SupportsHttpxClient, SupportsMintURL):
         )
         self.raise_on_error(resp)
         promises_dict = resp.json()
-        mint_response = PostSplitResponse_Deprecated.parse_obj(promises_dict)
+        mint_response = PostSwapResponse_Deprecated.parse_obj(promises_dict)
         promises = [BlindedSignature(**p.dict()) for p in mint_response.promises]
 
         if len(promises) == 0:

--- a/tests/test_mint_api.py
+++ b/tests/test_mint_api.py
@@ -422,7 +422,7 @@ async def test_melt_external(ledger: Ledger, wallet: Wallet):
     assert quote.amount == 62
     assert quote.fee_reserve == 2
 
-    keep, send = await wallet.split_to_send(wallet.proofs, 64)
+    keep, send = await wallet.swap_to_send(wallet.proofs, 64)
     inputs_payload = [p.to_dict() for p in send]
 
     # outputs for change

--- a/tests/test_mint_fees.py
+++ b/tests/test_mint_fees.py
@@ -123,7 +123,7 @@ async def test_split_with_fees(wallet1: Wallet, ledger: Ledger):
     assert fees == 1
     outputs = await wallet1.construct_outputs(amount_split(9))
 
-    promises = await ledger.split(proofs=send_proofs, outputs=outputs)
+    promises = await ledger.swap(proofs=send_proofs, outputs=outputs)
     assert len(promises) == len(outputs)
     assert [p.amount for p in promises] == [p.amount for p in outputs]
 
@@ -141,7 +141,7 @@ async def test_split_with_high_fees(wallet1: Wallet, ledger: Ledger):
     assert fees == 3
     outputs = await wallet1.construct_outputs(amount_split(7))
 
-    promises = await ledger.split(proofs=send_proofs, outputs=outputs)
+    promises = await ledger.swap(proofs=send_proofs, outputs=outputs)
     assert len(promises) == len(outputs)
     assert [p.amount for p in promises] == [p.amount for p in outputs]
 
@@ -161,7 +161,7 @@ async def test_split_not_enough_fees(wallet1: Wallet, ledger: Ledger):
     outputs = await wallet1.construct_outputs(amount_split(10))
 
     await assert_err(
-        ledger.split(proofs=send_proofs, outputs=outputs), "are not balanced"
+        ledger.swap(proofs=send_proofs, outputs=outputs), "are not balanced"
     )
 
 

--- a/tests/test_mint_init.py
+++ b/tests/test_mint_init.py
@@ -252,7 +252,7 @@ async def test_startup_regtest_pending_quote_pending(wallet: Wallet, ledger: Led
     # wallet pays the invoice
     quote = await wallet.melt_quote(invoice_payment_request)
     total_amount = quote.amount + quote.fee_reserve
-    _, send_proofs = await wallet.split_to_send(wallet.proofs, total_amount)
+    _, send_proofs = await wallet.swap_to_send(wallet.proofs, total_amount)
     asyncio.create_task(
         wallet.melt(
             proofs=send_proofs,
@@ -297,7 +297,7 @@ async def test_startup_regtest_pending_quote_success(wallet: Wallet, ledger: Led
     # wallet pays the invoice
     quote = await wallet.melt_quote(invoice_payment_request)
     total_amount = quote.amount + quote.fee_reserve
-    _, send_proofs = await wallet.split_to_send(wallet.proofs, total_amount)
+    _, send_proofs = await wallet.swap_to_send(wallet.proofs, total_amount)
     asyncio.create_task(
         wallet.melt(
             proofs=send_proofs,
@@ -347,7 +347,7 @@ async def test_startup_regtest_pending_quote_failure(wallet: Wallet, ledger: Led
     # wallet pays the invoice
     quote = await wallet.melt_quote(invoice_payment_request)
     total_amount = quote.amount + quote.fee_reserve
-    _, send_proofs = await wallet.split_to_send(wallet.proofs, total_amount)
+    _, send_proofs = await wallet.swap_to_send(wallet.proofs, total_amount)
     asyncio.create_task(
         wallet.melt(
             proofs=send_proofs,

--- a/tests/test_mint_operations.py
+++ b/tests/test_mint_operations.py
@@ -175,7 +175,7 @@ async def test_split(wallet1: Wallet, ledger: Ledger):
         [p.amount for p in send_proofs], secrets, rs
     )
 
-    promises = await ledger.split(proofs=send_proofs, outputs=outputs)
+    promises = await ledger.swap(proofs=send_proofs, outputs=outputs)
     assert len(promises) == len(outputs)
     assert [p.amount for p in promises] == [p.amount for p in outputs]
 
@@ -187,7 +187,7 @@ async def test_split_with_no_outputs(wallet1: Wallet, ledger: Ledger):
     await wallet1.mint(64, id=invoice.id)
     _, send_proofs = await wallet1.swap_to_send(wallet1.proofs, 10, set_reserved=False)
     await assert_err(
-        ledger.split(proofs=send_proofs, outputs=[]),
+        ledger.swap(proofs=send_proofs, outputs=[]),
         "no outputs provided",
     )
 
@@ -213,7 +213,7 @@ async def test_split_with_input_less_than_outputs(wallet1: Wallet, ledger: Ledge
     )
 
     await assert_err(
-        ledger.split(proofs=send_proofs, outputs=outputs),
+        ledger.swap(proofs=send_proofs, outputs=outputs),
         "are not balanced",
     )
 
@@ -237,7 +237,7 @@ async def test_split_with_input_more_than_outputs(wallet1: Wallet, ledger: Ledge
     outputs, rs = wallet1._construct_outputs(output_amounts, secrets, rs)
 
     await assert_err(
-        ledger.split(proofs=inputs, outputs=outputs),
+        ledger.swap(proofs=inputs, outputs=outputs),
         "are not balanced",
     )
 
@@ -262,11 +262,11 @@ async def test_split_twice_with_same_outputs(wallet1: Wallet, ledger: Ledger):
     )
     outputs, rs = wallet1._construct_outputs(output_amounts, secrets, rs)
 
-    await ledger.split(proofs=inputs1, outputs=outputs)
+    await ledger.swap(proofs=inputs1, outputs=outputs)
 
     # try to spend other proofs with the same outputs again
     await assert_err(
-        ledger.split(proofs=inputs2, outputs=outputs),
+        ledger.swap(proofs=inputs2, outputs=outputs),
         "outputs have already been signed before.",
     )
 
@@ -277,7 +277,7 @@ async def test_split_twice_with_same_outputs(wallet1: Wallet, ledger: Ledger):
     )
     outputs, rs = wallet1._construct_outputs(output_amounts, secrets, rs)
 
-    await ledger.split(proofs=inputs2, outputs=outputs)
+    await ledger.swap(proofs=inputs2, outputs=outputs)
 
 
 @pytest.mark.asyncio

--- a/tests/test_mint_regtest.py
+++ b/tests/test_mint_regtest.py
@@ -43,7 +43,7 @@ async def test_regtest_pending_quote(wallet: Wallet, ledger: Ledger):
     # wallet pays the invoice
     quote = await wallet.melt_quote(invoice_payment_request)
     total_amount = quote.amount + quote.fee_reserve
-    _, send_proofs = await wallet.split_to_send(wallet.proofs, total_amount)
+    _, send_proofs = await wallet.swap_to_send(wallet.proofs, total_amount)
     asyncio.create_task(ledger.melt(proofs=send_proofs, quote=quote.quote))
     # asyncio.create_task(
     #     wallet.melt(

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -241,14 +241,14 @@ async def test_split(wallet1: Wallet):
 
 
 @pytest.mark.asyncio
-async def test_split_to_send(wallet1: Wallet):
+async def test_swap_to_send(wallet1: Wallet):
     invoice = await wallet1.request_mint(64)
     await pay_if_regtest(invoice.bolt11)
     await wallet1.mint(64, id=invoice.id)
     assert wallet1.balance == 64
 
     # this will select 32 sats and them (nothing to keep)
-    keep_proofs, send_proofs = await wallet1.split_to_send(
+    keep_proofs, send_proofs = await wallet1.swap_to_send(
         wallet1.proofs, 32, set_reserved=True
     )
     assert_amt(send_proofs, 32)
@@ -307,7 +307,7 @@ async def test_melt(wallet1: Wallet):
         assert total_amount == 64
         assert quote.fee_reserve == 0
 
-    _, send_proofs = await wallet1.split_to_send(wallet1.proofs, total_amount)
+    _, send_proofs = await wallet1.swap_to_send(wallet1.proofs, total_amount)
 
     melt_response = await wallet1.melt(
         proofs=send_proofs,
@@ -343,12 +343,12 @@ async def test_melt(wallet1: Wallet):
 
 
 @pytest.mark.asyncio
-async def test_split_to_send_more_than_balance(wallet1: Wallet):
+async def test_swap_to_send_more_than_balance(wallet1: Wallet):
     invoice = await wallet1.request_mint(64)
     await pay_if_regtest(invoice.bolt11)
     await wallet1.mint(64, id=invoice.id)
     await assert_err(
-        wallet1.split_to_send(wallet1.proofs, 128, set_reserved=True),
+        wallet1.swap_to_send(wallet1.proofs, 128, set_reserved=True),
         "balance too low.",
     )
     assert wallet1.balance == 64
@@ -405,7 +405,7 @@ async def test_send_and_redeem(wallet1: Wallet, wallet2: Wallet):
     invoice = await wallet1.request_mint(64)
     await pay_if_regtest(invoice.bolt11)
     await wallet1.mint(64, id=invoice.id)
-    _, spendable_proofs = await wallet1.split_to_send(
+    _, spendable_proofs = await wallet1.swap_to_send(
         wallet1.proofs, 32, set_reserved=True
     )
     await wallet2.redeem(spendable_proofs)

--- a/tests/test_wallet_htlc.py
+++ b/tests/test_wallet_htlc.py
@@ -74,7 +74,7 @@ async def test_htlc_split(wallet1: Wallet, wallet2: Wallet):
     preimage = "00000000000000000000000000000000"
     preimage_hash = hashlib.sha256(bytes.fromhex(preimage)).hexdigest()
     secret = await wallet1.create_htlc_lock(preimage=preimage)
-    _, send_proofs = await wallet1.split_to_send(wallet1.proofs, 8, secret_lock=secret)
+    _, send_proofs = await wallet1.swap_to_send(wallet1.proofs, 8, secret_lock=secret)
     for p in send_proofs:
         assert HTLCSecret.deserialize(p.secret).data == preimage_hash
 
@@ -87,7 +87,7 @@ async def test_htlc_redeem_with_preimage(wallet1: Wallet, wallet2: Wallet):
     preimage = "00000000000000000000000000000000"
     # preimage_hash = hashlib.sha256(bytes.fromhex(preimage)).hexdigest()
     secret = await wallet1.create_htlc_lock(preimage=preimage)
-    _, send_proofs = await wallet1.split_to_send(wallet1.proofs, 8, secret_lock=secret)
+    _, send_proofs = await wallet1.swap_to_send(wallet1.proofs, 8, secret_lock=secret)
     for p in send_proofs:
         p.witness = HTLCWitness(preimage=preimage).json()
     await wallet2.redeem(send_proofs)
@@ -103,7 +103,7 @@ async def test_htlc_redeem_with_wrong_preimage(wallet1: Wallet, wallet2: Wallet)
     secret = await wallet1.create_htlc_lock(
         preimage=preimage[:-5] + "11111"
     )  # wrong preimage
-    _, send_proofs = await wallet1.split_to_send(wallet1.proofs, 8, secret_lock=secret)
+    _, send_proofs = await wallet1.swap_to_send(wallet1.proofs, 8, secret_lock=secret)
     for p in send_proofs:
         p.witness = HTLCWitness(preimage=preimage).json()
     await assert_err(
@@ -122,7 +122,7 @@ async def test_htlc_redeem_with_no_signature(wallet1: Wallet, wallet2: Wallet):
     secret = await wallet1.create_htlc_lock(
         preimage=preimage, hashlock_pubkey=pubkey_wallet1
     )
-    _, send_proofs = await wallet1.split_to_send(wallet1.proofs, 8, secret_lock=secret)
+    _, send_proofs = await wallet1.swap_to_send(wallet1.proofs, 8, secret_lock=secret)
     for p in send_proofs:
         p.witness = HTLCWitness(preimage=preimage).json()
     await assert_err(
@@ -142,7 +142,7 @@ async def test_htlc_redeem_with_wrong_signature(wallet1: Wallet, wallet2: Wallet
     secret = await wallet1.create_htlc_lock(
         preimage=preimage, hashlock_pubkey=pubkey_wallet1
     )
-    _, send_proofs = await wallet1.split_to_send(wallet1.proofs, 8, secret_lock=secret)
+    _, send_proofs = await wallet1.swap_to_send(wallet1.proofs, 8, secret_lock=secret)
     signatures = await wallet1.sign_p2pk_proofs(send_proofs)
     for p, s in zip(send_proofs, signatures):
         p.witness = HTLCWitness(
@@ -166,7 +166,7 @@ async def test_htlc_redeem_with_correct_signature(wallet1: Wallet, wallet2: Wall
     secret = await wallet1.create_htlc_lock(
         preimage=preimage, hashlock_pubkey=pubkey_wallet1
     )
-    _, send_proofs = await wallet1.split_to_send(wallet1.proofs, 8, secret_lock=secret)
+    _, send_proofs = await wallet1.swap_to_send(wallet1.proofs, 8, secret_lock=secret)
 
     signatures = await wallet1.sign_p2pk_proofs(send_proofs)
     for p, s in zip(send_proofs, signatures):
@@ -192,7 +192,7 @@ async def test_htlc_redeem_hashlock_wrong_signature_timelock_correct_signature(
         locktime_seconds=2,
         locktime_pubkey=pubkey_wallet1,
     )
-    _, send_proofs = await wallet1.split_to_send(wallet1.proofs, 8, secret_lock=secret)
+    _, send_proofs = await wallet1.swap_to_send(wallet1.proofs, 8, secret_lock=secret)
 
     signatures = await wallet1.sign_p2pk_proofs(send_proofs)
     for p, s in zip(send_proofs, signatures):
@@ -226,7 +226,7 @@ async def test_htlc_redeem_hashlock_wrong_signature_timelock_wrong_signature(
         locktime_seconds=2,
         locktime_pubkey=pubkey_wallet1,
     )
-    _, send_proofs = await wallet1.split_to_send(wallet1.proofs, 8, secret_lock=secret)
+    _, send_proofs = await wallet1.swap_to_send(wallet1.proofs, 8, secret_lock=secret)
 
     signatures = await wallet1.sign_p2pk_proofs(send_proofs)
     for p, s in zip(send_proofs, signatures):

--- a/tests/test_wallet_p2pk.py
+++ b/tests/test_wallet_p2pk.py
@@ -74,7 +74,7 @@ async def test_p2pk(wallet1: Wallet, wallet2: Wallet):
     pubkey_wallet2 = await wallet2.create_p2pk_pubkey()
     # p2pk test
     secret_lock = await wallet1.create_p2pk_lock(pubkey_wallet2)  # sender side
-    _, send_proofs = await wallet1.split_to_send(
+    _, send_proofs = await wallet1.swap_to_send(
         wallet1.proofs, 8, secret_lock=secret_lock
     )
     await wallet2.redeem(send_proofs)
@@ -100,7 +100,7 @@ async def test_p2pk_sig_all(wallet1: Wallet, wallet2: Wallet):
     secret_lock = await wallet1.create_p2pk_lock(
         pubkey_wallet2, sig_all=True
     )  # sender side
-    _, send_proofs = await wallet1.split_to_send(
+    _, send_proofs = await wallet1.swap_to_send(
         wallet1.proofs, 8, secret_lock=secret_lock
     )
     await wallet2.redeem(send_proofs)
@@ -114,7 +114,7 @@ async def test_p2pk_receive_with_wrong_private_key(wallet1: Wallet, wallet2: Wal
     pubkey_wallet2 = await wallet2.create_p2pk_pubkey()  # receiver side
     # sender side
     secret_lock = await wallet1.create_p2pk_lock(pubkey_wallet2)  # sender side
-    _, send_proofs = await wallet1.split_to_send(
+    _, send_proofs = await wallet1.swap_to_send(
         wallet1.proofs, 8, secret_lock=secret_lock
     )
     # receiver side: wrong private key
@@ -137,7 +137,7 @@ async def test_p2pk_short_locktime_receive_with_wrong_private_key(
     secret_lock = await wallet1.create_p2pk_lock(
         pubkey_wallet2, locktime_seconds=2
     )  # sender side
-    _, send_proofs = await wallet1.split_to_send(
+    _, send_proofs = await wallet1.swap_to_send(
         wallet1.proofs, 8, secret_lock=secret_lock
     )
     # receiver side: wrong private key
@@ -167,7 +167,7 @@ async def test_p2pk_locktime_with_refund_pubkey(wallet1: Wallet, wallet2: Wallet
         locktime_seconds=2,  # locktime
         tags=Tags([["refund", pubkey_wallet2]]),  # refund pubkey
     )  # sender side
-    _, send_proofs = await wallet1.split_to_send(
+    _, send_proofs = await wallet1.swap_to_send(
         wallet1.proofs, 8, secret_lock=secret_lock
     )
     send_proofs_copy = copy.deepcopy(send_proofs)
@@ -198,7 +198,7 @@ async def test_p2pk_locktime_with_wrong_refund_pubkey(wallet1: Wallet, wallet2: 
         locktime_seconds=2,  # locktime
         tags=Tags([["refund", garbage_pubkey_2.serialize().hex()]]),  # refund pubkey
     )  # sender side
-    _, send_proofs = await wallet1.split_to_send(
+    _, send_proofs = await wallet1.swap_to_send(
         wallet1.proofs, 8, secret_lock=secret_lock
     )
     send_proofs_copy = copy.deepcopy(send_proofs)
@@ -235,7 +235,7 @@ async def test_p2pk_locktime_with_second_refund_pubkey(
             [["refund", pubkey_wallet2, pubkey_wallet1]]
         ),  # multiple refund pubkeys
     )  # sender side
-    _, send_proofs = await wallet1.split_to_send(
+    _, send_proofs = await wallet1.swap_to_send(
         wallet1.proofs, 8, secret_lock=secret_lock
     )
     send_proofs_copy = copy.deepcopy(send_proofs)
@@ -263,7 +263,7 @@ async def test_p2pk_multisig_2_of_2(wallet1: Wallet, wallet2: Wallet):
         pubkey_wallet2, tags=Tags([["pubkeys", pubkey_wallet1]]), n_sigs=2
     )
 
-    _, send_proofs = await wallet1.split_to_send(
+    _, send_proofs = await wallet1.swap_to_send(
         wallet1.proofs, 8, secret_lock=secret_lock
     )
     # add signatures of wallet1
@@ -285,7 +285,7 @@ async def test_p2pk_multisig_duplicate_signature(wallet1: Wallet, wallet2: Walle
         pubkey_wallet2, tags=Tags([["pubkeys", pubkey_wallet1]]), n_sigs=2
     )
 
-    _, send_proofs = await wallet1.split_to_send(
+    _, send_proofs = await wallet1.swap_to_send(
         wallet1.proofs, 8, secret_lock=secret_lock
     )
     # add signatures of wallet2 – this is a duplicate signature
@@ -308,7 +308,7 @@ async def test_p2pk_multisig_quorum_not_met_1_of_2(wallet1: Wallet, wallet2: Wal
     secret_lock = await wallet1.create_p2pk_lock(
         pubkey_wallet2, tags=Tags([["pubkeys", pubkey_wallet1]]), n_sigs=2
     )
-    _, send_proofs = await wallet1.split_to_send(
+    _, send_proofs = await wallet1.swap_to_send(
         wallet1.proofs, 8, secret_lock=secret_lock
     )
     await assert_err(
@@ -330,7 +330,7 @@ async def test_p2pk_multisig_quorum_not_met_2_of_3(wallet1: Wallet, wallet2: Wal
         pubkey_wallet2, tags=Tags([["pubkeys", pubkey_wallet1]]), n_sigs=3
     )
 
-    _, send_proofs = await wallet1.split_to_send(
+    _, send_proofs = await wallet1.swap_to_send(
         wallet1.proofs, 8, secret_lock=secret_lock
     )
     # add signatures of wallet1
@@ -352,7 +352,7 @@ async def test_p2pk_multisig_with_duplicate_publickey(wallet1: Wallet, wallet2: 
     secret_lock = await wallet1.create_p2pk_lock(
         pubkey_wallet2, tags=Tags([["pubkeys", pubkey_wallet2]]), n_sigs=2
     )
-    _, send_proofs = await wallet1.split_to_send(
+    _, send_proofs = await wallet1.swap_to_send(
         wallet1.proofs, 8, secret_lock=secret_lock
     )
     await assert_err(wallet2.redeem(send_proofs), "Mint Error: pubkeys must be unique.")
@@ -377,7 +377,7 @@ async def test_p2pk_multisig_with_wrong_first_private_key(
     secret_lock = await wallet1.create_p2pk_lock(
         pubkey_wallet2, tags=Tags([["pubkeys", wrong_public_key_hex]]), n_sigs=2
     )
-    _, send_proofs = await wallet1.split_to_send(
+    _, send_proofs = await wallet1.swap_to_send(
         wallet1.proofs, 8, secret_lock=secret_lock
     )
     # add signatures of wallet1

--- a/tests/test_wallet_regtest.py
+++ b/tests/test_wallet_regtest.py
@@ -45,7 +45,7 @@ async def test_regtest_pending_quote(wallet: Wallet, ledger: Ledger):
     # wallet pays the invoice
     quote = await wallet.melt_quote(invoice_payment_request)
     total_amount = quote.amount + quote.fee_reserve
-    _, send_proofs = await wallet.split_to_send(wallet.proofs, total_amount)
+    _, send_proofs = await wallet.swap_to_send(wallet.proofs, total_amount)
     asyncio.create_task(
         wallet.melt(
             proofs=send_proofs,
@@ -85,7 +85,7 @@ async def test_regtest_failed_quote(wallet: Wallet, ledger: Ledger):
     # wallet pays the invoice
     quote = await wallet.melt_quote(invoice_payment_request)
     total_amount = quote.amount + quote.fee_reserve
-    _, send_proofs = await wallet.split_to_send(wallet.proofs, total_amount)
+    _, send_proofs = await wallet.swap_to_send(wallet.proofs, total_amount)
     asyncio.create_task(
         wallet.melt(
             proofs=send_proofs,

--- a/tests/test_wallet_restore.py
+++ b/tests/test_wallet_restore.py
@@ -185,7 +185,7 @@ async def test_restore_wallet_with_invalid_mnemonic(wallet3: Wallet):
 
 
 @pytest.mark.asyncio
-async def test_restore_wallet_after_split_to_send(wallet3: Wallet):
+async def test_restore_wallet_after_swap_to_send(wallet3: Wallet):
     await wallet3._init_private_key(
         "half depart obvious quality work element tank gorilla view sugar picture"
         " humble"
@@ -197,7 +197,7 @@ async def test_restore_wallet_after_split_to_send(wallet3: Wallet):
     await wallet3.mint(64, id=invoice.id)
     assert wallet3.balance == 64
 
-    _, spendable_proofs = await wallet3.split_to_send(
+    _, spendable_proofs = await wallet3.swap_to_send(
         wallet3.proofs, 32, set_reserved=True
     )  # type: ignore
 
@@ -222,7 +222,7 @@ async def test_restore_wallet_after_send_and_receive(wallet3: Wallet, wallet2: W
     await wallet3.mint(64, id=invoice.id)
     assert wallet3.balance == 64
 
-    _, spendable_proofs = await wallet3.split_to_send(
+    _, spendable_proofs = await wallet3.swap_to_send(
         wallet3.proofs, 32, set_reserved=True
     )  # type: ignore
 
@@ -265,7 +265,7 @@ async def test_restore_wallet_after_send_and_self_receive(wallet3: Wallet):
     await wallet3.mint(64, id=invoice.id)
     assert wallet3.balance == 64
 
-    _, spendable_proofs = await wallet3.split_to_send(
+    _, spendable_proofs = await wallet3.swap_to_send(
         wallet3.proofs, 32, set_reserved=True
     )  # type: ignore
 
@@ -295,7 +295,7 @@ async def test_restore_wallet_after_send_twice(
     box.add(wallet3.proofs)
     assert wallet3.balance == 2
 
-    keep_proofs, spendable_proofs = await wallet3.split_to_send(
+    keep_proofs, spendable_proofs = await wallet3.swap_to_send(
         wallet3.proofs, 1, set_reserved=True
     )  # type: ignore
     box.add(wallet3.proofs)
@@ -317,7 +317,7 @@ async def test_restore_wallet_after_send_twice(
 
     # again
 
-    _, spendable_proofs = await wallet3.split_to_send(
+    _, spendable_proofs = await wallet3.swap_to_send(
         wallet3.proofs, 1, set_reserved=True
     )  # type: ignore
     box.add(wallet3.proofs)
@@ -354,7 +354,7 @@ async def test_restore_wallet_after_send_and_self_receive_nonquadratic_value(
     box.add(wallet3.proofs)
     assert wallet3.balance == 64
 
-    keep_proofs, spendable_proofs = await wallet3.split_to_send(
+    keep_proofs, spendable_proofs = await wallet3.swap_to_send(
         wallet3.proofs, 10, set_reserved=True
     )  # type: ignore
     box.add(wallet3.proofs)
@@ -376,7 +376,7 @@ async def test_restore_wallet_after_send_and_self_receive_nonquadratic_value(
 
     # again
 
-    _, spendable_proofs = await wallet3.split_to_send(
+    _, spendable_proofs = await wallet3.swap_to_send(
         wallet3.proofs, 12, set_reserved=True
     )  # type: ignore
 

--- a/tests/test_wallet_restore.py
+++ b/tests/test_wallet_restore.py
@@ -164,7 +164,7 @@ async def test_restore_wallet_after_mint(wallet3: Wallet):
     await wallet3.load_proofs()
     wallet3.proofs = []
     assert wallet3.balance == 0
-    await wallet3.restore_promises_from_to(0, 20)
+    await wallet3.restore_promises_from_to(wallet3.keyset_id, 0, 20)
     assert wallet3.balance == 64
 
     # expect that DLEQ proofs are restored
@@ -205,7 +205,7 @@ async def test_restore_wallet_after_swap_to_send(wallet3: Wallet):
     await wallet3.load_proofs()
     wallet3.proofs = []
     assert wallet3.balance == 0
-    await wallet3.restore_promises_from_to(0, 100)
+    await wallet3.restore_promises_from_to(wallet3.keyset_id, 0, 100)
     assert wallet3.balance == 96
     await wallet3.invalidate(wallet3.proofs, check_spendable=True)
     assert wallet3.balance == 64
@@ -232,7 +232,7 @@ async def test_restore_wallet_after_send_and_receive(wallet3: Wallet, wallet2: W
     await wallet3.load_proofs(reload=True)
     assert wallet3.proofs == []
     assert wallet3.balance == 0
-    await wallet3.restore_promises_from_to(0, 100)
+    await wallet3.restore_promises_from_to(wallet3.keyset_id, 0, 100)
     assert wallet3.balance == 96
     await wallet3.invalidate(wallet3.proofs, check_spendable=True)
     assert wallet3.balance == 32
@@ -275,7 +275,7 @@ async def test_restore_wallet_after_send_and_self_receive(wallet3: Wallet):
     await wallet3.load_proofs(reload=True)
     assert wallet3.proofs == []
     assert wallet3.balance == 0
-    await wallet3.restore_promises_from_to(0, 100)
+    await wallet3.restore_promises_from_to(wallet3.keyset_id, 0, 100)
     assert wallet3.balance == 128
     await wallet3.invalidate(wallet3.proofs, check_spendable=True)
     assert wallet3.balance == 64
@@ -309,7 +309,7 @@ async def test_restore_wallet_after_send_twice(
     await wallet3.load_proofs(reload=True)
     assert wallet3.proofs == []
     assert wallet3.balance == 0
-    await wallet3.restore_promises_from_to(0, 10)
+    await wallet3.restore_promises_from_to(wallet3.keyset_id, 0, 10)
     box.add(wallet3.proofs)
     assert wallet3.balance == 4
     await wallet3.invalidate(wallet3.proofs, check_spendable=True)
@@ -331,7 +331,7 @@ async def test_restore_wallet_after_send_twice(
     await wallet3.load_proofs(reload=True)
     assert wallet3.proofs == []
     assert wallet3.balance == 0
-    await wallet3.restore_promises_from_to(0, 15)
+    await wallet3.restore_promises_from_to(wallet3.keyset_id, 0, 15)
     box.add(wallet3.proofs)
     assert wallet3.balance == 6
     await wallet3.invalidate(wallet3.proofs, check_spendable=True)
@@ -368,7 +368,7 @@ async def test_restore_wallet_after_send_and_self_receive_nonquadratic_value(
     await wallet3.load_proofs(reload=True)
     assert wallet3.proofs == []
     assert wallet3.balance == 0
-    await wallet3.restore_promises_from_to(0, 20)
+    await wallet3.restore_promises_from_to(wallet3.keyset_id, 0, 20)
     box.add(wallet3.proofs)
     assert wallet3.balance == 84
     await wallet3.invalidate(wallet3.proofs, check_spendable=True)
@@ -388,7 +388,7 @@ async def test_restore_wallet_after_send_and_self_receive_nonquadratic_value(
     await wallet3.load_proofs(reload=True)
     assert wallet3.proofs == []
     assert wallet3.balance == 0
-    await wallet3.restore_promises_from_to(0, 50)
+    await wallet3.restore_promises_from_to(wallet3.keyset_id, 0, 50)
     assert wallet3.balance == 108
     await wallet3.invalidate(wallet3.proofs, check_spendable=True)
     assert wallet3.balance == 64

--- a/tests/test_wallet_subscription.py
+++ b/tests/test_wallet_subscription.py
@@ -86,7 +86,7 @@ async def test_wallet_subscription_swap(wallet: Wallet):
         wallet.proofs, callback=callback
     )
 
-    _ = await wallet.split_to_send(wallet.proofs, 64)
+    _ = await wallet.swap_to_send(wallet.proofs, 64)
 
     wait = 1
     await asyncio.sleep(wait)


### PR DESCRIPTION
- Rename `split_to_send` to `swap_to_send` 
- Add new `--force-swap` flag to `cashu send` command
- `_select_proofs_to_swap` coin selection now spends *all* proofs form inactive keysets first