### PR TITLE
fix: use -- before quote ID in management CLI tests

### DIFF
--- a/tests/test_mint_rpc_cli.py
+++ b/tests/test_mint_rpc_cli.py
@@ -109,7 +109,8 @@ async def test_update_mint_quote(cli_prefix):
     mint_quote = await wallet.request_mint(100)
     await asyncio.sleep(1)
     runner = CliRunner()
-    result = runner.invoke(cli, [*cli_prefix, "update", "mint-quote", mint_quote.quote, "ISSUED"])
+    # Use -- to prevent Click from interpreting quote_id (e.g. -JmE...) as options
+    result = runner.invoke(cli, [*cli_prefix, "update", "mint-quote", "--", mint_quote.quote, "ISSUED"])
     assert result.exception is None
     assert "Successfully updated!" in result.output
 
@@ -124,7 +125,8 @@ async def test_update_melt_quote(cli_prefix):
     assert melt_quote.quote
     await asyncio.sleep(1)
     runner = CliRunner()
-    result = runner.invoke(cli, [*cli_prefix, "update", "melt-quote", melt_quote.quote, "PAID"])
+    # Use -- to prevent Click from interpreting quote_id (e.g. -JmE...) as options
+    result = runner.invoke(cli, [*cli_prefix, "update", "melt-quote", "--", melt_quote.quote, "PAID"])
     assert result.exception is None
     assert "Successfully updated!" in result.output
 
@@ -134,7 +136,8 @@ async def test_get_mint_quote(cli_prefix):
     mint_quote = await wallet.request_mint(100)
     await asyncio.sleep(1)
     runner = CliRunner()
-    result = runner.invoke(cli, [*cli_prefix, "get", "mint-quote", mint_quote.quote])
+    # Use -- to prevent Click from interpreting quote_id (e.g. -JmE...) as options
+    result = runner.invoke(cli, [*cli_prefix, "get", "mint-quote", "--", mint_quote.quote])
     assert result.exception is None
     assert "mint quote:" in result.output
 
@@ -148,7 +151,8 @@ async def test_get_melt_quote(cli_prefix):
     melt_quote = await wallet.melt_quote("lnbc1u1p5qefd7sp55l6kmcrnqz5rejy4lghmgf9de0ucmmn2s3lvkvtkrr0qkwk5r0espp5da4x63rspz5rcfretdh6573c6qlpnzpxc8yq26cyqjc4sk0srfwsdqqcqpjrzjqv3dpepm8kfdxrk3sl6wzqdf49s9c0h9ljtjrek6c08r6aejlwcnur2z3sqqrrgqqyqqqqqqqqqqfcsqjq9qxpqysgq4l5rfjd4h84w7prmtgzjvq79ddy266svuz0d7dg44jmnwjpxg0zxef6hn4j8nzfp4c67qjpe0c9aw63ghu7rtcdg6n4zka9hym69euqq8w5wmj")
     await asyncio.sleep(1)
     runner = CliRunner()
-    result = runner.invoke(cli, [*cli_prefix, "get", "melt-quote", melt_quote.quote])
+    # Use -- to prevent Click from interpreting quote_id (e.g. -JmE...) as options
+    result = runner.invoke(cli, [*cli_prefix, "get", "melt-quote", "--", melt_quote.quote])
     assert result.exception is None
     assert "melt quote:" in result.output
 


### PR DESCRIPTION
## Problem

`test_update_mint_quote` fails intermittently when the randomly generated quote ID starts with `-` (e.g. `-JmECgu3H0xlh2XsyDKVHFOAs_5b9Cb1haggycMW`).

**CI failure:** https://github.com/cashubtc/nutshell/actions/runs/22685753832/job/65768140022?pr=911#step:5:250


##  Cause

Quote IDs are produced by `random_hash()` (base64url encoding of 30 random bytes). The base64url alphabet includes `-`, so IDs can legally start with `-`.

When the test runs `cashu update mint-quote -JmE... ISSUED`, Click parses `-J...` as an option instead of a positional argument, causing a usage error (exit code 2).

## Solution

Add `--` before the quote ID in all management CLI test invocations that pass quote IDs. This tells Click to treat everything after as positional arguments, which is the standard way to handle values that look like options.