### PR TITLE
feat: async melt requests

### DIFF
--- a/cashu/core/models.py
+++ b/cashu/core/models.py
@@ -205,7 +205,7 @@ class PostMeltRequestOptionMpp(BaseModel):
 
 
 class PostMeltRequestOptions(BaseModel):
-    mpp: Optional[PostMeltRequestOptionMpp]
+    mpp: Optional[PostMeltRequestOptionMpp] = None
 
 
 class PostMeltQuoteRequest(BaseModel):
@@ -267,6 +267,7 @@ class PostMeltRequest(BaseModel):
     outputs: Union[List[BlindedMessage], None] = Field(
         None, max_items=settings.mint_max_request_length
     )
+    prefer_async: Optional[bool] = False
 
 
 class PostMeltResponse_deprecated(BaseModel):

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -1135,7 +1135,7 @@ class Ledger(
             logger.debug(
                 f"Melt quote {melt_quote.quote} is being finalized. prefer_async={prefer_async}"
             )
-            melt_quote = await _execute_payment_and_finalize_with_error_handling(
+            melt_quote = await self._execute_payment_and_finalize_with_error_handling(
                 melt_quote,
                 proofs,
                 previous_state,

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -106,6 +106,7 @@ class Ledger(
         self.invoice_listener_tasks: List[asyncio.Task] = []
         self.watchdog_tasks: List[asyncio.Task] = []
         self.regular_tasks: List[asyncio.Task] = []
+        self.background_tasks: set = set()
 
         if not seed:
             raise Exception("seed not set")

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -938,6 +938,7 @@ class Ledger(
         proofs: List[Proof],
         quote: str,
         outputs: Optional[List[BlindedMessage]] = None,
+        prefer_async: bool = False,
     ) -> PostMeltQuoteResponse:
         """Invalidates proofs and pays a Lightning invoice.
 
@@ -945,6 +946,8 @@ class Ledger(
             proofs (List[Proof]): Proofs provided for paying the Lightning invoice
             quote (str): ID of the melt quote.
             outputs (Optional[List[BlindedMessage]]): Blank outputs for returning overpaid fees to the wallet.
+            prefer_async (bool): If set to true, the melt operation will occur in a different task while
+                the request will return immediately with the melt quote state set to PENDING.
 
         Raises:
             e: Lightning payment unsuccessful

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -1013,119 +1013,152 @@ class Ledger(
         if outputs:
             await self._store_blinded_messages(outputs, melt_id=melt_quote.quote)
 
-        # if the melt corresponds to an internal mint, mark both as paid
-        melt_quote = await self.melt_mint_settle_internally(melt_quote, proofs)
-        # quote not paid yet (not internal), pay it with the backend
-        if not melt_quote.paid:
-            logger.debug(f"Lightning: pay invoice {melt_quote.request}")
-            try:
-                payment = await self.backends[method][unit].pay_invoice(
-                    melt_quote, melt_quote.fee_reserve * 1000
-                )
-                logger.debug(
-                    f"Melt – Result: {payment.result.name}: preimage: {payment.preimage},"
-                    f" fee: {payment.fee.str() if payment.fee is not None else 'None'}"
-                )
-                if (
-                    payment.checking_id
-                    and payment.checking_id != melt_quote.checking_id
-                ):
-                    logger.warning(
-                        f"pay_invoice returned different checking_id: {payment.checking_id} than melt quote: {melt_quote.checking_id}. Will use it for potentially checking payment status later."
+        # helper that performs backend payment flow and finalization
+        async def _execute_payment_and_finalize(
+            mq: MeltQuote,
+            proofs_copy: List[Proof],
+            prev_state: MeltQuoteState,
+            fee_reserve_provided_local: int,
+            unit_local: Unit,
+            method_local: Method,
+            outputs: Optional[List[BlindedMessage]],
+        ):
+            # if it still needs to be paid
+            if not mq.paid:
+                logger.debug(f"Lightning: pay invoice {mq.request}")
+                try:
+                    payment = await self.backends[method_local][unit_local].pay_invoice(
+                        mq, mq.fee_reserve * 1000
                     )
-                    melt_quote.checking_id = payment.checking_id
-                    await self.crud.update_melt_quote(quote=melt_quote, db=self.db)
-            except Exception as e:
-                logger.error(f"Exception during pay_invoice: {e}")
-                payment = PaymentResponse(
-                    result=PaymentResult.UNKNOWN,
-                    error_message=str(e),
-                )
-
-            match payment.result:
-                case PaymentResult.FAILED | PaymentResult.UNKNOWN:
-                    # explicitly check payment status for failed or unknown payment states
-                    checking_id = payment.checking_id or melt_quote.checking_id
                     logger.debug(
-                        f"Payment state is {payment.result.name}.{' Error: ' + payment.error_message + '.' if payment.error_message else ''} Checking status for {checking_id}."
+                        f"Melt – Result: {payment.result.name}: preimage: {payment.preimage},"
+                        f" fee: {payment.fee.str() if payment.fee is not None else 'None'}"
                     )
-                    try:
-                        status = await self.backends[method][unit].get_payment_status(
-                            checking_id
+                    if payment.checking_id and payment.checking_id != mq.checking_id:
+                        logger.warning(
+                            f"pay_invoice returned different checking_id: {payment.checking_id} than melt quote: {mq.checking_id}. Will use it for potentially checking payment status later."
                         )
-                    except Exception as e:
-                        # Something went wrong. We might have lost connection to the backend. Keep transaction pending and return.
-                        logger.error(
-                            f"Lightning backend error: could not check payment status. Proofs for melt quote {melt_quote.quote} are stuck as PENDING.\nError: {e}"
-                        )
-                        self.disable_melt = True
-                        return PostMeltQuoteResponse.from_melt_quote(melt_quote)
+                        mq.checking_id = payment.checking_id
+                        await self.crud.update_melt_quote(quote=mq, db=self.db)
+                except Exception as e:
+                    logger.error(f"Exception during pay_invoice: {e}")
+                    payment = PaymentResponse(
+                        result=PaymentResult.UNKNOWN,
+                        error_message=str(e),
+                    )
 
-                    match status.result:
-                        case PaymentResult.FAILED | PaymentResult.UNKNOWN:
-                            # Everything as expected. Payment AND a status check both agree on a failure. We roll back the transaction.
-                            await self.db_write._unset_proofs_pending(
-                                proofs, keysets=self.keysets
-                            )
-                            await self.db_write._unset_melt_quote_pending(
-                                quote=melt_quote, state=previous_state
-                            )
-                            await self.crud.delete_blinded_messages_melt_id(
-                                melt_id=melt_quote.quote, db=self.db
-                            )
-                            if status.error_message:
-                                logger.error(
-                                    f"Status check error: {status.error_message}"
-                                )
-                            raise LightningPaymentFailedError(
-                                f"Lightning payment failed{': ' + payment.error_message if payment.error_message else ''}."
-                            )
-                        case _:
-                            # Something went wrong with our implementation or the backend. Status check returned different result than payment. Keep transaction pending and return.
+                match payment.result:
+                    case PaymentResult.FAILED | PaymentResult.UNKNOWN:
+                        checking_id = payment.checking_id or mq.checking_id
+                        logger.debug(
+                            f"Payment state is {payment.result.name}.{' Error: ' + payment.error_message + '.' if payment.error_message else ''} Checking status for {checking_id}."
+                        )
+                        try:
+                            status = await self.backends[method_local][
+                                unit_local
+                            ].get_payment_status(checking_id)
+                        except Exception as e:
                             logger.error(
-                                f"Payment state was {payment.result} but additional payment state check returned {status.result.name}. Proofs for melt quote {melt_quote.quote} are stuck as PENDING."
+                                f"Lightning backend error: could not check payment status. Proofs for melt quote {mq.quote} are stuck as PENDING.\nError: {e}"
                             )
                             self.disable_melt = True
-                            return PostMeltQuoteResponse.from_melt_quote(melt_quote)
+                            return mq
 
-                case PaymentResult.SETTLED:
-                    # payment successful
-                    if payment.fee:
-                        melt_quote.fee_paid = payment.fee.to(
-                            to_unit=unit, round="up"
-                        ).amount
-                    if payment.preimage:
-                        melt_quote.payment_preimage = payment.preimage
-                    # set quote as paid
-                    melt_quote.state = MeltQuoteState.paid
-                    melt_quote.paid_time = int(time.time())
-                    # NOTE: This is the only branch for a successful payment
+                        match status.result:
+                            case PaymentResult.FAILED | PaymentResult.UNKNOWN:
+                                # rollback
+                                await self.db_write._unset_proofs_pending(
+                                    proofs_copy, keysets=self.keysets
+                                )
+                                await self.db_write._unset_melt_quote_pending(
+                                    quote=mq, state=prev_state
+                                )
+                                await self.crud.delete_blinded_messages_melt_id(
+                                    melt_id=melt_quote.quote, db=self.db
+                                )
+                                if status.error_message:
+                                    logger.error(
+                                        f"Status check error: {status.error_message}"
+                                    )
+                                raise LightningPaymentFailedError(
+                                    f"Lightning payment failed{': ' + payment.error_message if payment.error_message else ''}."
+                                )
+                            case _:
+                                logger.error(
+                                    f"Payment state was {payment.result} but additional payment state check returned {status.result.name}. Proofs for melt quote {mq.quote} are stuck as PENDING."
+                                )
+                                self.disable_melt = True
+                                return mq
 
-                case PaymentResult.PENDING | _:
-                    logger.debug(
-                        f"Lightning payment is {payment.result.name}: {payment.checking_id}"
-                    )
-                    return PostMeltQuoteResponse.from_melt_quote(melt_quote)
+                    case PaymentResult.SETTLED:
+                        if payment.fee:
+                            mq.fee_paid = payment.fee.to(
+                                to_unit=unit_local, round="up"
+                            ).amount
+                        if payment.preimage:
+                            mq.payment_preimage = payment.preimage
+                        mq.state = MeltQuoteState.paid
+                        mq.paid_time = int(time.time())
 
-        # melt was successful (either internal or via backend), invalidate proofs
-        await self._invalidate_proofs(proofs=proofs, quote_id=melt_quote.quote)
-        await self.db_write._unset_proofs_pending(proofs, keysets=self.keysets)
+                    case PaymentResult.PENDING | _:
+                        logger.debug(
+                            f"Lightning payment is {payment.result.name}: {payment.checking_id}"
+                        )
+                        return mq
 
-        # prepare change to compensate wallet for overpaid fees
-        return_promises: List[BlindedSignature] = []
-        if outputs:
-            return_promises = await self._generate_change_promises(
-                fee_provided=fee_reserve_provided,
-                fee_paid=melt_quote.fee_paid,
-                outputs=outputs,
-                melt_id=melt_quote.quote,
-                keyset=self.keysets[outputs[0].id],
+            # successful payment branch: invalidate proofs and unset pending
+            await self._invalidate_proofs(proofs=proofs_copy, quote_id=mq.quote)
+            await self.db_write._unset_proofs_pending(proofs_copy, keysets=self.keysets)
+
+            # prepare change to compensate wallet for overpaid fees
+            return_promises: List[BlindedSignature] = []
+            if outputs:
+                return_promises = await self._generate_change_promises(
+                    fee_provided=fee_reserve_provided_local,
+                    fee_paid=mq.fee_paid,
+                    outputs=outputs,
+                    melt_id=mq.quote,
+                    keyset=self.keysets[outputs[0].id],
+                )
+                mq.outputs = outputs
+            mq.change = return_promises
+
+            await self.crud.update_melt_quote(quote=mq, db=self.db)
+            await self.events.submit(mq)
+            return mq
+
+        # if we can settle the melt internally, do it and set melt_quote.paid = True
+        melt_quote = await self.melt_mint_settle_internally(melt_quote, proofs)
+
+        # handle internal melts immediately
+        if melt_quote.paid or not prefer_async:
+            logger.debug(
+                f"Melt quote {melt_quote.quote} is being finalized. prefer_async={prefer_async}"
             )
-
-        melt_quote.change = return_promises
-
-        await self.crud.update_melt_quote(quote=melt_quote, db=self.db)
-        await self.events.submit(melt_quote)
+            melt_quote = await _execute_payment_and_finalize_with_error_handling(
+                melt_quote,
+                proofs,
+                previous_state,
+                fee_reserve_provided,
+                unit,
+                method,
+                outputs,
+                _execute_payment_and_finalize
+            )
+        # If prefer_async is set, launch background task and return pending immediately
+        else:
+            self._create_background_task(
+                self._execute_payment_and_finalize_with_error_handling(
+                    melt_quote,
+                    proofs,
+                    previous_state,
+                    fee_reserve_provided,
+                    unit,
+                    method,
+                    outputs,
+                    _execute_payment_and_finalize,
+                )
+            )
 
         return PostMeltQuoteResponse.from_melt_quote(melt_quote)
 

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -195,6 +195,9 @@ class Ledger(
         logger.debug("Shutting down regular tasks")
         for task in self.regular_tasks:
             task.cancel()
+        logger.debug("Shutting down background melt tasks")
+        for task in self.background_tasks:
+            task.cancel()
 
     async def _check_pending_proofs_and_melt_quotes(self):
         """Startup routine that checks all pending melt quotes and either invalidates

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -327,9 +327,11 @@ async def melt(request: Request, payload: PostMeltRequest) -> PostMeltQuoteRespo
     """
     Requests tokens to be destroyed and sent out via Lightning.
     """
-    logger.trace(f"> POST /v1/melt/bolt11: {payload}")
+    prefer = request.headers.get("Prefer")
+    logger.trace(f"> POST /v1/melt/bolt11: {payload}" + (f" with Prefer header set to {prefer}" if prefer else ""))
     resp = await ledger.melt(
-        proofs=payload.inputs, quote=payload.quote, outputs=payload.outputs
+        proofs=payload.inputs, quote=payload.quote, outputs=payload.outputs,
+        prefer_async=(True if prefer and "respond-async" in prefer.lower() else False)
     )
     logger.trace(f"< POST /v1/melt/bolt11: {resp}")
     return resp

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -327,11 +327,13 @@ async def melt(request: Request, payload: PostMeltRequest) -> PostMeltQuoteRespo
     """
     Requests tokens to be destroyed and sent out via Lightning.
     """
-    prefer = request.headers.get("Prefer")
-    logger.trace(f"> POST /v1/melt/bolt11: {payload}" + (f" with Prefer header set to {prefer}" if prefer else ""))
+    prefer_async = False
+    if payload.prefer_async:
+        prefer_async = True
+    logger.trace(f"> POST /v1/melt/bolt11: {payload}" + (f" with prefer_async={prefer_async}" if prefer_async else ""))
     resp = await ledger.melt(
         proofs=payload.inputs, quote=payload.quote, outputs=payload.outputs,
-        prefer_async=(True if prefer and "respond-async" in prefer.lower() else False)
+        prefer_async=prefer_async
     )
     logger.trace(f"< POST /v1/melt/bolt11: {resp}")
     return resp

--- a/cashu/wallet/lightning/lightning.py
+++ b/cashu/wallet/lightning/lightning.py
@@ -57,11 +57,12 @@ class LightningWallet(Wallet):
             payment_request=mint_quote.request,
         )
 
-    async def pay_invoice(self, request: str) -> PaymentResponse:
+    async def pay_invoice(self, request: str, prefer_async: bool = False) -> PaymentResponse:
         """Pay lightning invoice
 
         Args:
             request (str): bolt11 payment request
+            prefer_async (bool): If set, will append a `Prefer: respond-async` header to the request
 
         Returns:
             PaymentResponse: containing details of the operation
@@ -74,7 +75,7 @@ class LightningWallet(Wallet):
             return PaymentResponse(result=PaymentResult.FAILED)
         _, send_proofs = await self.swap_to_send(self.proofs, total_amount)
         try:
-            resp = await self.melt(send_proofs, request, quote.fee_reserve, quote.quote)
+            resp = await self.melt(send_proofs, request, quote.fee_reserve, quote.quote, prefer_async)
             if resp.change:
                 fees_paid_sat = quote.fee_reserve - sum_promises(resp.change)
             else:

--- a/cashu/wallet/v1_api.py
+++ b/cashu/wallet/v1_api.py
@@ -523,6 +523,7 @@ class LedgerAPI(LedgerAPIDeprecated, SupportsAuth):
         quote: str,
         proofs: List[Proof],
         outputs: Optional[List[BlindedMessage]],
+        prefer_async: bool = False,
     ) -> PostMeltQuoteResponse:
         """
         Accepts proofs and a lightning invoice to pay in exchange.
@@ -542,11 +543,13 @@ class LedgerAPI(LedgerAPIDeprecated, SupportsAuth):
                 "outputs": {i: outputs_include for i in range(len(outputs))},
             }
 
+        headers = {"Prefer": "respond-async"} if prefer_async else None
         resp = await self._request(
             POST,
             "melt/bolt11",
             json=payload.dict(include=_meltrequest_include_fields(proofs, outputs)),  # type: ignore
             timeout=None,
+            headers=headers,
         )
         try:
             self.raise_on_error_request(resp)

--- a/cashu/wallet/v1_api.py
+++ b/cashu/wallet/v1_api.py
@@ -529,7 +529,7 @@ class LedgerAPI(LedgerAPIDeprecated, SupportsAuth):
         Accepts proofs and a lightning invoice to pay in exchange.
         """
 
-        payload = PostMeltRequest(quote=quote, inputs=proofs, outputs=outputs)
+        payload = PostMeltRequest(quote=quote, inputs=proofs, outputs=outputs, prefer_async=prefer_async)
 
         def _meltrequest_include_fields(
             proofs: List[Proof], outputs: List[BlindedMessage]
@@ -541,15 +541,14 @@ class LedgerAPI(LedgerAPIDeprecated, SupportsAuth):
                 "quote": ...,
                 "inputs": {i: proofs_include for i in range(len(proofs))},
                 "outputs": {i: outputs_include for i in range(len(outputs))},
+                "prefer_async": ...,
             }
 
-        headers = {"Prefer": "respond-async"} if prefer_async else None
         resp = await self._request(
             POST,
             "melt/bolt11",
             json=payload.dict(include=_meltrequest_include_fields(proofs, outputs)),  # type: ignore
             timeout=None,
-            headers=headers,
         )
         try:
             self.raise_on_error_request(resp)

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -828,7 +828,7 @@ class Wallet(
         return melt_quote
 
     async def melt(
-        self, proofs: List[Proof], invoice: str, fee_reserve_sat: int, quote_id: str
+        self, proofs: List[Proof], invoice: str, fee_reserve_sat: int, quote_id: str, prefer_async: bool = False,
     ) -> PostMeltQuoteResponse:
         """Pays a lightning invoice and returns the status of the payment.
 
@@ -836,7 +836,7 @@ class Wallet(
             proofs (List[Proof]): List of proofs to be spent.
             invoice (str): Lightning invoice to be paid.
             fee_reserve_sat (int): Amount of fees to be reserved for the payment.
-
+            prefer_async (bool): If set, appends a `Prefer: respons-async` header to the request.
         """
 
         # Make sure we're operating on an independent copy of proofs
@@ -858,7 +858,7 @@ class Wallet(
         await self.set_reserved_for_melt(proofs, reserved=True, quote_id=quote_id)
         proofs = self.sign_proofs_inplace_melt(proofs, change_outputs, quote_id)
         try:
-            melt_quote_resp = await super().melt(quote_id, proofs, change_outputs)
+            melt_quote_resp = await super().melt(quote_id, proofs, change_outputs, prefer_async)
         except Exception as e:
             logger.debug(f"Mint error: {e}")
             # remove the melt_id in proofs and set reserved to False

--- a/tests/mint/test_mint_melt_async.py
+++ b/tests/mint/test_mint_melt_async.py
@@ -1,0 +1,130 @@
+import asyncio
+
+import pytest
+import pytest_asyncio
+
+from cashu.core.base import MeltQuoteState, Unit
+from cashu.core.settings import settings
+from cashu.mint.ledger import Ledger
+from cashu.wallet.wallet import Wallet
+from tests.helpers import (
+    get_real_invoice,
+    is_deprecated_api_only,
+    is_fake,
+    pay_if_regtest,
+)
+
+SERVER_ENDPOINT = "http://localhost:3337"
+invoice_62_sat = "lnbcrt620n1pn0r3vepp5zljn7g09fsyeahl4rnhuy0xax2puhua5r3gspt7ttlfrley6valqdqqcqzzsxqyz5vqsp577h763sel3q06tfnfe75kvwn5pxn344sd5vnays65f9wfgx4fpzq9qxpqysgqg3re9afz9rwwalytec04pdhf9mvh3e2k4r877tw7dr4g0fvzf9sny5nlfggdy6nduy2dytn06w50ls34qfldgsj37x0ymxam0a687mspp0ytr8"
+
+
+@pytest_asyncio.fixture(scope="function")
+async def wallet1(ledger: Ledger):
+    wallet1 = await Wallet.with_db(
+        url=SERVER_ENDPOINT,
+        db="test_data/wallet_1",
+        name="wallet_1",
+    )
+    await wallet1.load_mint()
+    yield wallet1
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    is_deprecated_api_only,
+    reason=("Deprecated API"),
+)
+async def test_melt_internal_async(ledger: Ledger, wallet1: Wallet):
+    quote = await wallet1.request_mint(64)
+    await pay_if_regtest(quote.request)
+    proofs = await wallet1.mint(64, quote.quote)
+    assert wallet1.available_balance == 64
+
+    # create a melt quote for an internal payment
+    invoice_internal = await wallet1.mint_quote(10, Unit.sat)
+
+    # melt the proofs
+    quote = await wallet1.melt_quote(invoice_internal.request)
+    melt_resp = await wallet1.melt(
+        proofs,
+        invoice_internal.request,
+        quote.fee_reserve,
+        quote.quote,
+        prefer_async=True,
+    )
+
+    # internal melts are settled immediately
+    assert melt_resp.state == MeltQuoteState.paid.value
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    is_deprecated_api_only,
+    reason=("Deprecated API"),
+)
+async def test_melt_external_async(ledger: Ledger, wallet1: Wallet):
+    # mint a proof in keyset_a
+    quote = await wallet1.request_mint(64)
+    await pay_if_regtest(quote.request)
+    proofs = await wallet1.mint(64, quote.quote)
+    assert wallet1.available_balance == 64
+
+    # create a melt quote for an external payment
+    external_invoice = (
+        invoice_62_sat if is_fake else get_real_invoice(62)["payment_request"]
+    )
+    quote = await wallet1.melt_quote(external_invoice)
+
+    # melt the proofs
+    melt_resp = await wallet1.melt(
+        proofs, external_invoice, quote.fee_reserve, quote.quote, prefer_async=True
+    )
+
+    # the response should be pending
+    assert melt_resp.state == "PENDING"
+
+    delay = settings.fakewallet_delay_outgoing_payment or 0
+    await asyncio.sleep(delay + 1)
+
+    settled = await wallet1.get_melt_quote(quote.quote)
+    assert settled is not None
+    assert settled.state == MeltQuoteState.paid
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    is_deprecated_api_only or is_fake,
+    reason=("Deprecated API"),
+)
+async def test_melt_external_async_get_quote_race(ledger: Ledger, wallet1: Wallet):
+    # we call get_melt_quote right after executing a melt
+    # mint a proof in keyset_a
+    quote = await wallet1.request_mint(64)
+    await pay_if_regtest(quote.request)
+    proofs = await wallet1.mint(64, quote.quote)
+    assert wallet1.available_balance == 64
+
+    # create a melt quote for an external payment
+    external_invoice = (
+        invoice_62_sat if is_fake else get_real_invoice(62)["payment_request"]
+    )
+    quote = await wallet1.melt_quote(external_invoice)
+
+    # melt the proofs
+    melt_resp = await wallet1.melt(
+        proofs, external_invoice, quote.fee_reserve, quote.quote, prefer_async=True
+    )
+
+    # the response should be pending
+    assert melt_resp.state == "PENDING"
+
+    pending_quote = await wallet1.get_melt_quote(quote.quote)
+    assert pending_quote
+    assert pending_quote.state == MeltQuoteState.pending
+
+    delay = settings.fakewallet_delay_outgoing_payment or 0
+    await asyncio.sleep(delay + 1)
+
+    settled = await wallet1.get_melt_quote(quote.quote)
+    assert settled is not None
+    assert settled.state == MeltQuoteState.paid


### PR DESCRIPTION
## Summary
This PR adds support for `prefer_async` option in the `POST /v1/melt/bolt11` request body. If a request contains this option set to true, the Mint no longer blocks until the operation is completed, but rather it schedules a task for the backend and returns immediately with a `PENDING` melt quote response.

Relevant specification PR is [here](https://github.com/cashubtc/nuts/pull/285).

### Changes
- Added `prefer_async` field to `PostMeltRequest` model.
- Updated `Wallet.melt` to support `prefer_async` argument.
- Updated Mint's `POST /v1/melt/bolt11` endpoint to handle `prefer_async` from the request body.
