### PR TITLE
Mint: Allow zero as max peg-in and peg-out parameters

### DIFF
--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -132,19 +132,19 @@ class MintLimits(MintSettings):
     )
     mint_max_peg_in: int = Field(
         default=None,
-        gt=0,
+        ge=0,
         title="Maximum peg-in",
         description="Maximum amount for a mint operation.",
     )
     mint_max_peg_out: int = Field(
         default=None,
-        gt=0,
+        ge=0,
         title="Maximum peg-out",
         description="Maximum amount for a melt operation.",
     )
     mint_max_balance: int = Field(
         default=None,
-        gt=0,
+        ge=0,
         title="Maximum mint balance",
         description="Maximum mint balance.",
     )


### PR DESCRIPTION
Update the mint settings to permit maximum peg-in and peg-out values of zero, enhancing flexibility in mint operations.