### PR TITLE
list raw proofs, per Issue #710

### DIFF
--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -910,6 +910,86 @@ async def pending(ctx: Context, legacy, number: int, offset: int):
         print("To receive all pending tokens use: cashu receive -a")
 
 
+@cli.command("proofs", help="List raw proofs in wallet.")
+@click.option(
+    "--all", "-a", default=False, is_flag=True, help="Include reserved proofs."
+)
+@click.option(
+    "--no-dleq", default=False, is_flag=True, help="Do not include DLEQ proofs."
+)
+@click.option(
+    "--indent",
+    "-i",
+    default=2,
+    help="Number of spaces to indent JSON with.",
+    type=int,
+)
+@click.option(
+    "--keyset",
+    "-k",
+    default=None,
+    help="Filter by keyset ID.",
+    type=str,
+)
+@click.pass_context
+@coro
+async def proofs_command(
+    ctx: Context, all: bool, no_dleq: bool, indent: int, keyset: str
+):
+    wallet: Wallet = ctx.obj["WALLET"]
+    await wallet.load_proofs()
+
+    # Get proofs based on --all flag
+    if all:
+        # Include both available and reserved proofs
+        proofs = wallet.proofs
+    else:
+        # Only include available (non-reserved) proofs
+        proofs = [p for p in wallet.proofs if not p.reserved]
+
+    # Filter by keyset if specified
+    if keyset:
+        proofs = [p for p in proofs if p.id == keyset]
+
+    if not proofs:
+        if keyset:
+            print(f"No proofs found for keyset: {keyset}")
+        else:
+            print("No proofs found.")
+        return
+
+    # Convert proofs to dictionary format
+    include_dleq = not no_dleq
+    proofs_dict = []
+    for proof in proofs:
+        proof_dict = {
+            "id": proof.id,
+            "amount": proof.amount,
+            "secret": proof.secret,
+            "Y": proof.Y,
+            "C": proof.C,
+        }
+
+        if include_dleq and proof.dleq:
+            proof_dict["dleq"] = {
+                "e": proof.dleq.e,
+                "s": proof.dleq.s,
+                "r": proof.dleq.r,
+            }
+
+        if proof.witness:
+            proof_dict["witness"] = proof.witness
+
+        proofs_dict.append(proof_dict)
+
+    # Print as JSON
+    proofs_json = json.dumps(
+        proofs_dict,
+        indent=indent,
+    )
+    print(proofs_json)
+
+
 @cli.command("lock", help="Generate receiving lock.")
 @click.pass_context
 @coro

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -157,7 +157,9 @@ def init_auth_wallet(func):
 )
 @click.pass_context
 @coro
-async def cli(ctx: Context, host: str, walletname: str, unit: str, tests: bool, verbose: bool):
+async def cli(
+    ctx: Context, host: str, walletname: str, unit: str, tests: bool, verbose: bool
+):
     if settings.debug:
         configure_logger()
     if settings.tor and not TorProxy().check_platform():

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -966,7 +966,6 @@ async def proofs_command(
             "id": proof.id,
             "amount": proof.amount,
             "secret": proof.secret,
-            "Y": proof.Y,
             "C": proof.C,
         }
 

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -359,7 +359,7 @@ async def invoice(
     # in case the user wants a specific split, we create a list of amounts
     optional_split = None
     if split:
-        assert amount % split == 0, "split must be divisor or amount"
+        assert amount % split == 0, "split must be divisor of amount"
         assert amount >= split, "split must smaller or equal amount"
         n_splits = amount // split
         optional_split = [split] * n_splits

--- a/tests/wallet/test_wallet_cli.py
+++ b/tests/wallet/test_wallet_cli.py
@@ -737,6 +737,9 @@ def test_proofs_with_all_flag(cli_prefix):
     # Create some tokens first so we have proofs to list
     result = runner.invoke(cli, [*cli_prefix, "invoice", "64"])
     assert result.exit_code == 0
+    # Send some, in order to 'reserve' the tokens such that they are only included if --all is passed
+    result = runner.invoke(cli, [*cli_prefix, "send", "12"])
+    assert result.exit_code == 0
 
     # Get available proofs (default)
     result_available = runner.invoke(cli, [*cli_prefix, "proofs", "--no-dleq"])
@@ -753,7 +756,7 @@ def test_proofs_with_all_flag(cli_prefix):
     all_proofs = json.loads(result_all.stdout.strip())
 
     # All proofs should include at least the same number as available proofs
-    assert len(all_proofs) >= len(available_proofs), "--all should include at least as many proofs as default"
+    assert len(all_proofs) > len(available_proofs), "--all should have more proofs, as it includes the reserved proofs"
 
     print(f"Available proofs: {len(available_proofs)}, All proofs: {len(all_proofs)}")
 

--- a/tests/wallet/test_wallet_cli.py
+++ b/tests/wallet/test_wallet_cli.py
@@ -711,17 +711,12 @@ def test_proofs_with_keyset_filter(cli_prefix):
         assert proof["id"] == test_keyset, f"proof has wrong keyset ID: {proof['id']} != {test_keyset}"
 
     # Filter with a non-existent keyset, to make sure nothing is returned
-    result_filtered = runner.invoke(cli, [*cli_prefix, "proofs", "--keyset", '009a1f293253e41e'])
-    assert result_filtered.exception is None
-    assert result_filtered.exit_code == 0
-
-    filtered_proofs = json.loads(result_filtered.stdout.strip())
-
-    assert len(filtered_proofs) > 0
-
-    # All filtered proofs should have the same keyset ID
-    for proof in filtered_proofs:
-        assert proof["id"] == test_keyset, f"proof has wrong keyset ID: {proof['id']} != {test_keyset}"
+    import secrets
+    nonexistent_keyset = '00' + secrets.token_hex(7)  # 16 hex chars (8 bytes)
+    result_filtered_again = runner.invoke(cli, [*cli_prefix, "proofs", "--keyset", nonexistent_keyset])
+    assert result_filtered_again.exception is None
+    assert result_filtered_again.exit_code == 0
+    assert "No proofs found for keyset:" in result_filtered_again.stdout
 
 
 def test_proofs_invalid_keyset(cli_prefix):

--- a/tests/wallet/test_wallet_cli.py
+++ b/tests/wallet/test_wallet_cli.py
@@ -623,6 +623,7 @@ def test_proofs_json_structure(cli_prefix):
 
     # Parse JSON from stdout
     import json
+
     proofs = json.loads(result.stdout.strip())
     assert len(proofs) > 0, "Should have proofs to test structure"
 
@@ -632,7 +633,7 @@ def test_proofs_json_structure(cli_prefix):
         assert isinstance(proof["amount"], int), "'amount' should be integer"
         assert isinstance(proof["secret"], str), "'secret' should be string"
         assert isinstance(proof["C"], str), "'C' should be string"
-        assert "dleq" in proof.keys() # will not be present if '--no-dleq' is passed
+        assert "dleq" in proof.keys()  # will not be present if '--no-dleq' is passed
 
 
 def test_proofs_with_no_dleq_flag(cli_prefix):
@@ -658,6 +659,7 @@ def test_proofs_with_no_dleq_flag(cli_prefix):
 
     # Parse JSON from both outputs
     import json
+
     proofs_with_dleq = json.loads(result_with_dleq.stdout.strip())
     proofs_no_dleq = json.loads(result_no_dleq.stdout.strip())
 
@@ -672,7 +674,9 @@ def test_proofs_with_no_dleq_flag(cli_prefix):
         assert isinstance(proof["amount"], int), "'amount' should be integer"
         assert isinstance(proof["secret"], str), "'secret' should be string"
         assert isinstance(proof["C"], str), "'C' should be string"
-        assert "dleq" not in proof, "proof should not contain 'dleq' field with --no-dleq"
+        assert (
+            "dleq" not in proof
+        ), "proof should not contain 'dleq' field with --no-dleq"
 
 
 def test_proofs_with_keyset_filter(cli_prefix):
@@ -692,6 +696,7 @@ def test_proofs_with_keyset_filter(cli_prefix):
     assert result_all.exception is None
 
     import json
+
     all_proofs = json.loads(result_all.stdout.strip())
     assert len(all_proofs) > 0, "Should have proofs to test keyset filtering"
 
@@ -699,7 +704,9 @@ def test_proofs_with_keyset_filter(cli_prefix):
     test_keyset = all_proofs[0]["id"]
 
     # Filter by that keyset
-    result_filtered = runner.invoke(cli, [*cli_prefix, "proofs", "--keyset", test_keyset])
+    result_filtered = runner.invoke(
+        cli, [*cli_prefix, "proofs", "--keyset", test_keyset]
+    )
     assert result_filtered.exception is None
     assert result_filtered.exit_code == 0
 
@@ -708,12 +715,17 @@ def test_proofs_with_keyset_filter(cli_prefix):
 
     # All filtered proofs should have the same keyset ID
     for proof in filtered_proofs:
-        assert proof["id"] == test_keyset, f"proof has wrong keyset ID: {proof['id']} != {test_keyset}"
+        assert (
+            proof["id"] == test_keyset
+        ), f"proof has wrong keyset ID: {proof['id']} != {test_keyset}"
 
     # Filter with a non-existent keyset, to make sure nothing is returned
     import secrets
-    nonexistent_keyset = '00' + secrets.token_hex(7)  # 16 hex chars (8 bytes)
-    result_filtered_again = runner.invoke(cli, [*cli_prefix, "proofs", "--keyset", nonexistent_keyset])
+
+    nonexistent_keyset = "00" + secrets.token_hex(7)  # 16 hex chars (8 bytes)
+    result_filtered_again = runner.invoke(
+        cli, [*cli_prefix, "proofs", "--keyset", nonexistent_keyset]
+    )
     assert result_filtered_again.exception is None
     assert result_filtered_again.exit_code == 0
     assert "No proofs found for keyset:" in result_filtered_again.stdout
@@ -727,7 +739,6 @@ def test_proofs_invalid_keyset(cli_prefix):
     assert result.exception is None
     assert result.exit_code == 0
     assert "No proofs found for keyset: nonexistent" in result.stdout
-
 
 
 def test_proofs_with_all_flag(cli_prefix):
@@ -756,7 +767,9 @@ def test_proofs_with_all_flag(cli_prefix):
     all_proofs = json.loads(result_all.stdout.strip())
 
     # All proofs should include at least the same number as available proofs
-    assert len(all_proofs) > len(available_proofs), "--all should have more proofs, as it includes the reserved proofs"
+    assert len(all_proofs) > len(
+        available_proofs
+    ), "--all should have more proofs, as it includes the reserved proofs"
 
     print(f"Available proofs: {len(available_proofs)}, All proofs: {len(all_proofs)}")
 
@@ -764,4 +777,6 @@ def test_proofs_with_all_flag(cli_prefix):
     available_secrets = {proof["secret"] for proof in available_proofs}
     all_secrets = {proof["secret"] for proof in all_proofs}
 
-    assert available_secrets.issubset(all_secrets), "all available proofs should be included in --all"
+    assert available_secrets.issubset(
+        all_secrets
+    ), "all available proofs should be included in --all"


### PR DESCRIPTION
As was requested in Issue #710 , this PR adds a `proofs` command to the wallet to list all the proofs in the wallet

```
Usage: cashu proofs [OPTIONS]

  List raw proofs in wallet.

Options:
  -a, --all             Include reserved proofs.
  --no-dleq             Do not include DLEQ proofs.
  -i, --indent INTEGER  Number of spaces to indent JSON with.
  -k, --keyset TEXT     Filter by keyset ID.
  --help                Show this message and exit.
```


Example output:

```
[
  {
    "id": "00add054379b98ee",
    "amount": 1,
    "secret": "c211ab6e1e457b83eb9f027c62ca7d9a8735afb12d9c7bf58b8a3a1532d03dd7",
    "C": "03a32cb7066c113db1dc275f08f36c9fffa944a1dcc93ff1fc80ebfa8833b9a93a",
    "dleq": {
      "e": "88c21cfd541d57d0cc80d46d0dea2fef4da4b50dd8311bb903f39766714f34c6",
      "s": "19c7249948ac8fec00dc09d07e8c3627a66de72c42a58337196bc2f41f31d09f",
      "r": "51ec2197e16100ae646286f7973f678f407c4a0d1581c691b5dd2d020b4d9747"
    }
  },
  {
    "id": "00add054379b98ee",
    "amount": 1,
    "secret": "efe43bcf291c7769704d28e27c43ddd8a0ca9de72f85f0f7ee85411f4bb6f247",
    "C": "03b27f2dbd818fe6e34ebba86d645f5993cc013af36febb1227b4c09152bf31ba9",
    "dleq": {
      "e": "4a6acd72e57b6de7b052882cbb29ccf4db291dbec6e3ead767cee66126c2f78b",
      "s": "417cc1456adcc854864ccb4791c33857926553adf447b158b92c83596633600c",
      "r": "a7e31e37da1569fe76d7703592cdf13efa23f589a65142789ff90299aeae0ed0"
    }
  },
...
```