### PR TITLE
test: await first melt in test_melt_quote_reuse_same_outputs

### DIFF
--- a/tests/mint/test_mint_melt.py
+++ b/tests/mint/test_mint_melt.py
@@ -242,7 +242,7 @@ async def test_melt_quote_reuse_same_outputs(wallet, ledger: Ledger):
     change_outputs, change_rs = wallet._construct_outputs(
         n_change_outputs * [1], change_secrets, change_rs
     )
-    (ledger.melt(proofs=proofs1, quote=melt_quote1.quote, outputs=change_outputs),)
+    await ledger.melt(proofs=proofs1, quote=melt_quote1.quote, outputs=change_outputs)
 
     await assert_err(
         ledger.melt(


### PR DESCRIPTION
The test `test_melt_quote_reuse_same_outputs` had an unawaited coroutine on line 245, causing:

- A `RuntimeWarning: coroutine 'Ledger.melt' was never awaited`
- The first melt never executing, so no outputs were stored
- The test passing for the **wrong reason** - it wasn't actually testing output reuse protection

Solution

Add `await` to the first melt call:

```python
# Before (line 245):
ledger.melt(proofs=proofs1, quote=melt_quote1.quote, outputs=change_outputs)

# After:
await ledger.melt(proofs=proofs1, quote=melt_quote1.quote, outputs=change_outputs)
```


The test verifies that reusing the same outputs in two melt requests fails:

1. **Line 893 (ledger.py)**: `_verify_outputs()` checks if outputs were already signed via `_check_outputs_pending_or_issued_before()`
2. **Line 158 (verification.py)**: `_check_outputs_pending_or_issued_before()` queries the promises table by `b_` (blinded message)
3. **Line 140 (verification.py)**: If any outputs are found, it raises `OutputsAlreadySignedError()`
4. **Line 933 (ledger.py)**: If outputs pass verification, they are stored in the promises table via `_store_blinded_messages()` with `melt_id=melt_quote.quote`

Expected behavior:

- **First melt**: Uses `change_outputs` - outputs stored in DB
- **Second melt**: Reuses the same `change_outputs` - should fail with `OutputsAlreadySignedError`

Without awaiting the first melt:

- The first melt never runs
- Outputs are never stored
- The second melt may not fail as expected
- The test may pass for the wrong reason

 the test should validate that the system prevents reusing the same outputs in multiple melt operations, but without `await`, it doesn't actually test this protection.