### PR TITLE
Fix: ledger requires deprecated `paid` flags in db + wallet disable base64 keysets by default

### DIFF
--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -8,7 +8,7 @@ from pydantic import BaseSettings, Extra, Field
 
 env = Env()
 
-VERSION = "0.16.0"
+VERSION = "0.16.1"
 
 
 def find_env_file():
@@ -62,6 +62,10 @@ class MintSettings(CashuSettings):
     mint_max_secret_length: int = Field(default=512)
 
     mint_input_fee_ppk: int = Field(default=0)
+
+
+class MintDeprecationFlags(MintSettings):
+    mint_inactivate_base64_keysets: bool = Field(default=False)
 
 
 class MintBackends(MintSettings):
@@ -186,9 +190,9 @@ class WalletSettings(CashuSettings):
     wallet_target_amount_count: int = Field(default=3)
 
 
-class WalletFeatures(CashuSettings):
-    wallet_inactivate_legacy_keysets: bool = Field(
-        default=False,
+class WalletDeprecationFlags(CashuSettings):
+    wallet_inactivate_base64_keysets: bool = Field(
+        default=True,
         title="Inactivate legacy base64 keysets",
         description="If you turn on this flag, old bas64 keysets will be ignored and the wallet will ony use new keyset versions.",
     )
@@ -232,10 +236,11 @@ class Settings(
     FakeWalletSettings,
     MintLimits,
     MintBackends,
+    MintDeprecationFlags,
     MintSettings,
     MintInformation,
     WalletSettings,
-    WalletFeatures,
+    WalletDeprecationFlags,
     CashuSettings,
 ):
     version: str = Field(default=VERSION)

--- a/cashu/mint/crud.py
+++ b/cashu/mint/crud.py
@@ -543,8 +543,8 @@ class LedgerCrudSqlite(LedgerCrud):
         await (conn or db).execute(
             f"""
             INSERT INTO {db.table_with_schema('melt_quotes')}
-            (quote, method, request, checking_id, unit, amount, fee_reserve, state, created_time, paid_time, fee_paid, proof, change, expiry)
-            VALUES (:quote, :method, :request, :checking_id, :unit, :amount, :fee_reserve, :state, :created_time, :paid_time, :fee_paid, :proof, :change, :expiry)
+            (quote, method, request, checking_id, unit, amount, fee_reserve, state, paid, created_time, paid_time, fee_paid, proof, change, expiry)
+            VALUES (:quote, :method, :request, :checking_id, :unit, :amount, :fee_reserve, :state, :paid, :created_time, :paid_time, :fee_paid, :proof, :change, :expiry)
             """,
             {
                 "quote": quote.quote,
@@ -555,6 +555,7 @@ class LedgerCrudSqlite(LedgerCrud):
                 "amount": quote.amount,
                 "fee_reserve": quote.fee_reserve or 0,
                 "state": quote.state.name,
+                "paid": quote.paid,  # this is deprecated! we need to store it because we have a NOT NULL constraint | we could also remove the column but sqlite doesn't support that (we would have to make a new table)
                 "created_time": db.to_timestamp(
                     db.timestamp_from_seconds(quote.created_time) or ""
                 ),

--- a/cashu/mint/crud.py
+++ b/cashu/mint/crud.py
@@ -117,6 +117,16 @@ class LedgerCrud(ABC):
         ...
 
     @abstractmethod
+    async def update_keyset(
+        self,
+        *,
+        db: Database,
+        keyset: MintKeyset,
+        conn: Optional[Connection] = None,
+    ) -> None:
+        ...
+
+    @abstractmethod
     async def get_balance(
         self,
         db: Database,
@@ -433,8 +443,8 @@ class LedgerCrudSqlite(LedgerCrud):
         await (conn or db).execute(
             f"""
             INSERT INTO {db.table_with_schema('mint_quotes')}
-            (quote, method, request, checking_id, unit, amount, issued, state, created_time, paid_time)
-            VALUES (:quote, :method, :request, :checking_id, :unit, :amount, :issued, :state, :created_time, :paid_time)
+            (quote, method, request, checking_id, unit, amount, paid, issued, state, created_time, paid_time)
+            VALUES (:quote, :method, :request, :checking_id, :unit, :amount, :paid, :issued, :state, :created_time, :paid_time)
             """,
             {
                 "quote": quote.quote,
@@ -443,6 +453,7 @@ class LedgerCrudSqlite(LedgerCrud):
                 "checking_id": quote.checking_id,
                 "unit": quote.unit,
                 "amount": quote.amount,
+                "paid": quote.paid,  # this is deprecated! we need to store it because we have a NOT NULL constraint | we could also remove the column but sqlite doesn't support that (we would have to make a new table)
                 "issued": quote.issued,  # this is deprecated! we need to store it because we have a NOT NULL constraint | we could also remove the column but sqlite doesn't support that (we would have to make a new table)
                 "state": quote.state.name,
                 "created_time": db.to_timestamp(
@@ -625,9 +636,11 @@ class LedgerCrudSqlite(LedgerCrud):
                     db.timestamp_from_seconds(quote.paid_time) or ""
                 ),
                 "proof": quote.payment_preimage,
-                "change": json.dumps([s.dict() for s in quote.change])
-                if quote.change
-                else None,
+                "change": (
+                    json.dumps([s.dict() for s in quote.change])
+                    if quote.change
+                    else None
+                ),
                 "quote": quote.quote,
                 "checking_id": quote.checking_id,
             },
@@ -719,6 +732,39 @@ class LedgerCrudSqlite(LedgerCrud):
             values,
         )
         return [MintKeyset(**row) for row in rows]
+
+    async def update_keyset(
+        self,
+        *,
+        db: Database,
+        keyset: MintKeyset,
+        conn: Optional[Connection] = None,
+    ) -> None:
+        await (conn or db).execute(
+            f"""
+            UPDATE {db.table_with_schema('keysets')}
+            SET seed = :seed, encrypted_seed = :encrypted_seed, seed_encryption_method = :seed_encryption_method, derivation_path = :derivation_path, valid_from = :valid_from, valid_to = :valid_to, first_seen = :first_seen, active = :active, version = :version, unit = :unit, input_fee_ppk = :input_fee_ppk
+            WHERE id = :id
+            """,
+            {
+                "id": keyset.id,
+                "seed": keyset.seed,
+                "encrypted_seed": keyset.encrypted_seed,
+                "seed_encryption_method": keyset.seed_encryption_method,
+                "derivation_path": keyset.derivation_path,
+                "valid_from": db.to_timestamp(
+                    keyset.valid_from or db.timestamp_now_str()
+                ),
+                "valid_to": db.to_timestamp(keyset.valid_to or db.timestamp_now_str()),
+                "first_seen": db.to_timestamp(
+                    keyset.first_seen or db.timestamp_now_str()
+                ),
+                "active": keyset.active,
+                "version": keyset.version,
+                "unit": keyset.unit.name,
+                "input_fee_ppk": keyset.input_fee_ppk,
+            },
+        )
 
     async def get_proofs_used(
         self,

--- a/cashu/mint/migrations.py
+++ b/cashu/mint/migrations.py
@@ -288,6 +288,7 @@ async def m011_add_quote_tables(db: Database):
                     checking_id TEXT NOT NULL,
                     unit TEXT NOT NULL,
                     amount {db.big_int} NOT NULL,
+                    paid BOOL NOT NULL,
                     issued BOOL NOT NULL,
                     created_time TIMESTAMP,
                     paid_time TIMESTAMP,
@@ -296,7 +297,6 @@ async def m011_add_quote_tables(db: Database):
 
                 );
             """
-            # NOTE: We remove the paid BOOL NOT NULL column
         )
 
         await conn.execute(
@@ -309,6 +309,7 @@ async def m011_add_quote_tables(db: Database):
                     unit TEXT NOT NULL,
                     amount {db.big_int} NOT NULL,
                     fee_reserve {db.big_int},
+                    paid BOOL NOT NULL,
                     created_time TIMESTAMP,
                     paid_time TIMESTAMP,
                     fee_paid {db.big_int},
@@ -318,14 +319,13 @@ async def m011_add_quote_tables(db: Database):
 
                 );
             """
-            # NOTE: We remove the paid BOOL NOT NULL column
         )
 
         await conn.execute(
             f"INSERT INTO {db.table_with_schema('mint_quotes')} (quote, method,"
-            " request, checking_id, unit, amount, issued, created_time,"
+            " request, checking_id, unit, amount, paid, issued, created_time,"
             " paid_time) SELECT id, 'bolt11', bolt11, COALESCE(payment_hash, 'None'),"
-            f" 'sat', amount, issued, COALESCE(created, '{db.timestamp_now_str()}'),"
+            f" 'sat', amount, False, issued, COALESCE(created, '{db.timestamp_now_str()}'),"
             f" NULL FROM {db.table_with_schema('invoices')} "
         )
 


### PR DESCRIPTION
wallet: turn on flag for deprecate base64 keysets by default
wallet: fix `no_name` wallet that started receiving proofs (Fixes #615)
ledger: fix issue with existing `paid` flag in mint and melt quotes
ledger: method to disable base64 keysets with a flag (default False)
