### PR TITLE
persist the database when launching through docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ The easiest way to get a mint running is through Docker.
 You can build the image yourself by running the following command. Make sure to adjust the environment variables in `docker-compose.yaml`.
 
 ```bash
-mkdir -p data/mint # for database, will be passed to the container for persistence 
 docker compose up mint
 ```
 


### PR DESCRIPTION
When launching through docker-compose, the database was not persisted in the container, so every container restart meant lost data.