### PR TITLE
sort split from split_wallet_state

### DIFF
--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -476,6 +476,7 @@ class Wallet(
         remaining_amount = amount - sum(amounts)
         if remaining_amount > 0:
             amounts += amount_split(remaining_amount)
+        amounts.sort()
 
         logger.debug(f"Amounts we want: {amounts}")
         if sum(amounts) != amount:


### PR DESCRIPTION
`split_wallet_state` method is returning an unsorted split. Sorting it so that blinded messages in mint request are sorted.