### PR TITLE
Add get quote API to wallet + check proof states in batches

### DIFF
--- a/cashu/wallet/v1_api.py
+++ b/cashu/wallet/v1_api.py
@@ -170,7 +170,7 @@ class LedgerAPI(LedgerAPIDeprecated):
         keys_dict: dict = resp.json()
         assert len(keys_dict), Exception("did not receive any keys")
         keys = KeysResponse.parse_obj(keys_dict)
-        keysets_str = ' '.join([f"{k.id} ({k.unit})" for k in keys.keysets])
+        keysets_str = " ".join([f"{k.id} ({k.unit})" for k in keys.keysets])
         logger.debug(f"Received {len(keys.keysets)} keysets from mint: {keysets_str}.")
         ret = [
             WalletKeyset(
@@ -314,6 +314,24 @@ class LedgerAPI(LedgerAPIDeprecated):
 
     @async_set_httpx_client
     @async_ensure_mint_loaded
+    async def get_mint_quote(self, quote: str) -> PostMintQuoteResponse:
+        """Returns an existing mint quote from the server.
+
+        Args:
+            quote (str): Quote ID
+
+        Returns:
+            PostMintQuoteResponse: Mint Quote Response
+        """
+        resp = await self.httpx.get(
+            join(self.url, f"/v1/mint/quote/bolt11/{quote}"),
+        )
+        self.raise_on_error_request(resp)
+        return_dict = resp.json()
+        return PostMintQuoteResponse.parse_obj(return_dict)
+
+    @async_set_httpx_client
+    @async_ensure_mint_loaded
     async def mint(
         self, outputs: List[BlindedMessage], quote: str
     ) -> List[BlindedSignature]:
@@ -396,6 +414,24 @@ class LedgerAPI(LedgerAPIDeprecated):
                 expiry=invoice_obj.expiry,
             )
         # END backwards compatibility < 0.15.0
+        self.raise_on_error_request(resp)
+        return_dict = resp.json()
+        return PostMeltQuoteResponse.parse_obj(return_dict)
+
+    @async_set_httpx_client
+    @async_ensure_mint_loaded
+    async def get_melt_quote(self, quote: str) -> PostMeltQuoteResponse:
+        """Returns an existing melt quote from the server.
+
+        Args:
+            quote (str): Quote ID
+
+        Returns:
+            PostMeltQuoteResponse: Melt Quote Response
+        """
+        resp = await self.httpx.get(
+            join(self.url, f"/v1/melt/quote/bolt11/{quote}"),
+        )
         self.raise_on_error_request(resp)
         return_dict = resp.json()
         return PostMeltQuoteResponse.parse_obj(return_dict)

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -170,7 +170,7 @@ async def test_mint(wallet1: Wallet):
     await pay_if_regtest(invoice.bolt11)
     quote_resp = await wallet1.get_mint_quote(invoice.id)
     assert quote_resp.request == invoice.bolt11
-    assert quote_resp.state == MintQuoteState.pending.value
+    assert quote_resp.state == MintQuoteState.paid.value
 
     expected_proof_amounts = wallet1.split_wallet_state(64)
     await wallet1.mint(64, id=invoice.id)

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -168,7 +168,7 @@ async def test_request_mint(wallet1: Wallet):
 async def test_mint(wallet1: Wallet):
     invoice = await wallet1.request_mint(64)
     await pay_if_regtest(invoice.bolt11)
-    quote_resp = await wallet1.get_mint_quote(invoice.bolt11)
+    quote_resp = await wallet1.get_mint_quote(invoice.id)
     assert quote_resp.request == invoice.bolt11
     assert quote_resp.state == MintQuoteState.pending.value
 

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -168,9 +168,10 @@ async def test_request_mint(wallet1: Wallet):
 async def test_mint(wallet1: Wallet):
     invoice = await wallet1.request_mint(64)
     await pay_if_regtest(invoice.bolt11)
-    quote_resp = await wallet1.get_mint_quote(invoice.id)
-    assert quote_resp.request == invoice.bolt11
-    assert quote_resp.state == MintQuoteState.paid.value
+    if not settings.debug_mint_only_deprecated:
+        quote_resp = await wallet1.get_mint_quote(invoice.id)
+        assert quote_resp.request == invoice.bolt11
+        assert quote_resp.state == MintQuoteState.paid.value
 
     expected_proof_amounts = wallet1.split_wallet_state(64)
     await wallet1.mint(64, id=invoice.id)
@@ -311,8 +312,9 @@ async def test_melt(wallet1: Wallet):
         assert total_amount == 64
         assert quote.fee_reserve == 0
 
-    quote_resp = await wallet1.get_melt_quote(quote.quote)
-    assert quote_resp.amount == quote.amount
+    if not settings.debug_mint_only_deprecated:
+        quote_resp = await wallet1.get_melt_quote(quote.quote)
+        assert quote_resp.amount == quote.amount
 
     _, send_proofs = await wallet1.swap_to_send(wallet1.proofs, total_amount)
 

--- a/tests/test_wallet_cli.py
+++ b/tests/test_wallet_cli.py
@@ -110,6 +110,9 @@ def test_balance(cli_prefix):
 
 @pytest.mark.skipif(is_regtest, reason="only works with FakeWallet")
 def test_invoice(mint, cli_prefix):
+    if settings.debug_mint_only_deprecated:
+        pytest.skip("only works with v1 API")
+
     runner = CliRunner()
     result = runner.invoke(
         cli,


### PR DESCRIPTION
This pull request introduces a new API endpoint to retrieve mint and melt quotes from the wallet. The `get_mint_quote` and `get_melt_quote` methods have been added to fetch existing quotes based on their IDs. Additionally, the minting process now checks the state of the mint quote before proceeding, ensuring that actions are only taken when the quote is valid. Tests have been updated to verify the functionality of the new API and its integration with existing processes.