### PR TITLE
Wallet fix: update keyset fees on `load_mint()`

### DIFF
--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -733,7 +733,7 @@ class WalletKeyset:
         self.valid_from = valid_from
         self.valid_to = valid_to
         self.first_seen = first_seen
-        self.active = active
+        self.active = bool(active)
         self.mint_url = mint_url
         self.input_fee_ppk = input_fee_ppk
 

--- a/cashu/wallet/crud.py
+++ b/cashu/wallet/crud.py
@@ -243,12 +243,13 @@ async def update_keyset(
     await (conn or db).execute(
         """
         UPDATE keysets
-        SET active = :active
+        SET active = :active, input_fee_ppk = :input_fee_ppk
         WHERE id = :id
         """,
         {
             "active": keyset.active,
             "id": keyset.id,
+            "input_fee_ppk": keyset.input_fee_ppk,
         },
     )
 

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -343,6 +343,9 @@ class Wallet(
                     ].input_fee_ppk = mint_keyset.input_fee_ppk
                     changed = True
                 if changed:
+                    logger.debug(
+                        f"Updating mint keyset: {mint_keyset.id} ({mint_keyset.unit}) fee: {mint_keyset.input_fee_ppk} ppk, active: {mint_keyset.active}"
+                    )
                     await update_keyset(
                         keyset=keysets_in_db_dict[mint_keyset.id], db=self.db
                     )


### PR DESCRIPTION
Wallet tried to update keyset fees but the crud didn't have that feature.