### PR TITLE
Add terms of service URL to MintInformation class

### DIFF
--- a/cashu/core/mint_info.py
+++ b/cashu/core/mint_info.py
@@ -18,6 +18,7 @@ class MintInfo(BaseModel):
     contact: Optional[List[MintInfoContact]]
     motd: Optional[str]
     icon_url: Optional[str]
+    tos_url: Optional[str]
     time: Optional[int]
     nuts: Dict[int, Any]
 

--- a/cashu/core/models.py
+++ b/cashu/core/models.py
@@ -52,6 +52,7 @@ class GetInfoResponse(BaseModel):
     contact: Optional[List[MintInfoContact]] = None
     motd: Optional[str] = None
     icon_url: Optional[str] = None
+    tos_url: Optional[str] = None
     urls: Optional[List[str]] = None
     time: Optional[int] = None
     nuts: Optional[Dict[int, Any]] = None

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -156,6 +156,7 @@ class MintInformation(CashuSettings):
     mint_info_motd: str = Field(default=None)
     mint_info_icon_url: str = Field(default=None)
     mint_info_urls: List[str] = Field(default=None)
+    mint_info_tos_url: str = Field(default=None)
 
 
 class WalletSettings(CashuSettings):

--- a/cashu/mint/features.py
+++ b/cashu/mint/features.py
@@ -61,6 +61,7 @@ class LedgerFeatures(SupportsBackends, SupportsPubkey):
             contact=contact_info,
             nuts=self.mint_features,
             icon_url=settings.mint_info_icon_url,
+            tos_url=settings.mint_info_tos_url,
             motd=settings.mint_info_motd,
             time=None,
         )

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -53,6 +53,7 @@ async def info() -> GetInfoResponse:
         contact=mint_info.contact,
         nuts=mint_info.nuts,
         icon_url=mint_info.icon_url,
+        tos_url=mint_info.tos_url,
         urls=settings.mint_info_urls,
         motd=mint_info.motd,
         time=int(time.time()),

--- a/cashu/wallet/mint_info.py
+++ b/cashu/wallet/mint_info.py
@@ -16,6 +16,7 @@ class MintInfo(BaseModel):
     contact: Optional[List[MintInfoContact]]
     motd: Optional[str]
     icon_url: Optional[str]
+    tos_url: Optional[str]
     time: Optional[int]
     nuts: Optional[Dict[int, Any]]
 


### PR DESCRIPTION
Introduce a new field for the terms of service URL in the MintInformation class and update the mint_info method to include this URL.

Implements https://github.com/cashubtc/nuts/pull/205