### PR TITLE
add description to NUT-04 method options

### DIFF
--- a/cashu/core/models.py
+++ b/cashu/core/models.py
@@ -18,12 +18,16 @@ from .settings import settings
 # ------- API: INFO -------
 
 
+class MintMethodBolt11OptionSetting(BaseModel):
+    description: Optional[bool] = None
+
+
 class MintMethodSetting(BaseModel):
     method: str
     unit: str
     min_amount: Optional[int] = None
     max_amount: Optional[int] = None
-    description: Optional[bool] = None
+    options: Optional[MintMethodBolt11OptionSetting] = None
 
 
 class MeltMethodSetting(BaseModel):

--- a/cashu/mint/features.py
+++ b/cashu/mint/features.py
@@ -6,6 +6,7 @@ from ..core.models import (
     MeltMethodSetting,
     MintInfoContact,
     MintInfoProtectedEndpoint,
+    MintMethodBolt11OptionSetting,
     MintMethodSetting,
 )
 from ..core.nuts.nuts import (
@@ -85,8 +86,10 @@ class LedgerFeatures(SupportsBackends, SupportsPubkey):
                 if settings.mint_max_mint_bolt11_sat:
                     mint_setting.max_amount = settings.mint_max_mint_bolt11_sat
                     mint_setting.min_amount = 0
+                mint_setting.options = MintMethodBolt11OptionSetting(
+                    description=unit_dict[unit].supports_description
+                )
                 mint_method_settings.append(mint_setting)
-                mint_setting.description = unit_dict[unit].supports_description
         melt_method_settings: List[MeltMethodSetting] = []
         for method, unit_dict in self.backends.items():
             for unit in unit_dict.keys():

--- a/tests/mint/test_mint_api.py
+++ b/tests/mint/test_mint_api.py
@@ -52,6 +52,8 @@ async def test_info(ledger: Ledger):
     setting = MintMethodSetting.parse_obj(info.nuts[MINT_NUT]["methods"][0])
     assert setting.method == "bolt11"
     assert setting.unit == "sat"
+    assert setting.options
+    assert setting.options.description is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
fix nutshell to adhere to the NUT-04 `settings` object

before:
<img width="289" height="205" alt="image" src="https://github.com/user-attachments/assets/20fd9ae3-4521-4172-baad-e699730be212" />
after:
<img width="317" height="245" alt="image" src="https://github.com/user-attachments/assets/f200e7af-56af-4532-98dd-84185bc372f7" />
