### PR TITLE
config cleanup regarding MPP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,10 +90,6 @@ MINT_LND_REST_CERT="/home/lnd/.lnd/tls.cert"
 MINT_LND_REST_MACAROON="/home/lnd/.lnd/data/chain/bitcoin/regtest/admin.macaroon"
 MINT_LND_REST_CERT_VERIFY=True
 
-# Use with LND
-# This setting enables MPP support for Partial multi-path payments (NUT-15)
-MINT_LND_ENABLE_MPP=TRUE
-
 # Use with CLNRestWallet
 MINT_CLNREST_URL=https://localhost:3010
 MINT_CLNREST_CERT="./clightning-2/regtest/ca.pem"

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -71,7 +71,6 @@ jobs:
           MINT_CLNREST_URL: https://localhost:3010
           MINT_CLNREST_RUNE: ./regtest/data/clightning-2/rune
           MINT_CLNREST_CERT: ./regtest/data/clightning-2/regtest/ca.pem
-          MINT_CLNREST_ENABLE_MPP: false
         run: |
           sudo chmod -R 777 .
           make test

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -63,12 +63,6 @@ jobs:
           MINT_LND_RPC_ENDPOINT: localhost:10009
           MINT_LND_RPC_CERT: ./regtest/data/lnd-3/tls.cert
           MINT_LND_RPC_MACAROON: ./regtest/data/lnd-3/data/chain/bitcoin/regtest/admin.macaroon
-
-          MINT_LND_ENABLE_MPP: true
-          #   LND_GRPC_ENDPOINT: localhost
-          #   LND_GRPC_PORT: 10009
-          #   LND_GRPC_CERT: ./regtest/data/lnd-3/tls.cert
-          #   LND_GRPC_MACAROON: ./regtest/data/lnd-3/data/chain/bitcoin/regtest/admin.macaroon
           # CoreLightningRestWallet
           MINT_CORELIGHTNING_REST_URL: https://localhost:3001
           MINT_CORELIGHTNING_REST_MACAROON: ./regtest/data/clightning-2-rest/access.macaroon


### PR DESCRIPTION
* first two commits are straightforward, they just remove MINT_LND_ENABLE_MPP=True in `.env.example` and `.github/workflows/regtest.yml` since this is default since PR [#667](https://github.com/cashubtc/nutshell/pull/667/commits/457ac30823b3a2f6d2cd448156b8a0fcd0f41867)
* the third commit removes `MINT_CLNREST_ENABLE_MPP: false` from `.github/workflows/regtest.yml` because we probably want to test the default behaviour (which is also True since PR [#667](https://github.com/cashubtc/nutshell/pull/667/commits/457ac30823b3a2f6d2cd448156b8a0fcd0f41867))

Or is there any particular reason why want to keep MPP disabled for CLN in the CI?