### PR TITLE
Add CLI Decode Command

### DIFF
--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -922,6 +922,9 @@ class Token(ABC):
     @abstractmethod
     def unit(self, unit: str): ...
 
+    @abstractmethod
+    def serialize_to_dict(self, include_dleq: bool): ...
+
 
 class TokenV3Token(BaseModel):
     mint: Optional[str] = None

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import getpass
+import json
 import os
 import time
 from datetime import datetime, timezone
@@ -760,6 +761,26 @@ async def receive_cli(
         return
     await print_balance(ctx)
 
+@cli.command("decode", help="Decode a cashu token and print in JSON format.")
+@click.option(
+    "--no-dleq", default=False, is_flag=True, help="Do not include DLEQ proofs."
+)
+@click.option(
+    "--indent", "-i", default=2, is_flag=False, help="Number of spaces to indent JSON with."
+)
+@click.argument("token", type=str, default="")
+def decode_to_json(token: str, no_dleq: bool, indent: int):
+    include_dleq = not no_dleq
+    if token:
+        token_obj = deserialize_token_from_string(token)
+        token_json = json.dumps(
+            token_obj.serialize_to_dict(include_dleq),
+            default=lambda obj: obj.hex() if isinstance(obj, bytes) else obj,
+            indent=indent,
+        )
+        print(token_json)
+    else:
+        print("Error: enter a token")
 
 @cli.command("burn", help="Burn spent tokens.")
 @click.argument("token", required=False, type=str)

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -400,12 +400,12 @@ class Wallet(
                 Defaults to False.
         """
         logger.trace(f"Loading mint {self.url}")
-        await self.load_mint_keysets(force_old_keysets)
-        await self.activate_keyset(keyset_id)
         try:
+            await self.load_mint_keysets(force_old_keysets)
+            await self.activate_keyset(keyset_id)
             await self.load_mint_info(reload=True)
         except Exception as e:
-            logger.debug(f"Could not load mint info: {e}")
+            logger.error(f"Could not load mint info: {e}")
             pass
 
     async def load_proofs(self, reload: bool = False, all_keysets=False) -> None:


### PR DESCRIPTION
This PR does two things:
* Adds a `cashu decode [OPTIONS] [TOKEN]` command that decodes a token without receiving it and prints it in JSON format.
* In `cashu/wallet/wallet.py:403-405` moves the calls for loading and activating the keyset into the try block so
they don't crash the wallet when the Mint is unreachable.

Related Issue: https://github.com/cashubtc/nutshell/issues/700
