### PR TITLE
Wallet check payment hash

### DIFF
--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -11,8 +11,8 @@ from os import listdir
 from os.path import isdir, join
 from typing import Optional, Union
 
-import click
 import bolt11
+import click
 from click import Context
 from loguru import logger
 
@@ -41,12 +41,12 @@ from ..cli.cli_helpers import (
     verify_mint,
 )
 from ..helpers import (
+    check_payment_preimage,
     deserialize_token_from_string,
     init_wallet,
     list_mints,
     receive,
     send,
-    check_payment_preimage,
 )
 from ..nostr import receive_nostr, send_nostr
 from ..subscriptions import SubscriptionManager

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -247,10 +247,10 @@ async def pay(
             and melt_response.payment_preimage != "0" * 64
         ):
             if not check_payment_preimage(payment_hash, melt_response.payment_preimage):
-                print("\nINVALID PAYMENT PREIMAGE!")
+                print(" Error: Invalid preimage!", end="", flush=True)
             print(f" (Preimage: {melt_response.payment_preimage}).")
         else:
-            print(" Mint did not provide a payment preimage.")
+            print(" Mint did not provide a preimage.")
     elif MintQuoteState(melt_response.state) == MintQuoteState.pending:
         print(" Invoice pending.")
     elif MintQuoteState(melt_response.state) == MintQuoteState.unpaid:

--- a/cashu/wallet/helpers.py
+++ b/cashu/wallet/helpers.py
@@ -1,6 +1,7 @@
 import os
 from typing import Optional
 
+import hashlib
 from loguru import logger
 
 from ..core.base import Token, TokenV3, TokenV4
@@ -169,3 +170,11 @@ async def send(
 
     await wallet.set_reserved(send_proofs, reserved=True)
     return wallet.available_balance, token
+
+def check_payment_preimage(
+    payment_hash: str,
+    preimage: str,
+) -> bool:
+    return bytes.fromhex(payment_hash) == hashlib.sha256(
+        bytes.fromhex(preimage)
+    ).digest()

--- a/cashu/wallet/helpers.py
+++ b/cashu/wallet/helpers.py
@@ -1,7 +1,7 @@
+import hashlib
 import os
 from typing import Optional
 
-import hashlib
 from loguru import logger
 
 from ..core.base import Token, TokenV3, TokenV4


### PR DESCRIPTION
Check the payment hash after a melt.
Print a ominous message if the preimage is invalid.