### PR TITLE
docs: update poetry activation instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,16 +3,19 @@
 Please contribute to Nutshell! You can open issues if you find bugs and pull requests for improvements.
 
 ## Contributing
+
 Pick an issue you would like to work on. Those with the tag `good first issue` are great for getting started. When you open a pull request, make sure that you've run tests and formatting locally before you push code.
 
 ## Formatting
+
 We use [Ruff](https://docs.astral.sh/ruff/formatter/) for formatting. To make sure that your tests succeed, please run `make format` before you push code. You can find the Ruff parameters in `pyproject.toml`.
 
 ## Setting up your environment
 
-We use [Poetry](https://python-poetry.org/) as a dependency and environment manager. Currently, Nutshell supports Python `3.10.4` which you can install using `pyenv` (see README.md). To install all dependencies, run `poetry install`. After install, you can activate the shell with `poetry shell`. Now you can execute `cashu --help` to use the wallet or `mint` to run the mint.
+We use [Poetry](https://python-poetry.org/) as a dependency and environment manager. Currently, Nutshell supports Python `3.10.4` which you can install using `pyenv` (see README.md). To install all dependencies, run `poetry install`. After install, activate the environment with `poetry env activate` (or install the optional poetry-plugin-shell if you prefer `poetry shell`). Now you can execute `cashu --help` to use the wallet or `mint` to run the mint.
 
 ### Precommit hook
+
 To run the formatter and mypy (linter) before you push code, you can install the very useful pre-commit hook which will check your code every time you push with git.
 
 ```bash
@@ -53,6 +56,7 @@ FAKEWALLET_DELAY_INCOMING_PAYMENT=3
 There are many tests that also run in regtest, a simulated Lightning network environment. To run the regtest, clone [this repository](https://github.com/callebtc/cashu-regtest) and run `./start.sh`. This will start your regtest environment with several Lightning node implementations.
 
 You can choose one of the nodes as a backend for nutshell using the `.env` variable:
+
 ```
 # Choose one from:
 # LndRestWallet, CLNRestWallet, CoreLightningRestWallet, LNbitsWallet


### PR DESCRIPTION
Issue: `CONTRIBUTING.md` still tells contributors to run poetry shell, which no longer exists by default in `Poetry ≥2.0`. New contributors hit a “command not available” error when following the setup instructions.

fix: Updated the setup paragraph to instruct contributors to run `poetry env activate` (and optionally mention installing poetry-plugin-shell if they prefer the legacy command). This keeps the docs consistent with Poetry 2.x behavior.