### PR TITLE
Issue 789. Avoid the duplication of websocket messages that failed that test

### DIFF
--- a/tests/wallet/test_wallet_subscription.py
+++ b/tests/wallet/test_wallet_subscription.py
@@ -28,6 +28,10 @@ async def wallet(mint):
 
 @pytest.mark.asyncio
 async def test_wallet_subscription_mint(wallet: Wallet):
+    """The state will go from UNPAID to PAID to ISSUED. After the state becomes 'PAID', the
+       wallet must take action (see the 'def callback' below) to convert the PAID invoice
+       to ISSUED
+    """
     if not wallet.mint_info.supports_nut(WEBSOCKETS_NUT):
         pytest.skip("No websocket support")
 
@@ -43,7 +47,8 @@ async def test_wallet_subscription_mint(wallet: Wallet):
         nonlocal triggered, msg_stack
         triggered = True
         msg_stack.append(msg)
-        asyncio.run(wallet.mint(int(mint_quote.amount), quote_id=mint_quote.quote))
+        if msg.payload['state'] == 'PAID':
+            asyncio.run(wallet.mint(int(mint_quote.amount), quote_id=mint_quote.quote))
 
     mint_quote, sub = await wallet.request_mint_with_callback(128, callback=callback)
     await pay_if_regtest(mint_quote.request)


### PR DESCRIPTION
The test ensures that the state goes from UNPAID -> PAID -> ISSUE

Sometimes though, there is duplication and the test fails:  UNPAID -> UNPAID -> PAID -> PAID -> ISSUE

After the invoice has been paid, the wallet calls `wallet.mint` to convert that paid invoice into issued proofs.

Every state transition calls the `callback` and `wallet.mint` was being called on every state transition.

In this PR, the call to `wallet.mint` is made just once - just when it's PAID - instead of three times