### PR TITLE
fix: preserve keyset timestamps during rotation on SQLite

### DIFF
--- a/cashu/core/db.py
+++ b/cashu/core/db.py
@@ -353,10 +353,15 @@ class Database(Compat):
         return timestamp
 
     def to_timestamp(
-        self, timestamp: Union[str, datetime.datetime]
+        self, timestamp: Union[str, datetime.datetime, int]
     ) -> Union[str, datetime.datetime]:
-        if not timestamp:
+        if timestamp is None or timestamp == "":
             timestamp = self.timestamp_now_str()
+        if isinstance(timestamp, int):
+            if self.type in {POSTGRES, COCKROACH}:
+                return datetime.datetime.fromtimestamp(timestamp)
+            elif self.type == SQLITE:
+                return str(timestamp)
         if self.type in {POSTGRES, COCKROACH}:
             # return datetime.datetime
             if isinstance(timestamp, datetime.datetime):


### PR DESCRIPTION
fix #882 
SQLite may return numeric timestamp strings as integers. The `to_timestamp()` function only handled `str` and `datetime` types, causing it to return "<nothing>" when receiving an `int`, which resulted in keyset timestamps being nullified during rotation after a mint restart.                                                                                                                                 
                                                                                                                                                        
This fix adds support for `int` timestamps by converting them to the appropriate format for each database type. 
