### PR TITLE
Add FakeWallet invoice features tag for supported payment secret

### DIFF
--- a/cashu/lightning/fake.py
+++ b/cashu/lightning/fake.py
@@ -7,6 +7,9 @@ from typing import AsyncGenerator, Dict, List, Optional
 
 from bolt11 import (
     Bolt11,
+    Feature,
+    FeatureState,
+    Features,
     MilliSatoshi,
     TagChar,
     Tags,
@@ -88,6 +91,7 @@ class FakeWallet(LightningBackend):
     ) -> InvoiceResponse:
         self.assert_unit_supported(amount.unit)
         tags = Tags()
+        tags.add(TagChar.features, Features.from_feature_list({Feature.payment_secret: FeatureState.supported}))
 
         if description_hash:
             tags.add(TagChar.description_hash, description_hash.hex())


### PR DESCRIPTION
LDK verifies this feature is set as supported on invoices.