### PR TITLE
Implement balance logging in watchdog worker

### DIFF
--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -546,7 +546,7 @@ class Unit(Enum):
     btc = 4
     auth = 999
 
-    def str(self, amount: int) -> str:
+    def str(self, amount: int | float) -> str:
         if self == Unit.sat:
             return f"{amount} sat"
         elif self == Unit.msat:

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -63,12 +63,12 @@ class MintSettings(CashuSettings):
 
     mint_input_fee_ppk: int = Field(default=0)
     mint_disable_melt_on_error: bool = Field(default=False)
+    auth_database: str = Field(default="data/mint")
+    mint_balance_check_interval_seconds: int = Field(default=10)
 
 
 class MintDeprecationFlags(MintSettings):
     mint_inactivate_base64_keysets: bool = Field(default=False)
-
-    auth_database: str = Field(default="data/mint")
 
 
 class MintBackends(MintSettings):

--- a/cashu/mint/crud.py
+++ b/cashu/mint/crud.py
@@ -8,6 +8,7 @@ from ..core.base import (
     MintKeyset,
     MintQuote,
     Proof,
+    Unit,
 )
 from ..core.db import (
     Connection,
@@ -770,3 +771,6 @@ class LedgerCrudSqlite(LedgerCrud):
         values = {f"y_{i}": Ys[i] for i in range(len(Ys))}
         rows = await (conn or db).fetchall(query, values)
         return [Proof(**r) for r in rows] if rows else []
+
+    async def get_balance_log(self, unit: Unit) -> List[int]:
+        return []

--- a/cashu/mint/migrations.py
+++ b/cashu/mint/migrations.py
@@ -868,3 +868,17 @@ async def m025_add_amounts_to_keysets(db: Database):
         await conn.execute(
             f"UPDATE {db.table_with_schema('keysets')} SET amounts = '[]'"
         )
+
+
+async def m026_add_balance_log_table(db: Database):
+    async with db.connect() as conn:
+        await conn.execute(
+            f"""
+                CREATE TABLE IF NOT EXISTS balance_log (
+                    unit TEXT NOT NULL,
+                    balance INTEGER NOT NULL,
+                    backend_balance INTEGER NOT NULL,
+                    time TIMESTAMP DEFAULT {db.timestamp_now}
+                );
+            """
+        )

--- a/cashu/mint/migrations.py
+++ b/cashu/mint/migrations.py
@@ -916,7 +916,7 @@ async def m027_add_balance_log_table(db: Database):
             f"""
                 CREATE TABLE IF NOT EXISTS balance_log (
                     unit TEXT NOT NULL,
-                    balance INTEGER NOT NULL,
+                    mint_balance INTEGER NOT NULL,
                     backend_balance INTEGER NOT NULL,
                     time TIMESTAMP DEFAULT {db.timestamp_now}
                 );

--- a/cashu/mint/watchdog.py
+++ b/cashu/mint/watchdog.py
@@ -1,0 +1,47 @@
+import asyncio
+from typing import List
+
+from loguru import logger
+
+from ..core.base import Unit
+from ..core.settings import settings
+from ..lightning.base import LightningBackend
+from .protocols import SupportsBackends, SupportsDb
+
+
+class LedgerWatchdog(SupportsDb, SupportsBackends):
+    def __init__(self) -> None:
+        return
+
+    async def dispatch_watchdogs(self) -> List[asyncio.Task]:
+        tasks = []
+        for method, unitbackends in self.backends.items():
+            for unit, backend in unitbackends.items():
+                tasks.append(
+                    asyncio.create_task(self.dispatch_backend_checker(unit, backend))
+                )
+        return tasks
+
+    async def dispatch_backend_checker(
+        self, unit: Unit, backend: LightningBackend
+    ) -> None:
+        logger.info(
+            f"Dispatching backend checker for unit: {unit.name} and backend: {backend.__class__.__name__}"
+        )
+        while True:
+            backend_status = await backend.status()
+            backend_balance = int(backend_status.balance)
+            async with self.db.connect() as conn:
+                keyset_balance = await self.crud.get_unit_balance(
+                    unit, db=self.db, conn=conn
+                )
+                await self.crud.store_balance_log(
+                    unit, backend_balance, keyset_balance, db=self.db, conn=conn
+                )
+
+            logger.trace(
+                f"Backend balance {backend.__class__.__name__}: {unit.str(backend_balance)}"
+            )
+            logger.trace(f"Unit balance {unit.name}: {unit.str(keyset_balance)}")
+
+            await asyncio.sleep(settings.mint_balance_check_interval_seconds)


### PR DESCRIPTION
Introduce functionality to store and log balances in the watchdog worker, enhancing monitoring of backend and keyset balances. Update balance retrieval methods to support this feature.

Todo:
- [ ] design killswitch mechanism