### PR TITLE
Wallet: default to `SIG_INPUTS` in P2PK lock

### DIFF
--- a/cashu/wallet/helpers.py
+++ b/cashu/wallet/helpers.py
@@ -137,7 +137,7 @@ async def send(
             secret_lock = await wallet.create_p2pk_lock(
                 lock.split(":")[1],
                 locktime_seconds=settings.locktime_delta_seconds,
-                sig_all=True,
+                sig_all=False,
                 n_sigs=1,
             )
             logger.debug(f"Secret lock: {secret_lock}")


### PR DESCRIPTION
let me know if you disagree but changed cli wallet to by default generate P2PK locks with sigflag `SIG_INPUTS` instead of `SIG_ALL`