### PR TITLE
feat: announce description in MintMethodSetting

### DIFF
--- a/cashu/core/models.py
+++ b/cashu/core/models.py
@@ -18,7 +18,15 @@ from .settings import settings
 # ------- API: INFO -------
 
 
-class MintMeltMethodSetting(BaseModel):
+class MintMethodSetting(BaseModel):
+    method: str
+    unit: str
+    min_amount: Optional[int] = None
+    max_amount: Optional[int] = None
+    description: Optional[bool] = None
+
+
+class MeltMethodSetting(BaseModel):
     method: str
     unit: str
     min_amount: Optional[int] = None

--- a/cashu/mint/features.py
+++ b/cashu/mint/features.py
@@ -2,7 +2,8 @@ from typing import Any, Dict, List, Union
 
 from ..core.base import Method
 from ..core.models import (
-    MintMeltMethodSetting,
+    MeltMethodSetting,
+    MintMethodSetting,
 )
 from ..core.nuts import (
     DLEQ_NUT,
@@ -22,32 +23,33 @@ from ..mint.protocols import SupportsBackends
 
 class LedgerFeatures(SupportsBackends):
     def mint_features(self) -> Dict[int, Union[List[Any], Dict[str, Any]]]:
-        # determine all method-unit pairs
-        method_settings: Dict[int, List[MintMeltMethodSetting]] = {}
-        for nut in [MINT_NUT, MELT_NUT]:
-            method_settings[nut] = []
-            for method, unit_dict in self.backends.items():
-                for unit in unit_dict.keys():
-                    setting = MintMeltMethodSetting(method=method.name, unit=unit.name)
-
-                    if nut == MINT_NUT and settings.mint_max_peg_in:
-                        setting.max_amount = settings.mint_max_peg_in
-                        setting.min_amount = 0
-                    elif nut == MELT_NUT and settings.mint_max_peg_out:
-                        setting.max_amount = settings.mint_max_peg_out
-                        setting.min_amount = 0
-
-                    method_settings[nut].append(setting)
+        mint_method_settings: List[MintMethodSetting] = []
+        for method, unit_dict in self.backends.items():
+            for unit in unit_dict.keys():
+                mint_setting = MintMethodSetting(method=method.name, unit=unit.name)
+                if settings.mint_max_peg_in:
+                    mint_setting.max_amount = settings.mint_max_peg_in
+                    mint_setting.min_amount = 0
+                mint_method_settings.append(mint_setting)
+                mint_setting.description = unit_dict[unit].supports_description
+        melt_method_settings: List[MeltMethodSetting] = []
+        for method, unit_dict in self.backends.items():
+            for unit in unit_dict.keys():
+                melt_setting = MeltMethodSetting(method=method.name, unit=unit.name)
+                if settings.mint_max_peg_out:
+                    melt_setting.max_amount = settings.mint_max_peg_out
+                    melt_setting.min_amount = 0
+                melt_method_settings.append(melt_setting)
 
         supported_dict = dict(supported=True)
 
         mint_features: Dict[int, Union[List[Any], Dict[str, Any]]] = {
             MINT_NUT: dict(
-                methods=method_settings[MINT_NUT],
+                methods=mint_method_settings,
                 disabled=settings.mint_peg_out_only,
             ),
             MELT_NUT: dict(
-                methods=method_settings[MELT_NUT],
+                methods=melt_method_settings,
                 disabled=False,
             ),
             STATE_NUT: supported_dict,

--- a/tests/test_mint_api.py
+++ b/tests/test_mint_api.py
@@ -6,7 +6,7 @@ import pytest_asyncio
 from cashu.core.base import MeltQuoteState, MintQuoteState, ProofSpentState
 from cashu.core.models import (
     GetInfoResponse,
-    MintMeltMethodSetting,
+    MintMethodSetting,
     PostCheckStateRequest,
     PostCheckStateResponse,
     PostMeltQuoteResponse,
@@ -14,6 +14,7 @@ from cashu.core.models import (
     PostRestoreRequest,
     PostRestoreResponse,
 )
+from cashu.core.nuts import MINT_NUT
 from cashu.core.settings import settings
 from cashu.mint.ledger import Ledger
 from cashu.wallet.crud import bump_secret_derivation
@@ -46,8 +47,8 @@ async def test_info(ledger: Ledger):
     assert response.json()["pubkey"] == ledger.pubkey.serialize().hex()
     info = GetInfoResponse(**response.json())
     assert info.nuts
-    assert info.nuts[4]["disabled"] is False
-    setting = MintMeltMethodSetting.parse_obj(info.nuts[4]["methods"][0])
+    assert info.nuts[MINT_NUT]["disabled"] is False
+    setting = MintMethodSetting.parse_obj(info.nuts[MINT_NUT]["methods"][0])
     assert setting.method == "bolt11"
     assert setting.unit == "sat"
 


### PR DESCRIPTION
ISTM that https://github.com/cashubtc/nutshell/pull/613 implements description for mint operations, but this feature is not properly announced via NUT-06

This PR does two things in order to implement it:
+ untangle MintMeltMethodSetting into MintMethodSetting and MeltMethodSetting
+ add description to MintMethodSetting

Please pay extra attention to rewrite of function `LedgerFeatures`.
Also I am not really sure how to test it properly, but at least I tried that `curl http://127.0.0.1:3338/v1/info` now returns:

``` json
"nuts":{"4":{"methods":[{"method":"bolt11","unit":"sat","description":true}],"disabled":false}
```

instead of (before the PR):

``` json
"nuts":{"4":{"methods":[{"method":"bolt11","unit":"sat"}],"disabled":false}
```