### PR TITLE
wait for uvicorn server to bind before running tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,7 +146,7 @@ def mint():
         try:
             httpx.get(settings.mint_url)
             break
-        except Exception:
+        except httpx.ConnectError:
             tries += 1
             time.sleep(0.1)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,6 +145,7 @@ def mint():
     while tries < 100:
         try:
             httpx.get(settings.mint_url)
+            break
         except Exception:
             tries += 1
             time.sleep(0.1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,6 @@ settings.log_level = "TRACE"
 settings.cashu_dir = "./test_data/"
 settings.mint_host = "localhost"
 settings.mint_port = SERVER_PORT
-settings.mint_host = "0.0.0.0"
 settings.mint_listen_port = SERVER_PORT
 settings.mint_url = SERVER_ENDPOINT
 settings.tor = False
@@ -139,6 +138,16 @@ def mint():
 
     server = UvicornServer(config=config)
     server.start()
-    time.sleep(1)
+
+    # Wait until the server has bound to the localhost socket. Max out after 10s.
+    tries = 0
+    while tries < 100:
+        try:
+            httpx.get(settings.mint_url)
+        except:
+            tries += 1
+            time.sleep(0.1)
+
+
     yield server
     server.stop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import shutil
 import time
 from pathlib import Path
 
+import httpx
 import pytest
 import pytest_asyncio
 import uvicorn
@@ -144,10 +145,9 @@ def mint():
     while tries < 100:
         try:
             httpx.get(settings.mint_url)
-        except:
+        except Exception:
             tries += 1
             time.sleep(0.1)
-
 
     yield server
     server.stop()


### PR DESCRIPTION
Previously we had a simple `time.sleep(1)` call after `server.start()` which was present to give the Mint's HTTP server time to spin up during test runs. This meant that if the server took longer than 1s to start on a dev's machine for any reason (even intermittently) then tests would fail due to connection errors.

The fix is to use a simple repeated polling check which allows the test runner to start only once the server is confirmed listening.


Drive-by: remove an unnecessary duplicate `settings.mint_host` assignment to the 'all interfaces' IP `0.0.0.0`.