### PR TITLE
Issue NUT-08 overpaid Lightning fees for melt quote checks on startup

### DIFF
--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -308,11 +308,11 @@ class MeltQuote(LedgerEvent):
 
         # parse change from row as json
         change = None
-        if row["change"]:
+        if "change" in row.keys() and row["change"]:
             change = json.loads(row["change"])
 
         outputs = None
-        if row["outputs"]:
+        if "outputs" in row.keys() and row["outputs"]:
             outputs = json.loads(row["outputs"])
 
         return cls(

--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -287,6 +287,7 @@ class MeltQuote(LedgerEvent):
     fee_paid: int = 0
     payment_preimage: Optional[str] = None
     expiry: Optional[int] = None
+    outputs: Optional[List[BlindedMessage]] = None
     change: Optional[List[BlindedSignature]] = None
     mint: Optional[str] = None
 
@@ -310,6 +311,10 @@ class MeltQuote(LedgerEvent):
         if row["change"]:
             change = json.loads(row["change"])
 
+        outputs = None
+        if row["outputs"]:
+            outputs = json.loads(row["outputs"])
+
         return cls(
             quote=row["quote"],
             method=row["method"],
@@ -322,6 +327,7 @@ class MeltQuote(LedgerEvent):
             created_time=created_time,
             paid_time=paid_time,
             fee_paid=row["fee_paid"],
+            outputs=outputs,
             change=change,
             expiry=expiry,
             payment_preimage=payment_preimage,

--- a/cashu/mint/crud.py
+++ b/cashu/mint/crud.py
@@ -440,7 +440,7 @@ class LedgerCrudSqlite(LedgerCrud):
                 "paid_time": db.to_timestamp(
                     db.timestamp_from_seconds(quote.paid_time) or ""
                 ),
-                "pubkey": quote.pubkey or ""
+                "pubkey": quote.pubkey or "",
             },
         )
 
@@ -522,8 +522,8 @@ class LedgerCrudSqlite(LedgerCrud):
         await (conn or db).execute(
             f"""
             INSERT INTO {db.table_with_schema('melt_quotes')}
-            (quote, method, request, checking_id, unit, amount, fee_reserve, state, paid, created_time, paid_time, fee_paid, proof, change, expiry)
-            VALUES (:quote, :method, :request, :checking_id, :unit, :amount, :fee_reserve, :state, :paid, :created_time, :paid_time, :fee_paid, :proof, :change, :expiry)
+            (quote, method, request, checking_id, unit, amount, fee_reserve, state, paid, created_time, paid_time, fee_paid, proof, outputs, change, expiry)
+            VALUES (:quote, :method, :request, :checking_id, :unit, :amount, :fee_reserve, :state, :paid, :created_time, :paid_time, :fee_paid, :proof, :outputs, :change, :expiry)
             """,
             {
                 "quote": quote.quote,
@@ -543,6 +543,7 @@ class LedgerCrudSqlite(LedgerCrud):
                 ),
                 "fee_paid": quote.fee_paid,
                 "proof": quote.payment_preimage,
+                "outputs": json.dumps(quote.outputs) if quote.outputs else None,
                 "change": json.dumps(quote.change) if quote.change else None,
                 "expiry": db.to_timestamp(
                     db.timestamp_from_seconds(quote.expiry) or ""
@@ -607,7 +608,7 @@ class LedgerCrudSqlite(LedgerCrud):
     ) -> None:
         await (conn or db).execute(
             f"""
-            UPDATE {db.table_with_schema('melt_quotes')} SET state = :state, fee_paid = :fee_paid, paid_time = :paid_time, proof = :proof, change = :change, checking_id = :checking_id WHERE quote = :quote
+            UPDATE {db.table_with_schema('melt_quotes')} SET state = :state, fee_paid = :fee_paid, paid_time = :paid_time, proof = :proof, outputs = :outputs, change = :change, checking_id = :checking_id WHERE quote = :quote
             """,
             {
                 "state": quote.state.value,
@@ -616,6 +617,11 @@ class LedgerCrudSqlite(LedgerCrud):
                     db.timestamp_from_seconds(quote.paid_time) or ""
                 ),
                 "proof": quote.payment_preimage,
+                "outputs": (
+                    json.dumps([s.dict() for s in quote.outputs])
+                    if quote.outputs
+                    else None
+                ),
                 "change": (
                     json.dumps([s.dict() for s in quote.change])
                     if quote.change

--- a/cashu/mint/db/write.py
+++ b/cashu/mint/db/write.py
@@ -163,7 +163,7 @@ class DbWriteHelper:
                 raise TransactionError(
                     f"Mint quote not pending: {quote.state.value}. Cannot set as {state.value}."
                 )
-            # set the quote as pending
+            # set the quote to previous state
             quote.state = state
             logger.trace(f"crud: setting quote {quote_id} as {state.value}")
             await self.crud.update_mint_quote(quote=quote, db=self.db, conn=conn)
@@ -196,7 +196,6 @@ class DbWriteHelper:
                 raise TransactionError("Melt quote already pending.")
             # set the quote as pending
             quote_copy.state = MeltQuoteState.pending
-
             if outputs:
                 quote_copy.outputs = outputs
             await self.crud.update_melt_quote(quote=quote_copy, db=self.db, conn=conn)
@@ -223,7 +222,7 @@ class DbWriteHelper:
                 raise TransactionError("Melt quote not found.")
             if quote_db.state != MeltQuoteState.pending:
                 raise TransactionError("Melt quote not pending.")
-            # set the quote as pending
+            # set the quote to previous state
             quote_copy.state = state
 
             # unset outputs

--- a/cashu/mint/migrations.py
+++ b/cashu/mint/migrations.py
@@ -839,11 +839,22 @@ async def m022_quote_set_states_to_values(db: Database):
                 f"UPDATE {db.table_with_schema('mint_quotes')} SET state = '{mint_quote_states.value}' WHERE state = '{mint_quote_states.name}'"
             )
 
+
 async def m023_add_key_to_mint_quote_table(db: Database):
     async with db.connect() as conn:
         await conn.execute(
             f"""
                 ALTER TABLE {db.table_with_schema('mint_quotes')}
                 ADD COLUMN pubkey TEXT DEFAULT NULL
+            """
+        )
+
+
+async def m024_add_melt_quote_outputs(db: Database):
+    async with db.connect() as conn:
+        await conn.execute(
+            f"""
+                ALTER TABLE {db.table_with_schema('melt_quotes')}
+                ADD COLUMN outputs TEXT DEFAULT NULL
             """
         )

--- a/cashu/wallet/transactions.py
+++ b/cashu/wallet/transactions.py
@@ -86,9 +86,9 @@ class WalletTransactions(SupportsDb, SupportsKeysets):
         remainder = amount_to_send
         selected_proofs = [smaller_proofs[0]]
         fee_ppk = self.get_fees_for_proofs_ppk(selected_proofs) if include_fees else 0
-        logger.debug(f"adding proof: {smaller_proofs[0].amount} – fee: {fee_ppk} ppk")
+        logger.trace(f"adding proof: {smaller_proofs[0].amount} – fee: {fee_ppk} ppk")
         remainder -= smaller_proofs[0].amount - fee_ppk / 1000
-        logger.debug(f"remainder: {remainder}")
+        logger.trace(f"remainder: {remainder}")
         if remainder > 0:
             logger.trace(
                 f"> selecting more proofs from {amount_summary(smaller_proofs[1:], self.unit)} sum: {sum_proofs(smaller_proofs[1:])} to reach {remainder}"

--- a/tests/test_mint_init.py
+++ b/tests/test_mint_init.py
@@ -452,18 +452,19 @@ async def test_startup_regtest_pending_quote_unknown(wallet: Wallet, ledger: Led
 
     await asyncio.sleep(SLEEP_TIME)
 
-    # run startup routinge
+    # run startup routine
     await ledger.startup_ledger()
 
-    # expect that no melt quote is pending
+    # expect that melt quote is still pending
     melt_quotes = await ledger.crud.get_all_melt_quotes_from_pending_proofs(
         db=ledger.db
     )
-    assert not melt_quotes
+    assert melt_quotes
+    assert melt_quotes[0].state == MeltQuoteState.pending
 
-    # expect that proofs are unspent
+    # expect that proofs are pending
     states = await ledger.db_read.get_proofs_states([p.Y for p in send_proofs])
-    assert all([s.unspent for s in states])
+    assert all([s.pending for s in states])
 
     # clean up
     cancel_invoice(preimage_hash=preimage_hash)

--- a/tests/test_mint_init.py
+++ b/tests/test_mint_init.py
@@ -239,6 +239,7 @@ async def test_startup_fakewallet_pending_quote_pending(ledger: Ledger):
 @pytest.mark.asyncio
 @pytest.mark.skipif(is_regtest, reason="only for fake wallet")
 async def test_startup_fakewallet_pending_quote_unknown(ledger: Ledger):
+    # unknown state simulates a failure th check the lightning backend
     pending_proof, quote = await create_pending_melts(ledger)
     states = await ledger.db_read.get_proofs_states([pending_proof.Y])
     assert states[0].pending
@@ -250,11 +251,12 @@ async def test_startup_fakewallet_pending_quote_unknown(ledger: Ledger):
     melt_quotes = await ledger.crud.get_all_melt_quotes_from_pending_proofs(
         db=ledger.db
     )
-    assert not melt_quotes
+    assert melt_quotes
+    assert melt_quotes[0].state == MeltQuoteState.pending
 
     # expect that proofs are still pending
     states = await ledger.db_read.get_proofs_states([pending_proof.Y])
-    assert states[0].unspent
+    assert states[0].pending
 
 
 @pytest.mark.asyncio

--- a/tests/test_mint_melt.py
+++ b/tests/test_mint_melt.py
@@ -167,8 +167,8 @@ async def test_fakewallet_pending_quote_get_melt_quote_unknown(ledger: Ledger):
     assert states[0].pending
     settings.fakewallet_payment_state = PaymentResult.UNKNOWN.name
 
-    # get_melt_quote(..., purge_unknown=True) should check the payment status and update the db
-    quote2 = await ledger.get_melt_quote(quote_id=quote.quote, purge_unknown=True)
+    # get_melt_quote(..., rollback_unknown=True) should check the payment status and update the db
+    quote2 = await ledger.get_melt_quote(quote_id=quote.quote, rollback_unknown=True)
     assert quote2.state == MeltQuoteState.unpaid
 
     # expect that pending tokens are still in db


### PR DESCRIPTION
Nutshell used to "eat up" overpaid fees in cases where the connection to the Lightning backend might have failed during an ongoing payment. 

Now, the `outputs` provided with a melt operation are stored in the db and the `change` is issued on the melt quote if the startup task detects that a melt quote has been paid while the mint had no connection to the Lightning backend.