### PR TITLE
Fix parsing of old format contact field in wallet

### DIFF
--- a/cashu/core/models.py
+++ b/cashu/core/models.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, root_validator
 
 from .base import (
     BlindedMessage,
@@ -42,6 +42,21 @@ class GetInfoResponse(BaseModel):
 
     def supports(self, nut: int) -> Optional[bool]:
         return nut in self.nuts if self.nuts else None
+
+    # BEGIN DEPRECATED: NUT-06 contact field change
+    # NUT-06 PR: https://github.com/cashubtc/nuts/pull/117
+    @root_validator(pre=True)
+    def preprocess_deprecated_contact_field(cls, values):
+        if "contact" in values and values["contact"]:
+            if isinstance(values["contact"][0], list):
+                print("IS LOST")
+                values["contact"] = [
+                    MintInfoContact(method=method, info=info)
+                    for method, info in values["contact"]
+                ]
+        return values
+
+    # END DEPRECATED: NUT-06 contact field change
 
 
 class Nut15MppSupport(BaseModel):

--- a/cashu/core/models.py
+++ b/cashu/core/models.py
@@ -49,10 +49,10 @@ class GetInfoResponse(BaseModel):
     def preprocess_deprecated_contact_field(cls, values):
         if "contact" in values and values["contact"]:
             if isinstance(values["contact"][0], list):
-                print("IS LOST")
                 values["contact"] = [
                     MintInfoContact(method=method, info=info)
                     for method, info in values["contact"]
+                    if method and info
                 ]
         return values
 

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -142,7 +142,7 @@ class MintInformation(CashuSettings):
     mint_info_name: str = Field(default="Cashu mint")
     mint_info_description: str = Field(default=None)
     mint_info_description_long: str = Field(default=None)
-    mint_info_contact: List[List[str]] = Field(default=[["", ""]])
+    mint_info_contact: List[List[str]] = Field(default=[])
     mint_info_motd: str = Field(default=None)
 
 

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -43,7 +43,9 @@ async def info() -> GetInfoResponse:
     logger.trace("> GET /v1/info")
     mint_features = ledger.mint_features()
     contact_info = [
-        MintInfoContact(method=m, info=i) for m, i in settings.mint_info_contact
+        MintInfoContact(method=m, info=i)
+        for m, i in settings.mint_info_contact
+        if m and i
     ]
     return GetInfoResponse(
         name=settings.mint_info_name,


### PR DESCRIPTION
This pull request fixes an issue where the contact field in the wallet was not being parsed correctly if it was in the old format. The issue was identified in commit "wallet parse contact field if its old format". The problem has been resolved by adding a root validator to preprocess the deprecated contact field and convert it to the new format. This ensures that the contact field is parsed correctly in all cases.