### PR TITLE
Fix: Unset pending melt quote by quote id

### DIFF
--- a/cashu/lightning/lnbits.py
+++ b/cashu/lightning/lnbits.py
@@ -113,21 +113,21 @@ class LNbitsWallet(LightningBackend):
             )
             r.raise_for_status()
         except Exception:
+            error_message = r.json().get("detail") or r.reason_phrase
             return PaymentResponse(
-                result=PaymentResult.FAILED, error_message=r.json()["detail"]
+                result=PaymentResult.FAILED, error_message=error_message
             )
-        if r.status_code > 299:
-            return PaymentResponse(
-                result=PaymentResult.FAILED,
-                error_message=(f"HTTP status: {r.reason_phrase}",),
-            )
-        if "detail" in r.json():
+        if r.json().get("detail"):
             return PaymentResponse(
                 result=PaymentResult.FAILED, error_message=(r.json()["detail"],)
             )
 
         data: dict = r.json()
-        checking_id = data["payment_hash"]
+        checking_id = data.get("payment_hash")
+        if not checking_id:
+            return PaymentResponse(
+                result=PaymentResult.UNKNOWN, error_message="No payment_hash received"
+            )
 
         # we do this to get the fee and preimage
         payment: PaymentStatus = await self.get_payment_status(checking_id)

--- a/cashu/mint/db/write.py
+++ b/cashu/mint/db/write.py
@@ -211,7 +211,7 @@ class DbWriteHelper:
         async with self.db.get_connection(lock_table="melt_quotes") as conn:
             # get melt quote from db and check if it is pending
             quote_db = await self.crud.get_melt_quote(
-                checking_id=quote.checking_id, db=self.db, conn=conn
+                quote_id=quote.quote, db=self.db, conn=conn
             )
             if not quote_db:
                 raise TransactionError("Melt quote not found.")


### PR DESCRIPTION
Lookup by `checking_id` caused the wrong melt quote be loaded from db if the same invoice was attempted to be paid multiple times.

Additional cleanup of lnbits backend.