### PR TITLE
include change in ws melt quote state updates

### DIFF
--- a/cashu/core/models.py
+++ b/cashu/core/models.py
@@ -246,12 +246,18 @@ class PostMeltQuoteResponse(BaseModel):
 
     @classmethod
     def from_melt_quote(self, melt_quote: MeltQuote) -> "PostMeltQuoteResponse":
-        to_dict = melt_quote.dict()
-        # turn state into string
-        to_dict["state"] = melt_quote.state.value
-        # add deprecated "paid" field
-        to_dict["paid"] = melt_quote.paid
-        return PostMeltQuoteResponse.parse_obj(to_dict)
+        return PostMeltQuoteResponse(
+            quote=melt_quote.quote,
+            amount=melt_quote.amount,
+            unit=melt_quote.unit,
+            request=melt_quote.request,
+            fee_reserve=melt_quote.fee_reserve,
+            paid=melt_quote.paid,
+            state=melt_quote.state.value,
+            expiry=melt_quote.expiry,
+            payment_preimage=melt_quote.payment_preimage,
+            change=melt_quote.change,
+        )
 
 
 # ------- API: MELT -------


### PR DESCRIPTION
Fixes #771 

Claude says this fixes it

Websocket melt quote state updates were missing the change field, causing wallets that rely on websockets to lose their change proofs. The issue was in PostMeltQuoteResponse.from_melt_quote() which used melt_quote.dict() + parse_obj() instead of explicit field construction, preventing proper serialization of BlindedSignature objects in the change field. Fixed by aligning the websocket serialization with the working REST endpoint implementation.