### PR TITLE
fix "Expected currency USD, got USDT" when generating mint quote

### DIFF
--- a/cashu/lightning/strike.py
+++ b/cashu/lightning/strike.py
@@ -219,9 +219,9 @@ class StrikeWallet(LightningBackend):
             error_message = r.json()["data"]["message"]
             raise Exception(error_message)
         strike_quote = StrikePaymentQuoteResponse.parse_obj(r.json())
-        if strike_quote.amount.currency != self.currency_map[self.unit]:
+        if strike_quote.amount.currency != self.currency:
             raise Exception(
-                f"Expected currency {self.currency_map[self.unit]}, got {strike_quote.amount.currency}"
+                f"Expected currency {self.currency}, got {strike_quote.amount.currency}"
             )
         amount = Amount.from_float(float(strike_quote.amount.amount), self.unit)
         fee = self.fee_int(strike_quote, self.unit)


### PR DESCRIPTION
# fixes #766 

The problem is that the `status` method would update the `self.currency` to `USDT`, but then when creating mint quote there was a check between the currency in the strike payment quote and backend's currency_map. If the quote is in USDT, then this would throw "Expected currency USD, got USDT".

Currently you can not pay invoices from a strike mint that is using USDT for its usd balance, so you are stuck