### PR TITLE
[BUGFIX] `SIG_ALL` check returns true for other sigflags

### DIFF
--- a/cashu/mint/conditions.py
+++ b/cashu/mint/conditions.py
@@ -258,7 +258,7 @@ class LedgerSpendingConditions:
 
         return secrets.pop()
 
-    def _check_at_least_one_sig_all(self, proofs: List[Proof]) -> Secret:
+    def _check_at_least_one_sig_all(self, proofs: List[Proof]) -> bool:
         """
         Verify that at least one secret has a SIG_ALL spending condition
         """

--- a/cashu/mint/conditions.py
+++ b/cashu/mint/conditions.py
@@ -258,6 +258,17 @@ class LedgerSpendingConditions:
 
         return secrets.pop()
 
+    def _check_at_least_one_sig_all(self, proofs: List[Proof]) -> Secret:
+        """
+        Verify that at least one secret has a SIG_ALL spending condition
+        """
+        for proof in proofs:
+            secret = Secret.deserialize(proof.secret)
+            if secret.tags.get_tag("sigflag") == SigFlags.SIG_ALL.value:
+                return True
+
+        return False
+
     def _verify_sigall_spending_conditions(
         self,
         proofs: List[Proof],
@@ -268,10 +279,9 @@ class LedgerSpendingConditions:
         If sigflag==SIG_ALL in any proof.secret, perform a signature check on all
         inputs (proofs) and outputs (outputs) together.
 
-        # We return True
-        # - if not all proof.secret are Secret spending condition
-        # - if not all secrets are P2PKSecret spending condition
-        # - if not all signature.sigflag are SIG_ALL
+        We return True
+        - if we successfully validated the spending condition
+        - if all proof.secret are **NOT** SIG_ALL spending condition
 
         We raise an exception:
         - if one input is SIG_ALL but not all inputs are SIG_ALL
@@ -285,6 +295,11 @@ class LedgerSpendingConditions:
 
         We return True if we successfully validated the spending condition.
         """
+
+        # verify at least one secret is SIG_ALL
+        if not self._check_at_least_one_sig_all(proofs):
+            # it makes no sense to continue with a SIG_ALL check
+            return True
 
         # verify that all secrets are of the same kind
         try:

--- a/cashu/mint/conditions.py
+++ b/cashu/mint/conditions.py
@@ -263,9 +263,12 @@ class LedgerSpendingConditions:
         Verify that at least one secret has a SIG_ALL spending condition
         """
         for proof in proofs:
-            secret = Secret.deserialize(proof.secret)
-            if secret.tags.get_tag("sigflag") == SigFlags.SIG_ALL.value:
-                return True
+            try:
+                secret = Secret.deserialize(proof.secret)
+                if secret.tags.get_tag("sigflag") == SigFlags.SIG_ALL.value:
+                    return True
+            except Exception:
+                pass
 
         return False
 

--- a/cashu/mint/conditions.py
+++ b/cashu/mint/conditions.py
@@ -177,7 +177,7 @@ class LedgerSpendingConditions:
                     break
 
         # check if we have enough valid signatures
-        if not n_pubkeys_with_valid_sigs >= n_sigs_required:
+        if n_pubkeys_with_valid_sigs < n_sigs_required:
             raise TransactionError(
                 f"signature threshold not met. {n_pubkeys_with_valid_sigs} <"
                 f" {n_sigs_required}."

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -870,6 +870,12 @@ class Ledger(
             # we don't need to set it here, _set_melt_quote_pending will set it in the db
             melt_quote.outputs = outputs
 
+        # verify SIG_ALL signatures
+        message_to_sign = (
+            "".join([p.secret for p in proofs] + [o.B_ for o in outputs or []]) + quote
+        )
+        self._verify_sigall_spending_conditions(proofs, outputs or [], message_to_sign)
+
         # verify that the amount of the input proofs is equal to the amount of the quote
         total_provided = sum_proofs(proofs)
         input_fees = self.get_fees_for_proofs(proofs)

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -870,12 +870,6 @@ class Ledger(
             # we don't need to set it here, _set_melt_quote_pending will set it in the db
             melt_quote.outputs = outputs
 
-        # verify SIG_ALL signatures
-        message_to_sign = (
-            "".join([p.secret for p in proofs] + [o.B_ for o in outputs or []]) + quote
-        )
-        self._verify_sigall_spending_conditions(proofs, outputs or [], message_to_sign)
-
         # verify that the amount of the input proofs is equal to the amount of the quote
         total_provided = sum_proofs(proofs)
         input_fees = self.get_fees_for_proofs(proofs)


### PR DESCRIPTION
Return `true` in a `SIG_ALL` check if no inputs contain `SIG_ALL` sigflags. 
This prevents an [early P2PK check in `melt`](https://github.com/cashubtc/nutshell/blob/29571287b31224c2a19fd690060c40b912fbc564/cashu/mint/ledger.py#L883) from wrongfully rejecting P2PK locked secrets that only have `SIG_INPUTS` sigflags.