### PR TITLE
REFACTOR: `paid` flag -> `PaymentResult` object

### DIFF
--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -80,6 +80,18 @@ class ProofState(LedgerEvent):
     def kind(self) -> JSONRPCSubscriptionKinds:
         return JSONRPCSubscriptionKinds.PROOF_STATE
 
+    @property
+    def unspent(self) -> bool:
+        return self.state == ProofSpentState.unspent
+
+    @property
+    def spent(self) -> bool:
+        return self.state == ProofSpentState.spent
+
+    @property
+    def pending(self) -> bool:
+        return self.state == ProofSpentState.pending
+
 
 class HTLCWitness(BaseModel):
     preimage: Optional[str] = None
@@ -357,13 +369,13 @@ class MeltQuote(LedgerEvent):
     # method that is invoked when the `state` attribute is changed. to protect the state from being set to anything else if the current state is paid
     def __setattr__(self, name, value):
         # an unpaid quote can only be set to pending or paid
-        if name == "state" and self.state == MeltQuoteState.unpaid:
+        if name == "state" and self.unpaid:
             if value not in [MeltQuoteState.pending, MeltQuoteState.paid]:
                 raise Exception(
                     f"Cannot change state of an unpaid melt quote to {value}."
                 )
         # a paid quote can not be changed
-        if name == "state" and self.state == MeltQuoteState.paid:
+        if name == "state" and self.paid:
             raise Exception("Cannot change state of a paid melt quote.")
 
         if name == "paid":
@@ -446,21 +458,21 @@ class MintQuote(LedgerEvent):
 
     def __setattr__(self, name, value):
         # un unpaid quote can only be set to paid
-        if name == "state" and self.state == MintQuoteState.unpaid:
+        if name == "state" and self.unpaid:
             if value != MintQuoteState.paid:
                 raise Exception(
                     f"Cannot change state of an unpaid mint quote to {value}."
                 )
         # a paid quote can only be set to pending or issued
-        if name == "state" and self.state == MintQuoteState.paid:
+        if name == "state" and self.paid:
             if value != MintQuoteState.pending and value != MintQuoteState.issued:
                 raise Exception(f"Cannot change state of a paid mint quote to {value}.")
         # a pending quote can only be set to paid or issued
-        if name == "state" and self.state == MintQuoteState.pending:
+        if name == "state" and self.pending:
             if value not in [MintQuoteState.paid, MintQuoteState.issued]:
                 raise Exception("Cannot change state of a pending mint quote.")
         # an issued quote cannot be changed
-        if name == "state" and self.state == MintQuoteState.issued:
+        if name == "state" and self.issued:
             raise Exception("Cannot change state of an issued mint quote.")
 
         if name == "paid":

--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -290,7 +290,6 @@ class MeltQuote(LedgerEvent):
     unit: str
     amount: int
     fee_reserve: int
-    paid: bool
     state: MeltQuoteState
     created_time: Union[int, None] = None
     paid_time: Union[int, None] = None
@@ -325,7 +324,6 @@ class MeltQuote(LedgerEvent):
             unit=row["unit"],
             amount=row["amount"],
             fee_reserve=row["fee_reserve"],
-            paid=row["paid"],
             state=MeltQuoteState[row["state"]],
             created_time=created_time,
             paid_time=paid_time,
@@ -344,6 +342,18 @@ class MeltQuote(LedgerEvent):
     def kind(self) -> JSONRPCSubscriptionKinds:
         return JSONRPCSubscriptionKinds.BOLT11_MELT_QUOTE
 
+    @property
+    def unpaid(self) -> bool:
+        return self.state == MeltQuoteState.unpaid
+
+    @property
+    def pending(self) -> bool:
+        return self.state == MeltQuoteState.pending
+
+    @property
+    def paid(self) -> bool:
+        return self.state == MeltQuoteState.paid
+
     # method that is invoked when the `state` attribute is changed. to protect the state from being set to anything else if the current state is paid
     def __setattr__(self, name, value):
         # an unpaid quote can only be set to pending or paid
@@ -355,6 +365,11 @@ class MeltQuote(LedgerEvent):
         # a paid quote can not be changed
         if name == "state" and self.state == MeltQuoteState.paid:
             raise Exception("Cannot change state of a paid melt quote.")
+
+        if name == "paid":
+            raise Exception(
+                "MeltQuote does not support `paid` anymore! Use `state` instead."
+            )
         super().__setattr__(name, value)
 
 
@@ -375,8 +390,6 @@ class MintQuote(LedgerEvent):
     checking_id: str
     unit: str
     amount: int
-    paid: bool
-    issued: bool
     state: MintQuoteState
     created_time: Union[int, None] = None
     paid_time: Union[int, None] = None
@@ -401,8 +414,6 @@ class MintQuote(LedgerEvent):
             checking_id=row["checking_id"],
             unit=row["unit"],
             amount=row["amount"],
-            paid=row["paid"],
-            issued=row["issued"],
             state=MintQuoteState[row["state"]],
             created_time=created_time,
             paid_time=paid_time,
@@ -416,6 +427,22 @@ class MintQuote(LedgerEvent):
     @property
     def kind(self) -> JSONRPCSubscriptionKinds:
         return JSONRPCSubscriptionKinds.BOLT11_MINT_QUOTE
+
+    @property
+    def unpaid(self) -> bool:
+        return self.state == MintQuoteState.unpaid
+
+    @property
+    def paid(self) -> bool:
+        return self.state == MintQuoteState.paid
+
+    @property
+    def pending(self) -> bool:
+        return self.state == MintQuoteState.pending
+
+    @property
+    def issued(self) -> bool:
+        return self.state == MintQuoteState.issued
 
     def __setattr__(self, name, value):
         # un unpaid quote can only be set to paid
@@ -435,6 +462,11 @@ class MintQuote(LedgerEvent):
         # an issued quote cannot be changed
         if name == "state" and self.state == MintQuoteState.issued:
             raise Exception("Cannot change state of an issued mint quote.")
+
+        if name == "paid":
+            raise Exception(
+                "MintQuote does not support `paid` anymore! Use `state` instead."
+            )
         super().__setattr__(name, value)
 
 

--- a/cashu/core/models.py
+++ b/cashu/core/models.py
@@ -205,7 +205,7 @@ class PostMeltQuoteResponse(BaseModel):
     fee_reserve: int  # input fee reserve
     paid: Optional[
         bool
-    ]  # whether the request has been paid # DEPRECATED as per NUT PR #136
+    ] = None  # whether the request has been paid # DEPRECATED as per NUT PR #136
     state: Optional[str]  # state of the quote
     expiry: Optional[int]  # expiry of the quote
     payment_preimage: Optional[str] = None  # payment preimage
@@ -216,6 +216,8 @@ class PostMeltQuoteResponse(BaseModel):
         to_dict = melt_quote.dict()
         # turn state into string
         to_dict["state"] = melt_quote.state.value
+        # add deprecated "paid" field
+        to_dict["paid"] = melt_quote.paid
         return PostMeltQuoteResponse.parse_obj(to_dict)
 
 

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -135,7 +135,7 @@ class FakeWalletSettings(MintSettings):
     fakewallet_delay_outgoing_payment: Optional[float] = Field(default=3.0)
     fakewallet_delay_incoming_payment: Optional[float] = Field(default=3.0)
     fakewallet_stochastic_invoice: bool = Field(default=False)
-    fakewallet_payment_state: Optional[bool] = Field(default=None)
+    fakewallet_payment_state: Optional[str] = Field(default="SETTLED")
 
 
 class MintInformation(CashuSettings):

--- a/cashu/lightning/base.py
+++ b/cashu/lightning/base.py
@@ -60,20 +60,44 @@ class PaymentResponse(BaseModel):
     preimage: Optional[str] = None
     error_message: Optional[str] = None
 
+    @property
+    def pending(self) -> bool:
+        return self.result == PaymentResult.PENDING
+    
+    @property
+    def settled(self) -> bool:
+        return self.result == PaymentResult.SETTLED
+
+    @property
+    def failed(self) -> bool:
+        return self.result == PaymentResult.FAILED
+
+    @property
+    def unknown(self) -> bool:
+        return self.result == PaymentResult.UNKNOWN
 
 class PaymentStatus(BaseModel):
     result: PaymentResult
     paid: Optional[bool] = None
     fee: Optional[Amount] = None
     preimage: Optional[str] = None
+    error_message: Optional[str] = None
 
     @property
     def pending(self) -> bool:
-        return self.paid is not True
+        return self.result == PaymentResult.PENDING
+    
+    @property
+    def settled(self) -> bool:
+        return self.result == PaymentResult.SETTLED
 
     @property
     def failed(self) -> bool:
-        return self.paid is False
+        return self.result == PaymentResult.FAILED
+
+    @property
+    def unknown(self) -> bool:
+        return self.result == PaymentResult.UNKNOWN
 
     def __str__(self) -> str:
         if self.result == PaymentResult.SETTLED:

--- a/cashu/lightning/base.py
+++ b/cashu/lightning/base.py
@@ -44,10 +44,12 @@ class PaymentResult(Enum):
     def __str__(self):
         return self.name
 
-    # We assume `None` is `FAILED`
+    # We assume `None` is `PENDING`
     @classmethod
     def from_paid_flag(cls, paid: Optional[bool]):
-        if paid is None or paid == False:
+        if paid is None:
+            return cls.PENDING
+        if paid == False:
             return cls.FAILED
         elif paid == True:
             return cls.SETTLED

--- a/cashu/lightning/base.py
+++ b/cashu/lightning/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import AsyncGenerator, Coroutine, Optional, Union
 from enum import Enum
+from typing import AsyncGenerator, Coroutine, Optional, Union
 
 from pydantic import BaseModel
 
@@ -49,9 +49,9 @@ class PaymentResult(Enum):
     def from_paid_flag(cls, paid: Optional[bool]):
         if paid is None:
             return cls.PENDING
-        if paid == False:
+        elif not paid:
             return cls.FAILED
-        elif paid == True:
+        elif paid:
             return cls.SETTLED
 
 class PaymentResponse(BaseModel):

--- a/cashu/lightning/blink.py
+++ b/cashu/lightning/blink.py
@@ -75,12 +75,13 @@ class BlinkWallet(LightningBackend):
 
     async def status(self) -> StatusResponse:
         try:
+            data = {
+                "query": "query me { me { defaultAccount { wallets { id walletCurrency balance }}}}",
+                "variables": {},
+            }
             r = await self.client.post(
                 url=self.endpoint,
-                data=(  # type: ignore
-                    '{"query":"query me { me { defaultAccount { wallets { id'
-                    ' walletCurrency balance }}}}", "variables":{}}'
-                ),
+                data=json.dumps(data),  # type: ignore
             )
             r.raise_for_status()
         except Exception as exc:

--- a/cashu/lightning/blink.py
+++ b/cashu/lightning/blink.py
@@ -77,10 +77,10 @@ class BlinkWallet(LightningBackend):
         try:
             r = await self.client.post(
                 url=self.endpoint,
-                data=(
+                data=(  # type: ignore
                     '{"query":"query me { me { defaultAccount { wallets { id'
                     ' walletCurrency balance }}}}", "variables":{}}'
-                ),  # type: ignore
+                ),
             )
             r.raise_for_status()
         except Exception as exc:

--- a/cashu/lightning/clnrest.py
+++ b/cashu/lightning/clnrest.py
@@ -20,10 +20,10 @@ from .base import (
     LightningBackend,
     PaymentQuoteResponse,
     PaymentResponse,
+    PaymentResult,
     PaymentStatus,
     StatusResponse,
     Unsupported,
-    PaymentResult,
 )
 
 # https://docs.corelightning.org/reference/lightning-pay

--- a/cashu/lightning/corelightningrest.py
+++ b/cashu/lightning/corelightningrest.py
@@ -253,12 +253,12 @@ class CoreLightningRestWallet(LightningBackend):
             pay = data["pays"][0]
 
             fee_msat, preimage = None, None
-            if INVOICE_RESULT_MAP.get(pay["status"]) == PaymentResult.SETTLED:
+            if PAYMENT_RESULT_MAP.get(pay["status"]) == PaymentResult.SETTLED:
                 fee_msat = -int(pay["amount_sent_msat"]) - int(pay["amount_msat"])
                 preimage = pay["preimage"]
 
             return PaymentStatus(
-                result=INVOICE_RESULT_MAP[pay["status"]],
+                result=PAYMENT_RESULT_MAP[pay["status"]],
                 fee=Amount(unit=Unit.msat, amount=fee_msat) if fee_msat else None,
                 preimage=preimage,
             )

--- a/cashu/lightning/corelightningrest.py
+++ b/cashu/lightning/corelightningrest.py
@@ -273,7 +273,8 @@ class CoreLightningRestWallet(LightningBackend):
         data = r.json()
         if r.is_error or "error" in data:
             raise Exception("error in cln response")
-        self.last_pay_index = data["invoices"][-1]["pay_index"]
+        if data.get("invoices"):
+            self.last_pay_index = data["invoices"][-1]["pay_index"]
 
         while True:
             try:

--- a/cashu/lightning/corelightningrest.py
+++ b/cashu/lightning/corelightningrest.py
@@ -19,10 +19,10 @@ from .base import (
     LightningBackend,
     PaymentQuoteResponse,
     PaymentResponse,
+    PaymentResult,
     PaymentStatus,
     StatusResponse,
     Unsupported,
-    PaymentResult,
 )
 from .macaroon import load_macaroon
 

--- a/cashu/lightning/fake.py
+++ b/cashu/lightning/fake.py
@@ -23,9 +23,9 @@ from .base import (
     LightningBackend,
     PaymentQuoteResponse,
     PaymentResponse,
+    PaymentResult,
     PaymentStatus,
     StatusResponse,
-    PaymentResult,
 )
 
 

--- a/cashu/lightning/lnbits.py
+++ b/cashu/lightning/lnbits.py
@@ -134,7 +134,6 @@ class LNbitsWallet(LightningBackend):
 
         return PaymentResponse(
             result=payment.result,
-            ok=True,
             checking_id=checking_id,
             fee=payment.fee,
             preimage=payment.preimage,
@@ -197,7 +196,7 @@ class LNbitsWallet(LightningBackend):
         return PaymentStatus(
             result=result,
             fee=Amount(unit=Unit.msat, amount=abs(data["details"]["fee"])),
-            preimage=data["preimage"],
+            preimage=data.get("preimage"),
         )
 
     async def get_payment_quote(

--- a/cashu/lightning/lnbits.py
+++ b/cashu/lightning/lnbits.py
@@ -173,10 +173,10 @@ class LNbitsWallet(LightningBackend):
             )
             r.raise_for_status()
         except Exception:
-            return PaymentStatus(paid=None)
+            return PaymentStatus(result=PaymentResult.UNKNOWN, paid=None)
         data = r.json()
         if "paid" not in data and "details" not in data:
-            return PaymentStatus(paid=None)
+            return PaymentStatus(result=PaymentResult.UNKNOWN, paid=None)
 
         paid_value = None
         result = PaymentResult.UNKNOWN

--- a/cashu/lightning/lnd_grpc/lnd_grpc.py
+++ b/cashu/lightning/lnd_grpc/lnd_grpc.py
@@ -24,10 +24,10 @@ from cashu.lightning.base import (
     LightningBackend,
     PaymentQuoteResponse,
     PaymentResponse,
+    PaymentResult,
     PaymentStatus,
     PostMeltQuoteRequest,
     StatusResponse,
-    PaymentResult,
 )
 
 # maps statuses to None, False, True:

--- a/cashu/lightning/lnd_grpc/lnd_grpc.py
+++ b/cashu/lightning/lnd_grpc/lnd_grpc.py
@@ -196,7 +196,7 @@ class LndRPCWallet(LightningBackend):
         fee_msat = r.payment_route.total_fees_msat
         preimage = r.payment_preimage.hex()
         return PaymentResponse(
-            result=PaymentResult.PENDING,
+            result=PaymentResult.SETTLED,
             checking_id=checking_id,
             fee=Amount(unit=Unit.msat, amount=fee_msat) if fee_msat else None,
             preimage=preimage,

--- a/cashu/lightning/lndrest.py
+++ b/cashu/lightning/lndrest.py
@@ -210,7 +210,7 @@ class LndRestWallet(LightningBackend):
         fee_msat = int(data["payment_route"]["total_fees_msat"])
         preimage = base64.b64decode(data["payment_preimage"]).hex()
         return PaymentResponse(
-            result=PaymentResult.PENDING,
+            result=PaymentResult.SETTLED,
             checking_id=checking_id,
             fee=Amount(unit=Unit.msat, amount=fee_msat) if fee_msat else None,
             preimage=preimage,

--- a/cashu/lightning/lndrest.py
+++ b/cashu/lightning/lndrest.py
@@ -21,9 +21,9 @@ from .base import (
     LightningBackend,
     PaymentQuoteResponse,
     PaymentResponse,
+    PaymentResult,
     PaymentStatus,
     StatusResponse,
-    PaymentResult,
 )
 from .macaroon import load_macaroon
 

--- a/cashu/mint/crud.py
+++ b/cashu/mint/crud.py
@@ -633,7 +633,7 @@ class LedgerCrudSqlite(LedgerCrud):
     ) -> None:
         await (conn or db).execute(
             f"""
-            UPDATE {db.table_with_schema('melt_quotes')} SET state = :state, fee_paid = :fee_paid, paid_time = :paid_time, proof = :proof, change = :change WHERE quote = :quote
+            UPDATE {db.table_with_schema('melt_quotes')} SET state = :state, fee_paid = :fee_paid, paid_time = :paid_time, proof = :proof, change = :change, checking_id = :checking_id WHERE quote = :quote
             """,
             {
                 "state": quote.state.name,
@@ -646,6 +646,7 @@ class LedgerCrudSqlite(LedgerCrud):
                 if quote.change
                 else None,
                 "quote": quote.quote,
+                "checking_id": quote.checking_id,
             },
         )
 

--- a/cashu/mint/crud.py
+++ b/cashu/mint/crud.py
@@ -234,6 +234,16 @@ class LedgerCrud(ABC):
         ...
 
     @abstractmethod
+    async def get_melt_quote_by_request(
+        self,
+        *,
+        request: str,
+        db: Database,
+        conn: Optional[Connection] = None,
+    ) -> Optional[MeltQuote]:
+        ...
+
+    @abstractmethod
     async def update_melt_quote(
         self,
         *,
@@ -610,8 +620,22 @@ class LedgerCrudSqlite(LedgerCrud):
             """,
             values,
         )
-        if row is None:
-            return None
+        return MeltQuote.from_row(row) if row else None
+
+    async def get_melt_quote_by_request(
+        self,
+        *,
+        request: str,
+        db: Database,
+        conn: Optional[Connection] = None,
+    ) -> Optional[MeltQuote]:
+        row = await (conn or db).fetchone(
+            f"""
+            SELECT * from {db.table_with_schema('melt_quotes')}
+            WHERE request = :request
+            """,
+            {"request": request},
+        )
         return MeltQuote.from_row(row) if row else None
 
     async def update_melt_quote(

--- a/cashu/mint/db/write.py
+++ b/cashu/mint/db/write.py
@@ -189,8 +189,8 @@ class DbWriteHelper:
             )
             if not quote_db:
                 raise TransactionError("Melt quote not found.")
-            if quote_db.pending:
-                raise TransactionError("Melt quote already pending.")
+            # if quote_db.pending:
+            #     raise TransactionError("Melt quote already pending.")
             # set the quote as pending
             quote_copy.state = MeltQuoteState.pending
             await self.crud.update_melt_quote(quote=quote_copy, db=self.db, conn=conn)

--- a/cashu/mint/db/write.py
+++ b/cashu/mint/db/write.py
@@ -129,9 +129,9 @@ class DbWriteHelper:
             )
             if not quote:
                 raise TransactionError("Mint quote not found.")
-            if quote.state == MintQuoteState.pending:
+            if quote.pending:
                 raise TransactionError("Mint quote already pending.")
-            if not quote.state == MintQuoteState.paid:
+            if not quote.paid:
                 raise TransactionError("Mint quote is not paid yet.")
             # set the quote as pending
             quote.state = MintQuoteState.pending
@@ -189,7 +189,7 @@ class DbWriteHelper:
             )
             if not quote_db:
                 raise TransactionError("Melt quote not found.")
-            if quote_db.state == MeltQuoteState.pending:
+            if quote_db.pending:
                 raise TransactionError("Melt quote already pending.")
             # set the quote as pending
             quote_copy.state = MeltQuoteState.pending

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -915,8 +915,8 @@ class Ledger(LedgerVerification, LedgerSpendingConditions, LedgerTasks, LedgerFe
         await self.db_write._verify_spent_proofs_and_set_pending(
             proofs, quote_id=melt_quote.quote
         )
-        previous_state = melt_quote.state
-        await self.db_write._set_melt_quote_pending(melt_quote)
+        # previous_state = melt_quote.state
+        # await self.db_write._set_melt_quote_pending(melt_quote)
         try:
             # settle the transaction internally if there is a mint quote with the same payment request
             melt_quote = await self.melt_mint_settle_internally(melt_quote, proofs)
@@ -979,9 +979,9 @@ class Ledger(LedgerVerification, LedgerSpendingConditions, LedgerTasks, LedgerFe
 
         except Exception as e:
             logger.trace(f"Melt exception: {e}")
-            await self.db_write._unset_melt_quote_pending(
-                quote=melt_quote, state=previous_state
-            )
+            # await self.db_write._unset_melt_quote_pending(
+            #     quote=melt_quote, state=previous_state
+            # )
             raise e
         finally:
             # delete proofs from pending list

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -458,8 +458,6 @@ class Ledger(LedgerVerification, LedgerSpendingConditions, LedgerTasks, LedgerFe
             checking_id=invoice_response.checking_id,
             unit=quote_request.unit,
             amount=quote_request.amount,
-            issued=False,
-            paid=False,
             state=MintQuoteState.unpaid,
             created_time=int(time.time()),
             expiry=expiry,

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -758,7 +758,8 @@ class Ledger(LedgerVerification, LedgerSpendingConditions, LedgerTasks, LedgerFe
             status: PaymentStatus = await self.backends[method][
                 unit
             ].get_payment_status(melt_quote.checking_id)
-            if status.result == PaymentResult.SETTLED:
+            if status.settled:
+
                 logger.trace(f"Setting quote {quote_id} as paid")
                 melt_quote.state = MeltQuoteState.paid
                 if status.fee:

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -4,7 +4,6 @@ import time
 from fastapi import APIRouter, Request, WebSocket
 from loguru import logger
 
-from ..core.base import MeltQuoteState, MintQuoteState
 from ..core.errors import KeysetNotFoundError
 from ..core.models import (
     GetInfoResponse,
@@ -169,7 +168,7 @@ async def mint_quote(
     resp = PostMintQuoteResponse(
         request=quote.request,
         quote=quote.quote,
-        paid=quote.state == MintQuoteState.paid,  # deprecated
+        paid=quote.paid,  # deprecated
         state=quote.state.value,
         expiry=quote.expiry,
     )
@@ -193,7 +192,7 @@ async def get_mint_quote(request: Request, quote: str) -> PostMintQuoteResponse:
     resp = PostMintQuoteResponse(
         quote=mint_quote.quote,
         request=mint_quote.request,
-        paid=mint_quote.state == MintQuoteState.paid,  # deprecated
+        paid=mint_quote.paid,  # deprecated
         state=mint_quote.state.value,
         expiry=mint_quote.expiry,
     )
@@ -284,7 +283,7 @@ async def get_melt_quote(request: Request, quote: str) -> PostMeltQuoteResponse:
         quote=melt_quote.quote,
         amount=melt_quote.amount,
         fee_reserve=melt_quote.fee_reserve,
-        paid=melt_quote.state == MeltQuoteState.paid,
+        paid=melt_quote.paid,
         state=melt_quote.state.value,
         expiry=melt_quote.expiry,
     )

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -4,6 +4,7 @@ import time
 from fastapi import APIRouter, Request, WebSocket
 from loguru import logger
 
+from ..core.base import MeltQuoteState, MintQuoteState
 from ..core.errors import KeysetNotFoundError
 from ..core.models import (
     GetInfoResponse,
@@ -168,7 +169,7 @@ async def mint_quote(
     resp = PostMintQuoteResponse(
         request=quote.request,
         quote=quote.quote,
-        paid=quote.paid,
+        paid=quote.state == MintQuoteState.paid,  # deprecated
         state=quote.state.value,
         expiry=quote.expiry,
     )
@@ -192,7 +193,7 @@ async def get_mint_quote(request: Request, quote: str) -> PostMintQuoteResponse:
     resp = PostMintQuoteResponse(
         quote=mint_quote.quote,
         request=mint_quote.request,
-        paid=mint_quote.paid,
+        paid=mint_quote.state == MintQuoteState.paid,  # deprecated
         state=mint_quote.state.value,
         expiry=mint_quote.expiry,
     )
@@ -283,7 +284,7 @@ async def get_melt_quote(request: Request, quote: str) -> PostMeltQuoteResponse:
         quote=melt_quote.quote,
         amount=melt_quote.amount,
         fee_reserve=melt_quote.fee_reserve,
-        paid=melt_quote.paid,
+        paid=melt_quote.state == MeltQuoteState.paid,
         state=melt_quote.state.value,
         expiry=melt_quote.expiry,
     )

--- a/cashu/mint/router_deprecated.py
+++ b/cashu/mint/router_deprecated.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional
 from fastapi import APIRouter, Request
 from loguru import logger
 
-from ..core.base import BlindedMessage, BlindedSignature, ProofSpentState
+from ..core.base import BlindedMessage, BlindedSignature
 from ..core.errors import CashuError
 from ..core.models import (
     CheckFeesRequest_deprecated,
@@ -345,13 +345,13 @@ async def check_spendable_deprecated(
     spendableList: List[bool] = []
     pendingList: List[bool] = []
     for proof_state in proofs_state:
-        if proof_state.state == ProofSpentState.unspent:
+        if proof_state.unspent:
             spendableList.append(True)
             pendingList.append(False)
-        elif proof_state.state == ProofSpentState.spent:
+        elif proof_state.spent:
             spendableList.append(False)
             pendingList.append(False)
-        elif proof_state.state == ProofSpentState.pending:
+        elif proof_state.pending:
             spendableList.append(True)
             pendingList.append(True)
     return CheckSpendableResponse_deprecated(

--- a/cashu/mint/tasks.py
+++ b/cashu/mint/tasks.py
@@ -56,7 +56,7 @@ class LedgerTasks(SupportsDb, SupportsBackends, SupportsEvents):
                 f"Invoice callback dispatcher: quote {quote} trying to set as {MintQuoteState.paid}"
             )
             # set the quote as paid
-            if quote.state == MintQuoteState.unpaid:
+            if quote.unpaid:
                 quote.state = MintQuoteState.paid
                 await self.crud.update_mint_quote(quote=quote, db=self.db, conn=conn)
                 logger.trace(

--- a/cashu/mint/tasks.py
+++ b/cashu/mint/tasks.py
@@ -57,7 +57,6 @@ class LedgerTasks(SupportsDb, SupportsBackends, SupportsEvents):
             )
             # set the quote as paid
             if quote.state == MintQuoteState.unpaid:
-                quote.paid = True
                 quote.state = MintQuoteState.paid
                 await self.crud.update_mint_quote(quote=quote, db=self.db, conn=conn)
                 logger.trace(

--- a/cashu/wallet/lightning/lightning.py
+++ b/cashu/wallet/lightning/lightning.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import bolt11
 
-from ...core.base import Amount, ProofSpentState, Unit
+from ...core.base import Amount, Unit
 from ...core.helpers import sum_promises
 from ...core.settings import settings
 from ...lightning.base import (
@@ -143,12 +143,12 @@ class LightningWallet(Wallet):
         if not proofs_states:
             return PaymentStatus(result=PaymentResult.FAILED)  # "states not fount"
 
-        if all([p.state == ProofSpentState.pending for p in proofs_states.states]):
+        if all([p.state.pending for p in proofs_states.states]):
             return PaymentStatus(result=PaymentResult.PENDING)  # "pending (with check)"
-        if any([p.state == ProofSpentState.spent for p in proofs_states.states]):
+        if any([p.state.spent for p in proofs_states.states]):
             # NOTE: consider adding this check in wallet.py and mark the invoice as paid if all proofs are spent
             return PaymentStatus(result=PaymentResult.SETTLED)  # "paid (with check)"
-        if all([p.state == ProofSpentState.unspent for p in proofs_states.states]):
+        if all([p.state.unspent for p in proofs_states.states]):
             return PaymentStatus(result=PaymentResult.FAILED)  # "failed (with check)"
         return PaymentStatus(result=PaymentResult.UNKNOWN)  # "undefined state"
 

--- a/cashu/wallet/lightning/lightning.py
+++ b/cashu/wallet/lightning/lightning.py
@@ -8,9 +8,9 @@ from ...core.settings import settings
 from ...lightning.base import (
     InvoiceResponse,
     PaymentResponse,
+    PaymentResult,
     PaymentStatus,
     StatusResponse,
-    PaymentResult,
 )
 from ...wallet.crud import get_lightning_invoice, get_proofs
 from ..wallet import Wallet

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -763,7 +763,7 @@ class Wallet(
             # remove the melt_id in proofs
             for p in proofs:
                 p.melt_id = None
-                await update_proof(p, melt_id=None, db=self.db)
+                await update_proof(p, melt_id="", db=self.db)
             raise Exception("could not pay invoice.")
 
         # invoice was paid successfully

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -14,7 +14,6 @@ from ..core.base import (
     DLEQWallet,
     Invoice,
     Proof,
-    ProofSpentState,
     Unit,
     WalletKeyset,
 )
@@ -995,7 +994,7 @@ class Wallet(
         if check_spendable:
             proof_states = await self.check_proof_state(proofs)
             for i, state in enumerate(proof_states.states):
-                if state.state == ProofSpentState.spent:
+                if state.spent:
                     invalidated_proofs.append(proofs[i])
         else:
             invalidated_proofs = proofs

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.10
 # disallow_untyped_defs = True
 ; check_untyped_defs = True
 ignore_missing_imports = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ settings.mint_seed_decryption_key = ""
 settings.mint_max_balance = 0
 settings.mint_transaction_rate_limit_per_minute = 60
 settings.mint_lnd_enable_mpp = True
-settings.mint_clnrest_enable_mpp = False
+settings.mint_clnrest_enable_mpp = True
 settings.mint_input_fee_ppk = 0
 settings.db_connection_pool = True
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -96,6 +96,7 @@ docker_lightning_unconnected_cli = [
     "--rpcserver=lnd-2",
 ]
 
+
 def docker_clightning_cli(index):
     return [
         "docker",
@@ -106,6 +107,7 @@ def docker_clightning_cli(index):
         "regtest",
         "--keywords",
     ]
+
 
 def run_cmd(cmd: list) -> str:
     timeout = 20
@@ -171,10 +173,12 @@ def pay_real_invoice(invoice: str) -> str:
     cmd.extend(["payinvoice", "--force", invoice])
     return run_cmd(cmd)
 
+
 def partial_pay_real_invoice(invoice: str, amount: int, node: int) -> str:
     cmd = docker_clightning_cli(node)
     cmd.extend(["pay", f"bolt11={invoice}", f"partial_msat={amount*1000}"])
     return run_cmd(cmd)
+
 
 def mine_blocks(blocks: int = 1) -> str:
     cmd = docker_bitcoin_cli.copy()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -2,7 +2,7 @@ import asyncio
 import datetime
 import os
 import time
-from typing import List
+from typing import List, Tuple
 
 import pytest
 import pytest_asyncio
@@ -63,7 +63,8 @@ async def test_db_tables(ledger: Ledger):
                 "SELECT table_name FROM information_schema.tables WHERE table_schema ="
                 " 'public';"
             )
-        tables = [t[0] for t in tables_res.all()]
+        tables_all: List[Tuple[str]] = tables_res.all()
+        tables = [t[0] for t in tables_all]
         tables_expected = [
             "dbversions",
             "keysets",

--- a/tests/test_mint_api.py
+++ b/tests/test_mint_api.py
@@ -3,7 +3,7 @@ import httpx
 import pytest
 import pytest_asyncio
 
-from cashu.core.base import MeltQuoteState, MintQuoteState, ProofSpentState
+from cashu.core.base import MeltQuoteState, MintQuoteState
 from cashu.core.models import (
     GetInfoResponse,
     MintMeltMethodSetting,
@@ -477,7 +477,7 @@ async def test_api_check_state(ledger: Ledger):
     response = PostCheckStateResponse.parse_obj(response.json())
     assert response
     assert len(response.states) == 2
-    assert response.states[0].state == ProofSpentState.unspent
+    assert response.states[0].state.unspent
 
 
 @pytest.mark.asyncio

--- a/tests/test_mint_fees.py
+++ b/tests/test_mint_fees.py
@@ -237,7 +237,7 @@ async def test_melt_external_with_fees(wallet1: Wallet, ledger: Ledger):
     )
 
     melt_quote_pre_payment = await ledger.get_melt_quote(melt_quote.quote)
-    assert not melt_quote_pre_payment.state, "melt quote should not be paid"
+    assert not melt_quote_pre_payment.paid, "melt quote should not be paid"
 
     assert not melt_quote.paid, "melt quote should not be paid"
     await ledger.melt(proofs=send_proofs, quote=melt_quote.quote)

--- a/tests/test_mint_fees.py
+++ b/tests/test_mint_fees.py
@@ -237,7 +237,7 @@ async def test_melt_external_with_fees(wallet1: Wallet, ledger: Ledger):
     )
 
     melt_quote_pre_payment = await ledger.get_melt_quote(melt_quote.quote)
-    assert not melt_quote_pre_payment.paid, "melt quote should not be paid"
+    assert not melt_quote_pre_payment.state, "melt quote should not be paid"
 
     assert not melt_quote.paid, "melt quote should not be paid"
     await ledger.melt(proofs=send_proofs, quote=melt_quote.quote)

--- a/tests/test_mint_init.py
+++ b/tests/test_mint_init.py
@@ -144,7 +144,6 @@ async def create_pending_melts(
         request="asdasd",
         checking_id=check_id,
         unit="sat",
-        paid=False,
         state=MeltQuoteState.unpaid,
         amount=100,
         fee_reserve=1,

--- a/tests/test_mint_init.py
+++ b/tests/test_mint_init.py
@@ -283,7 +283,6 @@ async def test_startup_regtest_pending_quote_pending(wallet: Wallet, ledger: Led
         )
     )
     await asyncio.sleep(SLEEP_TIME)
-    # settle_invoice(preimage=preimage)
 
     # run startup routinge
     await ledger.startup_ledger()

--- a/tests/test_mint_operations.py
+++ b/tests/test_mint_operations.py
@@ -1,7 +1,7 @@
 import pytest
 import pytest_asyncio
 
-from cashu.core.base import MeltQuoteState, MintQuoteState
+from cashu.core.base import MeltQuoteState
 from cashu.core.helpers import sum_proofs
 from cashu.core.models import PostMeltQuoteRequest, PostMintQuoteRequest
 from cashu.mint.ledger import Ledger
@@ -58,14 +58,14 @@ async def test_melt_internal(wallet1: Wallet, ledger: Ledger):
 
     melt_quote_pre_payment = await ledger.get_melt_quote(melt_quote.quote)
     assert not melt_quote_pre_payment.paid, "melt quote should not be paid"
-    assert melt_quote_pre_payment.state == MeltQuoteState.unpaid
+    assert melt_quote_pre_payment.unpaid
 
     keep_proofs, send_proofs = await wallet1.swap_to_send(wallet1.proofs, 64)
     await ledger.melt(proofs=send_proofs, quote=melt_quote.quote)
 
     melt_quote_post_payment = await ledger.get_melt_quote(melt_quote.quote)
     assert melt_quote_post_payment.paid, "melt quote should be paid"
-    assert melt_quote_post_payment.state == MeltQuoteState.paid
+    assert melt_quote_post_payment.paid
 
 
 @pytest.mark.asyncio
@@ -92,14 +92,14 @@ async def test_melt_external(wallet1: Wallet, ledger: Ledger):
 
     melt_quote_pre_payment = await ledger.get_melt_quote(melt_quote.quote)
     assert not melt_quote_pre_payment.paid, "melt quote should not be paid"
-    assert melt_quote_pre_payment.state == MeltQuoteState.unpaid
+    assert melt_quote_pre_payment.unpaid
 
     assert not melt_quote.paid, "melt quote should not be paid"
     await ledger.melt(proofs=send_proofs, quote=melt_quote.quote)
 
     melt_quote_post_payment = await ledger.get_melt_quote(melt_quote.quote)
     assert melt_quote_post_payment.paid, "melt quote should be paid"
-    assert melt_quote_post_payment.state == MeltQuoteState.paid
+    assert melt_quote_post_payment.paid
 
 
 @pytest.mark.asyncio
@@ -110,7 +110,7 @@ async def test_mint_internal(wallet1: Wallet, ledger: Ledger):
     mint_quote = await ledger.get_mint_quote(invoice.id)
 
     assert mint_quote.paid, "mint quote should be paid"
-    assert mint_quote.state == MintQuoteState.paid
+    assert mint_quote.paid
 
     output_amounts = [128]
     secrets, rs, derivation_paths = await wallet1.generate_n_secrets(
@@ -126,7 +126,7 @@ async def test_mint_internal(wallet1: Wallet, ledger: Ledger):
 
     mint_quote_after_payment = await ledger.get_mint_quote(invoice.id)
     assert mint_quote_after_payment.issued, "mint quote should be issued"
-    assert mint_quote_after_payment.state == MintQuoteState.issued
+    assert mint_quote_after_payment.issued
 
 
 @pytest.mark.asyncio
@@ -134,11 +134,11 @@ async def test_mint_internal(wallet1: Wallet, ledger: Ledger):
 async def test_mint_external(wallet1: Wallet, ledger: Ledger):
     quote = await ledger.mint_quote(PostMintQuoteRequest(amount=128, unit="sat"))
     assert not quote.paid, "mint quote should not be paid"
-    assert quote.state == MintQuoteState.unpaid
+    assert quote.unpaid
 
     mint_quote = await ledger.get_mint_quote(quote.quote)
     assert not mint_quote.paid, "mint quote already paid"
-    assert mint_quote.state == MintQuoteState.unpaid
+    assert mint_quote.unpaid
 
     await assert_err(
         wallet1.mint(128, id=quote.quote),
@@ -149,7 +149,7 @@ async def test_mint_external(wallet1: Wallet, ledger: Ledger):
 
     mint_quote = await ledger.get_mint_quote(quote.quote)
     assert mint_quote.paid, "mint quote should be paid"
-    assert mint_quote.state == MintQuoteState.paid
+    assert mint_quote.paid
 
     output_amounts = [128]
     secrets, rs, derivation_paths = await wallet1.generate_n_secrets(
@@ -159,8 +159,7 @@ async def test_mint_external(wallet1: Wallet, ledger: Ledger):
     await ledger.mint(outputs=outputs, quote_id=quote.quote)
 
     mint_quote_after_payment = await ledger.get_mint_quote(quote.quote)
-    assert mint_quote_after_payment.paid, "mint quote should be paid"
-    assert mint_quote_after_payment.state == MintQuoteState.issued
+    assert mint_quote_after_payment.issued, "mint quote should be issued"
 
 
 @pytest.mark.asyncio

--- a/tests/test_mint_operations.py
+++ b/tests/test_mint_operations.py
@@ -125,7 +125,7 @@ async def test_mint_internal(wallet1: Wallet, ledger: Ledger):
     )
 
     mint_quote_after_payment = await ledger.get_mint_quote(invoice.id)
-    assert mint_quote_after_payment.paid, "mint quote should be paid"
+    assert mint_quote_after_payment.issued, "mint quote should be issued"
     assert mint_quote_after_payment.state == MintQuoteState.issued
 
 

--- a/tests/test_mint_regtest.py
+++ b/tests/test_mint_regtest.py
@@ -3,7 +3,6 @@ import asyncio
 import pytest
 import pytest_asyncio
 
-from cashu.core.base import ProofSpentState
 from cashu.mint.ledger import Ledger
 from cashu.wallet.wallet import Wallet
 from tests.conftest import SERVER_ENDPOINT
@@ -63,7 +62,7 @@ async def test_regtest_pending_quote(wallet: Wallet, ledger: Ledger):
 
     # expect that proofs are still pending
     states = await ledger.db_read.get_proofs_states([p.Y for p in send_proofs])
-    assert all([s.state == ProofSpentState.pending for s in states])
+    assert all([s.pending for s in states])
 
     # only now settle the invoice
     settle_invoice(preimage=preimage)
@@ -71,7 +70,7 @@ async def test_regtest_pending_quote(wallet: Wallet, ledger: Ledger):
 
     # expect that proofs are now spent
     states = await ledger.db_read.get_proofs_states([p.Y for p in send_proofs])
-    assert all([s.state == ProofSpentState.spent for s in states])
+    assert all([s.spent for s in states])
 
     # expect that no melt quote is pending
     melt_quotes = await ledger.crud.get_all_melt_quotes_from_pending_proofs(

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -4,7 +4,7 @@ import pytest
 import pytest_asyncio
 from fastapi.testclient import TestClient
 
-from cashu.lightning.base import InvoiceResponse, PaymentStatus
+from cashu.lightning.base import InvoiceResponse, PaymentStatus, PaymentResult
 from cashu.wallet.api.app import app
 from cashu.wallet.wallet import Wallet
 from tests.conftest import SERVER_ENDPOINT
@@ -29,8 +29,8 @@ async def test_invoice(wallet: Wallet):
         response = client.post("/lightning/create_invoice?amount=100")
         assert response.status_code == 200
         invoice_response = InvoiceResponse.parse_obj(response.json())
-        state = PaymentStatus(paid=False)
-        while not state.paid:
+        state = PaymentStatus(result=PaymentResult.PENDING)
+        while state.pending:
             print("checking invoice state")
             response2 = client.get(
                 f"/lightning/invoice_state?payment_hash={invoice_response.checking_id}"
@@ -171,8 +171,8 @@ async def test_flow(wallet: Wallet):
         initial_balance = response.json()["balance"]
         response = client.post("/lightning/create_invoice?amount=100")
         invoice_response = InvoiceResponse.parse_obj(response.json())
-        state = PaymentStatus(paid=False)
-        while not state.paid:
+        state = PaymentStatus(result=PaymentResult.PENDING)
+        while state.pending:
             print("checking invoice state")
             response2 = client.get(
                 f"/lightning/invoice_state?payment_hash={invoice_response.checking_id}"

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -4,7 +4,7 @@ import pytest
 import pytest_asyncio
 from fastapi.testclient import TestClient
 
-from cashu.lightning.base import InvoiceResponse, PaymentStatus, PaymentResult
+from cashu.lightning.base import InvoiceResponse, PaymentResult, PaymentStatus
 from cashu.wallet.api.app import app
 from cashu.wallet.wallet import Wallet
 from tests.conftest import SERVER_ENDPOINT

--- a/tests/test_wallet_lightning.py
+++ b/tests/test_wallet_lightning.py
@@ -83,7 +83,7 @@ async def test_check_invoice_internal(wallet: LightningWallet):
     assert invoice.payment_request
     assert invoice.checking_id
     status = await wallet.get_invoice_status(invoice.checking_id)
-    assert status.paid
+    assert status.settled
 
 
 @pytest.mark.asyncio
@@ -94,10 +94,10 @@ async def test_check_invoice_external(wallet: LightningWallet):
     assert invoice.payment_request
     assert invoice.checking_id
     status = await wallet.get_invoice_status(invoice.checking_id)
-    assert not status.paid
+    assert not status.settled
     await pay_if_regtest(invoice.payment_request)
     status = await wallet.get_invoice_status(invoice.checking_id)
-    assert status.paid
+    assert status.settled
 
 
 @pytest.mark.asyncio
@@ -115,12 +115,12 @@ async def test_pay_invoice_internal(wallet: LightningWallet):
     assert invoice2.payment_request
     status = await wallet.pay_invoice(invoice2.payment_request)
 
-    assert status.ok
+    assert status.settled
 
     # check payment
     assert invoice2.checking_id
     status = await wallet.get_payment_status(invoice2.checking_id)
-    assert status.paid
+    assert status.settled
 
 
 @pytest.mark.asyncio
@@ -132,16 +132,16 @@ async def test_pay_invoice_external(wallet: LightningWallet):
     assert invoice.checking_id
     await pay_if_regtest(invoice.payment_request)
     status = await wallet.get_invoice_status(invoice.checking_id)
-    assert status.paid
+    assert status.settled
     assert wallet.available_balance >= 64
 
     # pay invoice
     invoice_real = get_real_invoice(16)
     status = await wallet.pay_invoice(invoice_real["payment_request"])
 
-    assert status.ok
+    assert status.settled
 
     # check payment
     assert status.checking_id
     status = await wallet.get_payment_status(status.checking_id)
-    assert status.paid
+    assert status.settled

--- a/tests/test_wallet_p2pk.py
+++ b/tests/test_wallet_p2pk.py
@@ -7,7 +7,7 @@ from typing import List
 import pytest
 import pytest_asyncio
 
-from cashu.core.base import Proof, ProofSpentState
+from cashu.core.base import Proof
 from cashu.core.crypto.secp import PrivateKey, PublicKey
 from cashu.core.migrations import migrate_databases
 from cashu.core.p2pk import SigFlags
@@ -80,7 +80,7 @@ async def test_p2pk(wallet1: Wallet, wallet2: Wallet):
     await wallet2.redeem(send_proofs)
 
     proof_states = await wallet2.check_proof_state(send_proofs)
-    assert all([p.state == ProofSpentState.spent for p in proof_states.states])
+    assert all([p.spent for p in proof_states.states])
 
     if not is_deprecated_api_only:
         for state in proof_states.states:

--- a/tests/test_wallet_regtest.py
+++ b/tests/test_wallet_regtest.py
@@ -4,7 +4,6 @@ import bolt11
 import pytest
 import pytest_asyncio
 
-from cashu.core.base import ProofSpentState
 from cashu.mint.ledger import Ledger
 from cashu.wallet.wallet import Wallet
 from tests.conftest import SERVER_ENDPOINT
@@ -57,14 +56,14 @@ async def test_regtest_pending_quote(wallet: Wallet, ledger: Ledger):
     await asyncio.sleep(SLEEP_TIME)
 
     states = await wallet.check_proof_state(send_proofs)
-    assert all([s.state == ProofSpentState.pending for s in states.states])
+    assert all([s.pending for s in states.states])
 
     settle_invoice(preimage=preimage)
 
     await asyncio.sleep(SLEEP_TIME)
 
     states = await wallet.check_proof_state(send_proofs)
-    assert all([s.state == ProofSpentState.spent for s in states.states])
+    assert all([s.spent for s in states.states])
 
 
 @pytest.mark.asyncio
@@ -97,11 +96,11 @@ async def test_regtest_failed_quote(wallet: Wallet, ledger: Ledger):
     await asyncio.sleep(SLEEP_TIME)
 
     states = await wallet.check_proof_state(send_proofs)
-    assert all([s.state == ProofSpentState.pending for s in states.states])
+    assert all([s.pending for s in states.states])
 
     cancel_invoice(preimage_hash=preimage_hash)
 
     await asyncio.sleep(SLEEP_TIME)
 
     states = await wallet.check_proof_state(send_proofs)
-    assert all([s.state == ProofSpentState.unspent for s in states.states])
+    assert all([s.unspent for s in states.states])

--- a/tests/test_wallet_regtest_mpp.py
+++ b/tests/test_wallet_regtest_mpp.py
@@ -59,19 +59,24 @@ async def test_regtest_pay_mpp(wallet: Wallet, ledger: Ledger):
             fee_reserve_sat=quote.fee_reserve,
             quote_id=quote.quote,
         )
+
     def mint_pay_mpp(invoice: str, amount: int, proofs: List[Proof]):
         asyncio.run(_mint_pay_mpp(invoice, amount, proofs))
 
     # call pay_mpp twice in parallel to pay the full invoice
-    t1 = threading.Thread(target=mint_pay_mpp, args=(invoice_payment_request, 32, proofs1))
-    t2 = threading.Thread(target=partial_pay_real_invoice, args=(invoice_payment_request, 32, 1))
+    t1 = threading.Thread(
+        target=mint_pay_mpp, args=(invoice_payment_request, 32, proofs1)
+    )
+    t2 = threading.Thread(
+        target=partial_pay_real_invoice, args=(invoice_payment_request, 32, 1)
+    )
 
     t1.start()
     t2.start()
     t1.join()
     t2.join()
 
-    assert wallet.balance <= 256 - 32
+    assert wallet.balance == 64
 
 
 @pytest.mark.asyncio
@@ -80,7 +85,7 @@ async def test_regtest_pay_mpp_incomplete_payment(wallet: Wallet, ledger: Ledger
     # make sure that mpp is supported by the bolt11-sat backend
     if not ledger.backends[Method["bolt11"]][wallet.unit].supports_mpp:
         pytest.skip("backend does not support mpp")
-    
+
     # This test cannot be done with CLN because we only have one mint
     # and CLN hates multiple partial payment requests
     if isinstance(ledger.backends[Method["bolt11"]][wallet.unit], CLNRestWallet):

--- a/tests/test_wallet_subscription.py
+++ b/tests/test_wallet_subscription.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 import pytest_asyncio
 
-from cashu.core.base import Method, MintQuoteState, ProofSpentState, ProofState
+from cashu.core.base import Method, MintQuoteState, ProofState
 from cashu.core.json_rpc.base import JSONRPCNotficationParams
 from cashu.core.nuts import WEBSOCKETS_NUT
 from cashu.core.settings import settings
@@ -54,13 +54,10 @@ async def test_wallet_subscription_mint(wallet: Wallet):
     assert triggered
     assert len(msg_stack) == 3
 
-    assert msg_stack[0].payload["paid"] is False
     assert msg_stack[0].payload["state"] == MintQuoteState.unpaid.value
 
-    assert msg_stack[1].payload["paid"] is True
     assert msg_stack[1].payload["state"] == MintQuoteState.paid.value
 
-    assert msg_stack[2].payload["paid"] is True
     assert msg_stack[2].payload["state"] == MintQuoteState.issued.value
 
 
@@ -100,16 +97,16 @@ async def test_wallet_subscription_swap(wallet: Wallet):
     pending_stack = msg_stack[:n_subscriptions]
     for msg in pending_stack:
         proof_state = ProofState.parse_obj(msg.payload)
-        assert proof_state.state == ProofSpentState.unspent
+        assert proof_state.unspent
 
     # the second one is the PENDING state
     spent_stack = msg_stack[n_subscriptions : n_subscriptions * 2]
     for msg in spent_stack:
         proof_state = ProofState.parse_obj(msg.payload)
-        assert proof_state.state == ProofSpentState.pending
+        assert proof_state.pending
 
     # the third one is the SPENT state
     spent_stack = msg_stack[n_subscriptions * 2 :]
     for msg in spent_stack:
         proof_state = ProofState.parse_obj(msg.payload)
-        assert proof_state.state == ProofSpentState.spent
+        assert proof_state.spent


### PR DESCRIPTION
This PR is to deprecate the `paid` flag in `PaymentResponse` and `PaymentStatus` in favor of a more structured `PaymentResult`, that allows for more flexibility.
I have modified the backends to fill in this new field. The main difference is we DO NOT return `SETTLED` when paying an invoice unless we get an explicit confirmation, instead we return `PENDING` and then `melt` notices this and checks the payment status.
I have also adapted the code in `get_mint_quote` and `melt` to rely on the newly added `result` field.
