### PR TITLE
This is a rebased version of "simplify `amount_split` by iterating over amount bits"

### DIFF
--- a/cashu/core/split.py
+++ b/cashu/core/split.py
@@ -5,9 +5,8 @@ def amount_split(amount: int) -> List[int]:
     """Given an amount returns a list of amounts returned e.g. 13 is [1, 4, 8]."""
     if amount <= 0:
         return []
-    bits_amt = bin(amount)[::-1][:-2]
     rv = []
-    for pos, bit in enumerate(bits_amt):
-        if bit == "1":
-            rv.append(2**pos)
+    for i in range(amount.bit_length()):
+        if amount & (1 << i):  # if bit i is set, add 2**i to list
+            rv.append(1 << i)
     return rv


### PR DESCRIPTION
This is a rebased version of  #245 

Original author: @theStack 
Changes: Rebased onto main and resolved conflicts.
Closes #245 

Original message: 
Small optimization: rather than involving a string data type here (which needs to also be reversed and sliced), we can just directly operate on the amount integer variable by iterating over all the bits and add 2^i to the return list if bit i is set.

Also, add type hints to the parameter / return value and assert that the passed value must not be negative.

Updated notes:
With all of the changes over the years the only bit needed from the original PR was the change from string manipulation of binary number to the Bitwise operations. There had been talk around failing tests due to assertions, and negative amounts. All of that has been updated / resolved in other commits.
