### PR TITLE
test(mint): add tests for gRPC server functions in management_rpc

### DIFF
--- a/tests/mint/test_mint_management_rpc.py
+++ b/tests/mint/test_mint_management_rpc.py
@@ -164,10 +164,6 @@ async def test_rotate_next_keyset(rpc_servicer):
     assert response.final_expiry == 86400
     assert response.max_order > 0
 
-
-
-
-
 @pytest.mark.asyncio
 async def test_nut04_quote(rpc_servicer):
     quote_id = "test-mint-quote-123"


### PR DESCRIPTION
## Summary
* Added comprehensive unit tests for `MintManagementRPC` gRPC endpoints.
* Validated server functions including `GetInfo`, configuration updates (`MOTD`, descriptions, `Name`, `IconUrl`), external references (URLs, Contacts), Lightning/Auth limits, quote management, and keyset rotation logic.
* Ensures direct RPC coverage independent of the existing CLI tests.