### PR TITLE
[FIX] Reject Internal MPP Melt Quote Requests

### DIFF
--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -668,6 +668,10 @@ class Ledger(LedgerVerification, LedgerSpendingConditions, LedgerTasks, LedgerFe
         # and therefore respond with internal transaction fees (0 for now)
         mint_quote = await self.crud.get_mint_quote(request=request, db=self.db)
         if mint_quote and mint_quote.unit == melt_quote.unit:
+            # check if the melt quote is partial and error if it is.
+            # it's just not possible to handle this case
+            if melt_quote.is_mpp:
+                raise TransactionError("multi-part internal payments are not possible. try with a regular payment.")
             payment_quote = self.create_internal_melt_quote(mint_quote, melt_quote)
         else:
             # not internal

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -671,13 +671,13 @@ class Ledger(LedgerVerification, LedgerSpendingConditions, LedgerTasks, LedgerFe
             # check if the melt quote is partial and error if it is.
             # it's just not possible to handle this case
             if melt_quote.is_mpp:
-                raise TransactionError("multi-part internal payments are not possible. try with a regular payment.")
+                raise TransactionError("internal mpp not allowed.")
             payment_quote = self.create_internal_melt_quote(mint_quote, melt_quote)
         else:
             # not internal
             # verify that the backend supports mpp if the quote request has an amount
             if melt_quote.is_mpp and not self.backends[method][unit].supports_mpp:
-                raise TransactionError("backend does not support mpp")
+                raise TransactionError("backend does not support mpp.")
             # get payment quote by backend
             payment_quote = await self.backends[method][unit].get_payment_quote(
                 melt_quote=melt_quote

--- a/tests/test_wallet_regtest_mpp.py
+++ b/tests/test_wallet_regtest_mpp.py
@@ -144,8 +144,9 @@ async def test_regtest_pay_mpp_incomplete_payment(wallet: Wallet, ledger: Ledger
 @pytest.mark.asyncio
 @pytest.mark.skipif(is_fake, reason="only regtest")
 async def test_regtest_internal_mpp_melt_quotes(wallet: Wallet, ledger: Ledger):
-    # make sure wallet knows the backend supports mpp
-    assert wallet.mint_info.supports_mpp("bolt11", wallet.unit)
+    # make sure that mpp is supported by the bolt11-sat backend
+    if not ledger.backends[Method["bolt11"]][wallet.unit].supports_mpp:
+        pytest.skip("backend does not support mpp")
 
     # create a mint quote
     mint_quote = await wallet.request_mint(128)

--- a/tests/test_wallet_regtest_mpp.py
+++ b/tests/test_wallet_regtest_mpp.py
@@ -148,7 +148,7 @@ async def test_regtest_internal_mpp_melt_quotes(wallet: Wallet, ledger: Ledger):
     assert wallet.mint_info.supports_mpp("bolt11", wallet.unit)
 
     # create a mint quote
-    mint_quote = wallet.request_mint(128)
+    mint_quote = await wallet.request_mint(128)
 
     # try and create a multi-part melt quote
     assert_err(wallet.melt_quote(mint_quote.request, 100), "multi-part internal payments are not possible. try with a regular payment.")

--- a/tests/test_wallet_regtest_mpp.py
+++ b/tests/test_wallet_regtest_mpp.py
@@ -141,6 +141,7 @@ async def test_regtest_pay_mpp_incomplete_payment(wallet: Wallet, ledger: Ledger
 
     assert wallet.balance <= 384 - 64
 
+
 @pytest.mark.asyncio
 @pytest.mark.skipif(is_fake, reason="only regtest")
 async def test_regtest_internal_mpp_melt_quotes(wallet: Wallet, ledger: Ledger):
@@ -152,4 +153,6 @@ async def test_regtest_internal_mpp_melt_quotes(wallet: Wallet, ledger: Ledger):
     mint_quote = await wallet.request_mint(128)
 
     # try and create a multi-part melt quote
-    assert_err(wallet.melt_quote(mint_quote.request, 100), "multi-part internal payments are not possible. try with a regular payment.")
+    await assert_err(
+        wallet.melt_quote(mint_quote.request, 100), "internal mpp not allowed"
+    )


### PR DESCRIPTION
Reject melt quote requests with invoice strings that reference an internal mint quote.
When the Mint receives these requests, it means some wallet is trying to pay a mint quote for this very Mint with a multi-part payment, which is not possible.