### PR TITLE
fix(wallet): skip mpp test for LNbits in regtest

### DIFF
--- a/tests/wallet/test_wallet_regtest_mpp.py
+++ b/tests/wallet/test_wallet_regtest_mpp.py
@@ -230,6 +230,10 @@ async def test_regtest_pay_mpp_cancel_payment(wallet: Wallet, ledger: Ledger):
 async def test_regtest_pay_mpp_cancel_payment_pay_partial_invoice(
     wallet: Wallet, ledger: Ledger
 ):
+    # make sure that mpp is supported by the bolt11-sat backend
+    if not ledger.backends[Method["bolt11"]][wallet.unit].supports_mpp:
+        pytest.skip("backend does not support mpp")
+
     # create a hold invoice that we can cancel
     preimage, invoice_dict = get_hold_invoice(64)
     invoice_payment_request = str(invoice_dict.get("payment_request", ""))


### PR DESCRIPTION
## Summary
* Fixes the spurious CI hang inside the `regtest-wallet` job exclusively when running with `LNbitsWallet`. 
* Added a check to skip `test_regtest_pay_mpp_cancel_payment_pay_partial_invoice` for backends lacking MPP support (like `LNbitsWallet`).
* The root cause was that running the test on `LNbitsWallet` spawned an isolated thread and event loop. Because `httpx.AsyncClient` objects are tied to the event loop they are created in, using them across loops causes a `RuntimeError` (`"Event object is bound to a different event loop"`). In Python 3.10 (which CI runs), this attempts to wait on an `asyncio.Semaphore` created by a different loop, failing silently and deadlocking indefinitely until the GitHub Actions 10-minute timeout is reached.