### PR TITLE
fix: correct inverted expiry check in mint quote validation

### DIFF
--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -504,7 +504,7 @@ class Ledger(
                 raise TransactionError("quote unit does not match output unit")
             if not quote.amount == sum_amount_outputs:
                 raise TransactionError("amount to mint does not match quote amount")
-            if quote.expiry and quote.expiry > int(time.time()):
+            if quote.expiry and quote.expiry < int(time.time()):
                 raise TransactionError("quote expired")
             if not self._verify_mint_quote_witness(quote, outputs, signature):
                 raise QuoteSignatureInvalidError()


### PR DESCRIPTION
## Summary

The expiry check in `mint()` was using `>` instead of `<`, causing the mint to:
- **Reject valid quotes** (where expiry is in the future)
- **Accept expired quotes** (where expiry is in the past)

## The Bug

`quote.expiry` is a Unix timestamp representing when the quote expires (set as `invoice.date + invoice.expiry`).

**Previous (buggy) code:**
```python
if quote.expiry and quote.expiry > int(time.time()):
    raise TransactionError("quote expired")
```

This raises "quote expired" when `quote.expiry > now`, meaning when the expiry is in the **future** (quote is still valid).

**Fixed code:**
```python
if quote.expiry and quote.expiry < int(time.time()):
    raise TransactionError("quote expired")
```

This correctly raises "quote expired" when `quote.expiry < now`, meaning when the expiry is in the **past** (quote has actually expired).

## Impact

- **Severity**: Denial of Service for mint operations
- **Not exploitable for fund theft** because the `quote.paid` check at line 497 happens first, ensuring the Lightning invoice was actually paid before reaching the expiry check
- Any mint with expiry set on quotes would reject all valid mint attempts

## Test

Simple proof that the logic was inverted:

```python
import time

# Quote created now with 1 hour expiry
quote_expiry = int(time.time()) + 3600
now = int(time.time())

# Buggy: quote_expiry > now = True → raises "quote expired" (WRONG - quote is valid!)
# Fixed: quote_expiry < now = False → quote is valid (CORRECT)
```