### PR TITLE
Add LightningPaymentFailedError exception

### DIFF
--- a/cashu/core/errors.py
+++ b/cashu/core/errors.py
@@ -153,6 +153,14 @@ class QuoteNotPaidError(CashuError):
         super().__init__(self.detail, code=self.code)
 
 
+class LightningPaymentFailedError(CashuError):
+    detail = "Lightning payment failed"
+    code = 20004
+
+    def __init__(self, detail: Optional[str] = None):
+        super().__init__(detail or self.detail, code=self.code)
+
+
 class QuoteSignatureInvalidError(CashuError):
     detail = "Signature for mint request invalid"
     code = 20008

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -36,6 +36,7 @@ from ..core.errors import (
     KeysetError,
     KeysetNotFoundError,
     LightningError,
+    LightningPaymentFailedError,
     NotAllowedError,
     QuoteNotPaidError,
     QuoteSignatureInvalidError,
@@ -1057,7 +1058,7 @@ class Ledger(LedgerVerification, LedgerSpendingConditions, LedgerTasks, LedgerFe
                                 logger.error(
                                     f"Status check error: {status.error_message}"
                                 )
-                            raise LightningError(
+                            raise LightningPaymentFailedError(
                                 f"Lightning payment failed{': ' + payment.error_message if payment.error_message else ''}."
                             )
                         case _:

--- a/tests/test_mint_melt.py
+++ b/tests/test_mint_melt.py
@@ -4,7 +4,7 @@ import pytest
 import pytest_asyncio
 
 from cashu.core.base import MeltQuote, MeltQuoteState, Proof
-from cashu.core.errors import LightningError
+from cashu.core.errors import LightningPaymentFailedError
 from cashu.core.models import PostMeltQuoteRequest, PostMintQuoteRequest
 from cashu.core.settings import settings
 from cashu.lightning.base import PaymentResult
@@ -220,32 +220,32 @@ async def test_melt_lightning_pay_invoice_failed_failed(ledger: Ledger, wallet: 
     settings.fakewallet_pay_invoice_state = PaymentResult.FAILED.name
     try:
         await ledger.melt(proofs=wallet.proofs, quote=quote_id)
-        raise AssertionError("Expected LightningError")
-    except LightningError:
+        raise AssertionError("Expected LightningPaymentFailedError")
+    except LightningPaymentFailedError:
         pass
 
     settings.fakewallet_payment_state = PaymentResult.UNKNOWN.name
     settings.fakewallet_pay_invoice_state = PaymentResult.FAILED.name
     try:
         await ledger.melt(proofs=wallet.proofs, quote=quote_id)
-        raise AssertionError("Expected LightningError")
-    except LightningError:
+        raise AssertionError("Expected LightningPaymentFailedError")
+    except LightningPaymentFailedError:
         pass
 
     settings.fakewallet_payment_state = PaymentResult.FAILED.name
     settings.fakewallet_pay_invoice_state = PaymentResult.UNKNOWN.name
     try:
         await ledger.melt(proofs=wallet.proofs, quote=quote_id)
-        raise AssertionError("Expected LightningError")
-    except LightningError:
+        raise AssertionError("Expected LightningPaymentFailedError")
+    except LightningPaymentFailedError:
         pass
 
     settings.fakewallet_payment_state = PaymentResult.UNKNOWN.name
     settings.fakewallet_pay_invoice_state = PaymentResult.UNKNOWN.name
     try:
         await ledger.melt(proofs=wallet.proofs, quote=quote_id)
-        raise AssertionError("Expected LightningError")
-    except LightningError:
+        raise AssertionError("Expected LightningPaymentFailedError")
+    except LightningPaymentFailedError:
         pass
 
 


### PR DESCRIPTION
Introduce a new exception class for handling failed Lightning payments, improving error management in the payment process.

Todo:
- [x] add test for error code for failed LN payment