### PR TITLE
SQLite WAL mode for journaling

### DIFF
--- a/cashu/mint/migrations.py
+++ b/cashu/mint/migrations.py
@@ -839,6 +839,7 @@ async def m022_quote_set_states_to_values(db: Database):
                 f"UPDATE {db.table_with_schema('mint_quotes')} SET state = '{mint_quote_states.value}' WHERE state = '{mint_quote_states.name}'"
             )
 
+
 async def m023_add_key_to_mint_quote_table(db: Database):
     async with db.connect() as conn:
         await conn.execute(
@@ -847,3 +848,8 @@ async def m023_add_key_to_mint_quote_table(db: Database):
                 ADD COLUMN pubkey TEXT DEFAULT NULL
             """
         )
+
+
+async def m024_add_pragma_journal_mode(db: Database):
+    async with db.connect() as conn:
+        await conn.execute("PRAGMA journal_mode=WAL")


### PR DESCRIPTION
Add support for Write-Ahead Logging (WAL) mode in SQLite by executing the appropriate PRAGMA command. This change enhances database performance and concurrency.