### PR TITLE
feat(wallet): add 'lock p2pk' CLI command with --timelock and --refund

### DIFF
--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -361,10 +361,10 @@ async def pay(
                 }
 
                 try:
-                     async with httpx.AsyncClient() as client:
+                    async with httpx.AsyncClient() as client:
                         r = await client.post(url, json=payload, timeout=10)
                         r.raise_for_status()
-                     print(f" Done (Status: {r.status_code}).")
+                    print(f" Done (Status: {r.status_code}).")
                 except Exception as e:
                     print(f" Failed: {e}")
                     print(f"Manual Token: {token}")
@@ -745,6 +745,14 @@ async def balance(ctx: Context, verbose):
 )
 @click.option("--lock", "-l", default=None, help="Lock tokens (P2PK).", type=str)
 @click.option(
+    "--refund",
+    "-r",
+    default=None,
+    multiple=True,
+    help="Refund public key (can be specified multiple times).",
+    type=str,
+)
+@click.option(
     "--dleq",
     "-d",
     default=False,
@@ -754,7 +762,6 @@ async def balance(ctx: Context, verbose):
 )
 @click.option(
     "--legacy",
-    "-l",
     default=False,
     is_flag=True,
     help="Print legacy TokenV3 format.",
@@ -792,6 +799,7 @@ async def send_command(
     amount: int,
     memo: str,
     lock: str,
+    refund: tuple,
     dleq: bool,
     legacy: bool,
     offline: bool,
@@ -810,6 +818,7 @@ async def send_command(
         include_fees=include_fees,
         memo=memo,
         force_swap=force_swap,
+        refund_pubkeys=list(refund) if refund else None,
     )
     await print_balance(ctx)
 
@@ -1011,10 +1020,31 @@ async def pending(ctx: Context, legacy, number: int, offset: int):
         print("To receive all pending tokens use: cashu receive -a")
 
 
-@cli.command("lock", help="Generate receiving lock.")
+@cli.group(cls=NaturalOrderGroup)
+def lock():
+    """Generate receiving locks."""
+    pass
+
+
+@lock.command("p2pk", help="Generate a P2PK lock with optional timelock and refund.")
+@click.option(
+    "--timelock",
+    "-t",
+    default=None,
+    help="Locktime in seconds after which the refund pubkey can claim the tokens.",
+    type=int,
+)
+@click.option(
+    "--refund",
+    "-r",
+    default=None,
+    multiple=True,
+    help="Refund public key (can be specified multiple times).",
+    type=str,
+)
 @click.pass_context
 @coro
-async def lock(ctx: Context):
+async def lock_p2pk(ctx: Context, timelock: Optional[int], refund: tuple):
     wallet: Wallet = ctx.obj["WALLET"]
 
     pubkey = await wallet.create_p2pk_pubkey()
@@ -1025,9 +1055,21 @@ async def lock(ctx: Context):
     print("")
     print(f"Public receiving lock: {lock_str}")
     print("")
-    print(
-        f"Anyone can send tokens to this lock:\n\ncashu send <amount> --lock {lock_str}"
-    )
+
+    if timelock:
+        print(f"Timelock: {timelock} seconds")
+    if refund:
+        for r in refund:
+            print(f"Refund pubkey: {r}")
+    if timelock or refund:
+        print("")
+
+    send_cmd = f"cashu send <amount> --lock {lock_str}"
+    if refund:
+        for r in refund:
+            send_cmd += f" --refund {r}"
+
+    print(f"Anyone can send tokens to this lock:\n\n{send_cmd}")
     print("")
     print("Only you can receive tokens from this lock: cashu receive <token>")
 
@@ -1498,4 +1540,3 @@ async def lnurl_mint(ctx: Context):
             print("No tokens minted.")
     except Exception as e:
         print(f"Error minting quotes: {e}")
-

--- a/cashu/wallet/helpers.py
+++ b/cashu/wallet/helpers.py
@@ -1,6 +1,6 @@
 import hashlib
 import os
-from typing import Optional
+from typing import List, Optional
 
 from loguru import logger
 
@@ -8,6 +8,7 @@ from ..core.base import Token, TokenV3, TokenV4
 from ..core.db import Database
 from ..core.helpers import sum_proofs
 from ..core.migrations import migrate_databases
+from ..core.secret import Tags
 from ..core.settings import settings
 from ..wallet import migrations
 from ..wallet.crud import get_keysets
@@ -121,6 +122,7 @@ async def send(
     include_fees: bool = False,
     memo: Optional[str] = None,
     force_swap: bool = False,
+    refund_pubkeys: Optional[List[str]] = None,
 ):
     """
     Prints token to send to stdout.
@@ -137,11 +139,16 @@ async def send(
             logger.debug(
                 f"Adding a time lock of {settings.locktime_delta_seconds} seconds."
             )
+            tags = None
+            if refund_pubkeys:
+                tags = Tags()
+                tags["refund"] = refund_pubkeys
             secret_lock = await wallet.create_p2pk_lock(
                 lock.split(":")[1],
                 locktime_seconds=settings.locktime_delta_seconds,
                 sig_all=sigall,
                 n_sigs=1,
+                tags=tags,
             )
             logger.debug(f"Secret lock: {secret_lock}")
         else:

--- a/tests/wallet/test_wallet_cli.py
+++ b/tests/wallet/test_wallet_cli.py
@@ -584,3 +584,103 @@ def test_send_with_lock(mint, cli_prefix):
     assert "cashuB" in token_str, "output does not have a token"
     token = TokenV4.deserialize(token_str).to_tokenv3()
     assert pubkey in token.token[0].proofs[0].secret
+
+
+def test_lock_p2pk(cli_prefix):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "lock", "p2pk"],
+    )
+    assert result.exception is None
+    print("test_lock_p2pk", result.output)
+    assert "P2PK:" in result.output
+    assert "Pay to public key (P2PK)" in result.output
+    assert result.exit_code == 0
+
+
+def test_lock_p2pk_with_timelock(cli_prefix):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "lock", "p2pk", "--timelock", "3600"],
+    )
+    assert result.exception is None
+    print("test_lock_p2pk_with_timelock", result.output)
+    assert "P2PK:" in result.output
+    assert "Timelock: 3600 seconds" in result.output
+    assert result.exit_code == 0
+
+
+def test_lock_p2pk_with_refund(cli_prefix):
+    fake_refund_pubkey = "02" + "ab" * 32
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "lock", "p2pk", "--refund", fake_refund_pubkey],
+    )
+    assert result.exception is None
+    print("test_lock_p2pk_with_refund", result.output)
+    assert "P2PK:" in result.output
+    assert f"Refund pubkey: {fake_refund_pubkey}" in result.output
+    assert f"--refund {fake_refund_pubkey}" in result.output
+    assert result.exit_code == 0
+
+
+def test_lock_p2pk_with_timelock_and_refund(cli_prefix):
+    fake_refund_pubkey = "02" + "cd" * 32
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            *cli_prefix,
+            "lock",
+            "p2pk",
+            "--timelock",
+            "7200",
+            "--refund",
+            fake_refund_pubkey,
+        ],
+    )
+    assert result.exception is None
+    print("test_lock_p2pk_with_timelock_and_refund", result.output)
+    assert "P2PK:" in result.output
+    assert "Timelock: 7200 seconds" in result.output
+    assert f"Refund pubkey: {fake_refund_pubkey}" in result.output
+    assert result.exit_code == 0
+
+
+def test_send_with_lock_and_refund(mint, cli_prefix):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "locks"],
+    )
+    assert result.exception is None
+    lock = None
+    for word in result.output.split(" "):
+        word = word.strip()
+        if word.startswith("P2PK:"):
+            lock = word
+            break
+    assert lock is not None, "no lock found"
+
+    fake_refund_pubkey = "02" + "ef" * 32
+    result = runner.invoke(
+        cli,
+        [
+            *cli_prefix,
+            "send",
+            "10",
+            "--lock",
+            lock,
+            "--refund",
+            fake_refund_pubkey,
+        ],
+    )
+    assert result.exception is None
+    print("test_send_with_lock_and_refund", result.output)
+    token_str = result.output.split("\n")[0]
+    assert "cashuB" in token_str, "output does not have a token"
+    token = TokenV4.deserialize(token_str).to_tokenv3()
+    assert fake_refund_pubkey in token.token[0].proofs[0].secret


### PR DESCRIPTION
## [Wallet] Add new CLI command for locking tokens

Closes #506

### Changes

- Converted `cashu lock` into a subcommand group with `cashu lock p2pk`
- Added `--timelock / -t` and `--refund / -r` options to `cashu lock p2pk`
- Added `--refund / -r` option to `cashu send` for specifying refund pubkeys
- Fixed duplicate `-l` short flag conflict between `--lock` and `--legacy` on [send](cci:1://file:///Users/ritoban/github-repos/nutshell/cashu/wallet/helpers.py:112:0-175:42)
- Added tests for new commands

### Usage

```bash
cashu lock p2pk
cashu lock p2pk --timelock 3600 --refund 02abcdef...
cashu send 100 --lock P2PK:02abc... --refund 02def...
