### PR TITLE
Add restart policy for Redis Docker container

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,3 +6,4 @@ services:
     container_name: redis
     ports:
       - "6379:6379"
+    restart: always


### PR DESCRIPTION
Add a restart policy to ensure the Redis Docker container restarts automatically.