### PR TITLE
Fix: wallet include fees in swap outputs for inputs of successive melt

### DIFF
--- a/cashu/lightning/lnbits.py
+++ b/cashu/lightning/lnbits.py
@@ -87,11 +87,8 @@ class LNbitsWallet(LightningBackend):
                 url=f"{self.endpoint}/api/v1/payments", json=data
             )
             r.raise_for_status()
-        except Exception:
-            return InvoiceResponse(
-                ok=False,
-                error_message=r.json()["detail"],
-            )
+        except Exception as e:
+            return InvoiceResponse(ok=False, error_message=str(e))
 
         data = r.json()
         checking_id, payment_request = data["checking_id"], data["payment_request"]

--- a/cashu/wallet/nostr.py
+++ b/cashu/wallet/nostr.py
@@ -62,9 +62,7 @@ async def send_nostr(
         pubkey = await nip5_to_pubkey(wallet, pubkey)
     await wallet.load_mint()
     await wallet.load_proofs()
-    _, send_proofs = await wallet.swap_to_send(
-        wallet.proofs, amount, set_reserved=True, include_fees=False
-    )
+    _, send_proofs = await wallet.swap_to_send(wallet.proofs, amount, set_reserved=True)
     token = await wallet.serialize_proofs(send_proofs, include_dleq=include_dleq)
 
     if pubkey.startswith("npub"):

--- a/cashu/wallet/transactions.py
+++ b/cashu/wallet/transactions.py
@@ -36,7 +36,7 @@ class WalletTransactions(SupportsDb, SupportsKeysets):
     def get_fees_for_proofs_ppk(self, proofs: List[Proof]) -> int:
         return sum([self.keysets[p.id].input_fee_ppk for p in proofs])
 
-    async def _select_proofs_to_send(
+    async def coinselect(
         self,
         proofs: List[Proof],
         amount_to_send: Union[int, float],
@@ -59,7 +59,7 @@ class WalletTransactions(SupportsDb, SupportsKeysets):
             return []
 
         logger.trace(
-            f"_select_proofs_to_send – amount_to_send: {amount_to_send} – amounts we have: {amount_summary(proofs, self.unit)} (sum: {sum_proofs(proofs)})"
+            f"coinselect – amount_to_send: {amount_to_send} – amounts we have: {amount_summary(proofs, self.unit)} (sum: {sum_proofs(proofs)})"
         )
 
         sorted_proofs = sorted(proofs, key=lambda p: p.amount)
@@ -91,7 +91,7 @@ class WalletTransactions(SupportsDb, SupportsKeysets):
             logger.trace(
                 f"> selecting more proofs from {amount_summary(smaller_proofs[1:], self.unit)} sum: {sum_proofs(smaller_proofs[1:])} to reach {remainder}"
             )
-            selected_proofs += await self._select_proofs_to_send(
+            selected_proofs += await self.coinselect(
                 smaller_proofs[1:], remainder, include_fees=include_fees
             )
         sum_selected_proofs = sum_proofs(selected_proofs)
@@ -101,7 +101,7 @@ class WalletTransactions(SupportsDb, SupportsKeysets):
             return [next_bigger]
 
         logger.trace(
-            f"_select_proofs_to_send - selected proof amounts: {amount_summary(selected_proofs, self.unit)} (sum: {sum_proofs(selected_proofs)})"
+            f"coinselect - selected proof amounts: {amount_summary(selected_proofs, self.unit)} (sum: {sum_proofs(selected_proofs)})"
         )
         return selected_proofs
 

--- a/cashu/wallet/transactions.py
+++ b/cashu/wallet/transactions.py
@@ -36,7 +36,7 @@ class WalletTransactions(SupportsDb, SupportsKeysets):
     def get_fees_for_proofs_ppk(self, proofs: List[Proof]) -> int:
         return sum([self.keysets[p.id].input_fee_ppk for p in proofs])
 
-    async def coinselect(
+    def coinselect(
         self,
         proofs: List[Proof],
         amount_to_send: Union[int, float],
@@ -91,7 +91,7 @@ class WalletTransactions(SupportsDb, SupportsKeysets):
             logger.trace(
                 f"> selecting more proofs from {amount_summary(smaller_proofs[1:], self.unit)} sum: {sum_proofs(smaller_proofs[1:])} to reach {remainder}"
             )
-            selected_proofs += await self.coinselect(
+            selected_proofs += self.coinselect(
                 smaller_proofs[1:], remainder, include_fees=include_fees
             )
         sum_selected_proofs = sum_proofs(selected_proofs)
@@ -104,6 +104,10 @@ class WalletTransactions(SupportsDb, SupportsKeysets):
             f"coinselect - selected proof amounts: {amount_summary(selected_proofs, self.unit)} (sum: {sum_proofs(selected_proofs)})"
         )
         return selected_proofs
+
+    def coinselect_fee(self, proofs: List[Proof], amount: int) -> int:
+        proofs_send = self.coinselect(proofs, amount, include_fees=True)
+        return self.get_fees_for_proofs(proofs_send)
 
     async def set_reserved(self, proofs: List[Proof], reserved: bool) -> None:
         """Mark a proof as reserved or reset it in the wallet db to avoid reuse when it is sent.

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -667,7 +667,7 @@ class Wallet(
         # create a suitable amount lists to keep and send based on the proofs
         # provided and the state of the wallet
         keep_outputs, send_outputs = self.determine_output_amounts(
-            proofs, amount, include_fees_to_send=False, keyset_id_outputs=self.keyset_id
+            proofs, amount, include_fees_to_send=True, keyset_id_outputs=self.keyset_id
         )
 
         amounts = keep_outputs + send_outputs

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -667,7 +667,7 @@ class Wallet(
         # create a suitable amount lists to keep and send based on the proofs
         # provided and the state of the wallet
         keep_outputs, send_outputs = self.determine_output_amounts(
-            proofs, amount, include_fees_to_send=True, keyset_id_outputs=self.keyset_id
+            proofs, amount, include_fees_to_send=False, keyset_id_outputs=self.keyset_id
         )
 
         amounts = keep_outputs + send_outputs

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -1078,7 +1078,7 @@ class Wallet(
             raise Exception("balance too low.")
 
         # coin selection for potentially offline sending
-        send_proofs = await self.coinselect(proofs, amount, include_fees=include_fees)
+        send_proofs = self.coinselect(proofs, amount, include_fees=include_fees)
         fees = self.get_fees_for_proofs(send_proofs)
         logger.trace(
             f"select_to_send: selected: {self.unit.str(sum_proofs(send_proofs))} (+ {self.unit.str(fees)} fees) – wanted: {self.unit.str(amount)}"
@@ -1136,7 +1136,7 @@ class Wallet(
             raise Exception("balance too low.")
 
         # coin selection for swapping, needs to include fees
-        swap_proofs = await self.coinselect(proofs, amount, include_fees=True)
+        swap_proofs = self.coinselect(proofs, amount, include_fees=True)
 
         # Extra rule: add proofs from inactive keysets to swap_proofs to get rid of them
         swap_proofs += [

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -1096,7 +1096,7 @@ class Wallet(
                     proofs,
                     amount,
                     set_reserved=False,
-                    include_fees_to_send=include_fees,
+                    include_fees=include_fees,
                 )
             else:
                 raise Exception(
@@ -1114,7 +1114,7 @@ class Wallet(
         *,
         secret_lock: Optional[Secret] = None,
         set_reserved: bool = False,
-        include_fees_to_send: bool = True,
+        include_fees: bool = False,
     ) -> Tuple[List[Proof], List[Proof]]:
         """
         Swaps a set of proofs with the mint to get a set that sums up to a desired amount that can be sent. The remaining
@@ -1129,6 +1129,7 @@ class Wallet(
             set_reserved (bool, optional): If set, the proofs are marked as reserved. Should be set to False if a payment attempt
                 is made with the split that could fail (like a Lightning payment). Should be set to True if the token to be sent is
                 displayed to the user to be then sent to someone else. Defaults to False.
+            include_fees (bool, optional): If set, the fees for spending the send_proofs later are included in the amount to be selected. Defaults to True.
 
         Returns:
             Tuple[List[Proof], List[Proof]]: Tuple of proofs to keep and proofs to send
@@ -1154,7 +1155,7 @@ class Wallet(
             f"Amount to send: {self.unit.str(amount)} (+ {self.unit.str(fees)} fees)"
         )
         keep_proofs, send_proofs = await self.split(
-            swap_proofs, amount, secret_lock, include_fees_to_send
+            swap_proofs, amount, secret_lock, include_fees
         )
         if set_reserved:
             await self.set_reserved(send_proofs, reserved=True)

--- a/tests/test_mint_fees.py
+++ b/tests/test_mint_fees.py
@@ -129,7 +129,9 @@ async def test_wallet_swap_to_send_with_fee(wallet1: Wallet, ledger: Ledger):
 
     # quirk: this should call a `/v1/swap` with the mint but the mint will
     # throw an error since the fees are only changed in the `ledger` instance, not in the uvicorn API server
-    # this *should* succeed normally
+    # this *should* succeed if the fees were set in the API server
+    # at least, we can verify that the wallet is correctly computing the fees
+    # by asserting for this super specific error message from the (API server) mint
     await assert_err(
         wallet1.select_to_send(wallet1.proofs, 10),
         "Mint Error: inputs (32) - fees (0) vs outputs (31) are not balanced.",

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -254,7 +254,7 @@ async def test_swap_to_send(wallet1: Wallet):
     assert_amt(send_proofs, 32)
     assert_amt(keep_proofs, 0)
 
-    spendable_proofs = await wallet1._select_proofs_to_send(wallet1.proofs, 32)
+    spendable_proofs = await wallet1.coinselect(wallet1.proofs, 32)
     assert sum_proofs(spendable_proofs) == 32
 
     assert sum_proofs(send_proofs) == 32

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -254,7 +254,7 @@ async def test_swap_to_send(wallet1: Wallet):
     assert_amt(send_proofs, 32)
     assert_amt(keep_proofs, 0)
 
-    spendable_proofs = await wallet1.coinselect(wallet1.proofs, 32)
+    spendable_proofs = wallet1.coinselect(wallet1.proofs, 32)
     assert sum_proofs(spendable_proofs) == 32
 
     assert sum_proofs(send_proofs) == 32


### PR DESCRIPTION
For keysets with fees, in cases where a melt requires a swap, the wallet did not include the ecash fees in the outputs generated by that swap.