### PR TITLE
feat: support NUT-28 P2BK

### DIFF
--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -129,6 +129,7 @@ class Proof(BaseModel):
     C: str = ""  # signature on secret, unblinded by wallet
     dleq: Optional[DLEQWallet] = None  # DLEQ proof
     witness: Union[None, str] = None  # witness for spending condition
+    p2pk_e: Union[None, str] = None  # NUT-28 P2BK ephemeral pubkey E (33-byte SEC1 hex)
 
     # whether this proof is reserved for sending, used for coin management in the wallet
     reserved: Union[None, bool] = False
@@ -172,6 +173,9 @@ class Proof(BaseModel):
 
         if self.witness:
             return_dict["witness"] = self.witness
+
+        if self.p2pk_e:
+            return_dict["p2pk_e"] = self.p2pk_e
 
         return return_dict
 
@@ -1354,6 +1358,7 @@ class TokenV4Proof(BaseModel):
     c: bytes  # signature
     d: Optional[TokenV4DLEQ] = None  # DLEQ proof
     w: Optional[str] = None  # witness
+    pe: Optional[bytes] = None  # NUT-28 P2BK ephemeral pubkey E (33-byte SEC1)
 
     @classmethod
     def from_proof(cls, proof: Proof, include_dleq=False):
@@ -1371,6 +1376,7 @@ class TokenV4Proof(BaseModel):
                 else None
             ),
             w=proof.witness,
+            pe=bytes.fromhex(proof.p2pk_e) if proof.p2pk_e else None,
         )
 
 
@@ -1441,6 +1447,7 @@ class TokenV4(Token):
                     else None
                 ),
                 witness=p.w,
+                p2pk_e=p.pe.hex() if p.pe else None,
             )
             for token in self.t
             for p in token.p
@@ -1480,6 +1487,7 @@ class TokenV4(Token):
                                 else None
                             ),
                             w=p.witness,
+                            pe=bytes.fromhex(p.p2pk_e) if p.p2pk_e else None,
                         )
                         for p in proofs
                     ],
@@ -1507,6 +1515,10 @@ class TokenV4(Token):
             for proof in token["p"]:
                 if not proof.get("w"):
                     del proof["w"]
+                # strip pe if not present
+                if not proof.get("pe"):
+                    if "pe" in proof:
+                        del proof["pe"]
         # optional memo
         if self.d:
             return_dict.update(dict(d=self.d))
@@ -1568,6 +1580,7 @@ class TokenV4(Token):
                                 else None
                             ),
                             witness=p.w,
+                            p2pk_e=p.pe.hex() if p.pe else None,
                         )
                         for p in token.p
                     ],

--- a/cashu/core/p2bk.py
+++ b/cashu/core/p2bk.py
@@ -54,32 +54,27 @@ def blind_pubkeys(
     data_pubkey: str, 
     additional_pubkeys: List[str], 
     refund_pubkeys: List[str], 
-    receiver_pubkey: str,
     ephemeral_privkey: Optional[PrivateKey] = None,
 ) -> Tuple[str, List[str], List[str], str]:
-    """blind all pubkeys in a P2PK secret using ECDH.
+    """Blind all pubkeys in a P2PK secret using per-key ECDH.
+
+    Each pubkey P_i gets its own shared secret Zx_i = x(e * P_i), as required
+    by NUT-28: "For each receiver key P, compute: Unique shared secret Zx = x(eP)."
 
     Args:
         data_pubkey: The main locking pubkey.
         additional_pubkeys: Additional pubkeys from the "pubkeys" tag.
         refund_pubkeys: Refund pubkeys from the "refund" tag.
-        receiver_pubkey: The receiver's long-lived pubkey P (used for ECDH).
         ephemeral_privkey: Optional ephemeral private key. Generated if None.
 
     Returns:
         Tuple of (blinded_data_pubkey, blinded_additional, blinded_refund, ephemeral_pubkey_hex)
     """
-    receiver_pubkey_hex = _compressed_pubkey(receiver_pubkey)
-    receiver_pk = PublicKey(bytes.fromhex(receiver_pubkey_hex))
-
     if ephemeral_privkey is None:
         ephemeral_privkey = PrivateKey(os.urandom(32))
 
     assert ephemeral_privkey.public_key
     ephemeral_pubkey_hex = ephemeral_privkey.public_key.format(compressed=True).hex()
-
-    # compute ECDH shared secret Zx = x(e * P)
-    zx = ecdh_shared_secret(receiver_pk, ephemeral_privkey)
 
     # collect all pubkeys in slot order: [data, ...pubkeys, ...refund]
     all_pubkeys = [data_pubkey] + additional_pubkeys + refund_pubkeys
@@ -87,10 +82,12 @@ def blind_pubkeys(
     for i, pk_hex in enumerate(all_pubkeys):
         pk_hex = _compressed_pubkey(pk_hex)
         pk = PublicKey(bytes.fromhex(pk_hex))
-        r_i = derive_blinding_scalar(zx, i)
+        # Per-key ECDH: Zx_i = x(e * P_i)
+        zx_i = ecdh_shared_secret(pk, ephemeral_privkey)
+        r_i = derive_blinding_scalar(zx_i, i)
         blinding_point = _scalar_to_privkey(r_i).public_key
         assert blinding_point
-        blinded_pk = pk + blinding_point  # P' = P + r_i*G
+        blinded_pk = pk + blinding_point  # type: ignore[operator]  # P' = P + r_i*G
         blinded.append(blinded_pk.format(compressed=True).hex())
 
     # split back into data, pubkeys, refund

--- a/cashu/core/p2bk.py
+++ b/cashu/core/p2bk.py
@@ -1,0 +1,157 @@
+import hashlib
+import os
+from typing import List, Optional, Tuple
+
+from .crypto.secp import PrivateKey, PublicKey
+
+# Domain separator for P2BK blinding scalar derivation
+P2BK_DOMAIN_SEPARATOR = b"Cashu_P2BK_v1"
+
+# secp256k1 curve order
+SECP256K1_ORDER = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+
+def _compressed_pubkey(pubkey_hex: str) -> str:
+    """Ensure a pubkey is in compressed SEC1 format (33 bytes / 66 hex chars).
+    Silently adds '02' prefix to bare 32-byte (BIP-340 / Nostr) x-only keys.
+    """
+    raw = bytes.fromhex(pubkey_hex)
+    if len(raw) == 32:
+        # x-only key, add 02 prefix
+        return "02" + pubkey_hex
+    if len(raw) == 33 and raw[0] in (0x02, 0x03):
+        return pubkey_hex
+    raise ValueError(f"Invalid pubkey length: {len(raw)} bytes")
+
+def ecdh_shared_secret(point: PublicKey, scalar: PrivateKey) -> bytes:
+    """Compute x-only ECDH shared secret Zx = x(scalar * point)"""
+    shared_point = point.multiply(bytes.fromhex(scalar.to_hex()))
+    # compressed format is prefix (1 byte) + x-coordinate (32 bytes)
+    compressed = shared_point.format(compressed=True)
+    return compressed[1:]  # strip the 02/03 prefix to get Zx
+
+def derive_blinding_scalar(zx: bytes, slot_index: int) -> int:
+    """Derive a deterministic blinding scalar r_i from ECDH shared secret and slot index."""
+    i_byte = bytes([slot_index & 0xFF])
+    data = P2BK_DOMAIN_SEPARATOR + zx + i_byte
+    r = int.from_bytes(hashlib.sha256(data).digest(), "big")
+    if r == 0 or r >= SECP256K1_ORDER:
+        # retry with 0xff appended
+        data_retry = data + b"\xff"
+        r = int.from_bytes(hashlib.sha256(data_retry).digest(), "big")
+        if r == 0 or r >= SECP256K1_ORDER:
+            raise ValueError("P2BK: blinding scalar derivation failed")
+    return r
+
+def _scalar_to_privkey(scalar: int) -> PrivateKey:
+    """Convert an integer scalar to a PrivateKey."""
+    return PrivateKey(scalar.to_bytes(32, "big"))
+
+def _pubkey_x(pubkey: PublicKey) -> bytes:
+    """Get the x-coordinate (32 bytes) from a compressed public key."""
+    return pubkey.format(compressed=True)[1:]
+
+def blind_pubkeys(
+    data_pubkey: str, 
+    additional_pubkeys: List[str], 
+    refund_pubkeys: List[str], 
+    receiver_pubkey: str,
+    ephemeral_privkey: Optional[PrivateKey] = None,
+) -> Tuple[str, List[str], List[str], str]:
+    """blind all pubkeys in a P2PK secret using ECDH.
+
+    Args:
+        data_pubkey: The main locking pubkey.
+        additional_pubkeys: Additional pubkeys from the "pubkeys" tag.
+        refund_pubkeys: Refund pubkeys from the "refund" tag.
+        receiver_pubkey: The receiver's long-lived pubkey P (used for ECDH).
+        ephemeral_privkey: Optional ephemeral private key. Generated if None.
+
+    Returns:
+        Tuple of (blinded_data_pubkey, blinded_additional, blinded_refund, ephemeral_pubkey_hex)
+    """
+    receiver_pubkey_hex = _compressed_pubkey(receiver_pubkey)
+    receiver_pk = PublicKey(bytes.fromhex(receiver_pubkey_hex))
+
+    if ephemeral_privkey is None:
+        ephemeral_privkey = PrivateKey(os.urandom(32))
+
+    assert ephemeral_privkey.public_key
+    ephemeral_pubkey_hex = ephemeral_privkey.public_key.format(compressed=True).hex()
+
+    # compute ECDH shared secret Zx = x(e * P)
+    zx = ecdh_shared_secret(receiver_pk, ephemeral_privkey)
+
+    # collect all pubkeys in slot order: [data, ...pubkeys, ...refund]
+    all_pubkeys = [data_pubkey] + additional_pubkeys + refund_pubkeys
+    blinded = []
+    for i, pk_hex in enumerate(all_pubkeys):
+        pk_hex = _compressed_pubkey(pk_hex)
+        pk = PublicKey(bytes.fromhex(pk_hex))
+        r_i = derive_blinding_scalar(zx, i)
+        blinding_point = _scalar_to_privkey(r_i).public_key
+        assert blinding_point
+        blinded_pk = pk + blinding_point  # P' = P + r_i*G
+        blinded.append(blinded_pk.format(compressed=True).hex())
+
+    # split back into data, pubkeys, refund
+    blinded_data = blinded[0]
+    blinded_additional = blinded[1 : 1 + len(additional_pubkeys)]
+    blinded_refund = blinded[1 + len(additional_pubkeys) :]
+
+    return blinded_data, blinded_additional, blinded_refund, ephemeral_pubkey_hex
+
+
+def derive_blinded_private_key(
+    privkey: PrivateKey,
+    ephemeral_pubkey_hex: str,
+    blinded_pubkey_hex: str,
+    slot_index: int,
+) -> Optional[PrivateKey]:
+    """derive the blinded private key for a given slot.
+
+    Args:
+        privkey: Receiver's long-lived private key p.
+        ephemeral_pubkey_hex: Sender's ephemeral public key E (hex, 33 bytes).
+        blinded_pubkey_hex: The blinded public key P' from the secret.
+        slot_index: The slot index i.
+
+    Returns:
+        The blinded PrivateKey k, or None if this slot is not for this key.
+    """
+    ephemeral_pubkey_hex = _compressed_pubkey(ephemeral_pubkey_hex)
+    E = PublicKey(bytes.fromhex(ephemeral_pubkey_hex))
+
+    # Zx = x(p * E)
+    zx = ecdh_shared_secret(E, privkey)
+
+    r_i = derive_blinding_scalar(zx, slot_index)
+
+    # R_i = r_i * G
+    r_i_key = _scalar_to_privkey(r_i)
+    R_i = r_i_key.public_key
+    assert R_i
+
+    # Unblind: P = P' - R_i
+    blinded_pubkey_hex = _compressed_pubkey(blinded_pubkey_hex)
+    P_prime = PublicKey(bytes.fromhex(blinded_pubkey_hex))
+    P = P_prime - R_i  # type: ignore
+
+    # Verify x(P) == x(p*G)
+    assert privkey.public_key
+    pG = privkey.public_key
+    if _pubkey_x(P) != _pubkey_x(pG):
+        return None  # this slot is not for this key
+
+    # Parity check
+    p_int = int.from_bytes(bytes.fromhex(privkey.to_hex()), "big")
+    P_prefix = P.format(compressed=True)[0]
+    pG_prefix = pG.format(compressed=True)[0]
+
+    if P_prefix == pG_prefix:
+        # standard derivation: k = (p + r_i) mod n
+        k = (p_int + r_i) % SECP256K1_ORDER
+    else:
+        # negated derivation: k = (-p + r_i) mod n
+        k = ((-p_int) + r_i) % SECP256K1_ORDER
+
+    return _scalar_to_privkey(k)

--- a/cashu/wallet/crud.py
+++ b/cashu/wallet/crud.py
@@ -29,8 +29,8 @@ async def store_proof(
     await (conn or db).execute(
         """
         INSERT INTO proofs
-          (id, amount, C, secret, time_created, derivation_path, dleq, mint_id, melt_id)
-        VALUES (:id, :amount, :C, :secret, :time_created, :derivation_path, :dleq, :mint_id, :melt_id)
+          (id, amount, C, secret, time_created, derivation_path, dleq, mint_id, melt_id, p2pk_e)
+        VALUES (:id, :amount, :C, :secret, :time_created, :derivation_path, :dleq, :mint_id, :melt_id, :p2pk_e)
         """,
         {
             "id": proof.id,
@@ -42,6 +42,7 @@ async def store_proof(
             "dleq": json.dumps(proof.dleq.model_dump()) if proof.dleq else "",
             "mint_id": proof.mint_id,
             "melt_id": proof.melt_id,
+            "p2pk_e": proof.p2pk_e,
         },
     )
 

--- a/cashu/wallet/crud.py
+++ b/cashu/wallet/crud.py
@@ -110,8 +110,8 @@ async def invalidate_proof(
     await (conn or db).execute(
         """
         INSERT INTO proofs_used
-          (amount, C, secret, time_used, id, derivation_path, mint_id, melt_id)
-        VALUES (:amount, :C, :secret, :time_used, :id, :derivation_path, :mint_id, :melt_id)
+          (amount, C, secret, time_used, id, derivation_path, mint_id, melt_id, p2pk_e)
+        VALUES (:amount, :C, :secret, :time_used, :id, :derivation_path, :mint_id, :melt_id, :p2pk_e)
         """,
         {
             "amount": proof.amount,
@@ -122,6 +122,7 @@ async def invalidate_proof(
             "derivation_path": proof.derivation_path,
             "mint_id": proof.mint_id,
             "melt_id": proof.melt_id,
+            "p2pk_e": proof.p2pk_e,
         },
     )
 

--- a/cashu/wallet/helpers.py
+++ b/cashu/wallet/helpers.py
@@ -146,6 +146,7 @@ async def send(
     Prints token to send to stdout.
     """
     secret_lock = None
+    p2pk_e = None
     if lock:
         assert len(lock) > 21, Exception(
             "Error: lock has to be at least 22 characters long."
@@ -169,8 +170,26 @@ async def send(
                 tags=tags,
             )
             logger.debug(f"Secret lock: {secret_lock}")
+        elif lock.startswith("P2BK:") or lock.startswith("P2BK-SIGALL:"):
+            sigall = lock.startswith("P2BK-SIGALL:")
+            logger.debug(f"Locking token with P2BK to: {lock}")
+            logger.debug(
+                f"Adding a time lock of {settings.locktime_delta_seconds} seconds."
+            )
+            tags = None
+            if refund_pubkeys:
+                tags = Tags()
+                tags["refund"] = refund_pubkeys
+            secret_lock, p2pk_e = await wallet.create_p2bk_lock(
+                lock.split(":")[1],
+                locktime_seconds=settings.locktime_delta_seconds,
+                sig_all=sigall,
+                n_sigs=1,
+                tags=tags,
+            )
+            logger.debug(f"P2BK secret lock: {secret_lock}, ephemeral pubkey: {p2pk_e}")
         else:
-            raise Exception("Error: lock has to start with P2PK: or P2PK-SIGALL:")
+            raise Exception("Error: lock has to start with P2PK:, P2PK-SIGALL:, P2BK:, or P2BK-SIGALL:")
 
     await wallet.load_proofs()
 
@@ -181,6 +200,7 @@ async def send(
             amount,
             set_reserved=False,  # we set reserved later
             secret_lock=secret_lock,
+            p2pk_e=p2pk_e,
         )
     else:
         send_proofs, fees = await wallet.select_to_send(

--- a/cashu/wallet/migrations.py
+++ b/cashu/wallet/migrations.py
@@ -360,3 +360,13 @@ async def m018_add_deleted_at_column_to_keysets(db: Database):
         await conn.execute(
             "ALTER TABLE keysets ADD COLUMN deleted_at TIMESTAMP DEFAULT NULL"
         )
+
+
+async def m019_add_p2pk_e_to_proofs(db: Database):
+    """
+    Column to store the NUT-28 P2BK ephemeral pubkey (p2pk_e / E) on proofs.
+    Without this, P2BK tokens become unspendable after a wallet restart.
+    """
+    async with db.connect() as conn:
+        await conn.execute("ALTER TABLE proofs ADD COLUMN p2pk_e TEXT")
+        await conn.execute("ALTER TABLE proofs_used ADD COLUMN p2pk_e TEXT")

--- a/cashu/wallet/p2bk.py
+++ b/cashu/wallet/p2bk.py
@@ -46,6 +46,16 @@ class WalletP2BK(SupportsPrivateKey, SupportsDb):
 
         if not tags:
             tags = Tags()
+
+        if tags:
+            for refund_pk in tags.get_tag_all("refund"):
+                if refund_pk.lower() != data.lower():
+                    raise ValueError(
+                        "P2BK refund keys must match the receiver pubkey. "
+                        "Multi-party refund requires per-receiver ECDH which "
+                        "is not yet implemented."
+                    )
+
         if locktime_seconds:
             tags["locktime"] = str(
                 int((datetime.now() + timedelta(seconds=locktime_seconds)).timestamp())

--- a/cashu/wallet/p2bk.py
+++ b/cashu/wallet/p2bk.py
@@ -1,0 +1,123 @@
+from datetime import datetime, timedelta
+from typing import List, Optional, Tuple
+
+from ..core.base import Proof
+from ..core.crypto.secp import PrivateKey
+from ..core.db import Database
+from ..core.p2bk import (
+    blind_pubkeys,
+    derive_blinded_private_key,
+)
+from ..core.p2pk import (
+    P2PKSecret,
+    SigFlags,
+)
+from ..core.secret import SecretKind, Tags
+from .protocols import SupportsDb, SupportsPrivateKey
+
+
+class WalletP2BK(SupportsPrivateKey, SupportsDb):
+    db: Database
+    private_key: PrivateKey
+
+    async def create_p2bk_lock(
+        self,
+        data: str,
+        locktime_seconds: Optional[int] = None,
+        tags: Optional[Tags] = None,
+        sig_all: bool = False,
+        n_sigs: int = 1,
+        ephemeral_privkey: Optional[PrivateKey] = None,
+    ) -> Tuple[P2PKSecret, str]:
+        """Generate a P2BK-blinded P2PK secret.
+        Blinds pubkeys in [data, ...pubkeys, ...refund] slot order using ECDH.
+
+        Args:
+            data: Receiver's public key to lock to.
+            locktime_seconds: Locktime in seconds.
+            tags: Tags (may contain pubkeys, refund keys).
+            sig_all: Whether to use SIG_ALL spending condition.
+            n_sigs: Number of signatures required.
+            ephemeral_privkey: Ephemeral private key (reuse for SIG_ALL across outputs).
+
+        Returns:
+            Tuple of (P2PKSecret with blinded keys, ephemeral pubkey E hex).
+        """
+
+        if not tags:
+            tags = Tags()
+        if locktime_seconds:
+            tags["locktime"] = str(
+                int((datetime.now() + timedelta(seconds=locktime_seconds)).timestamp())
+            )
+        tags["sigflag"] = (
+            SigFlags.SIG_ALL.value if sig_all else SigFlags.SIG_INPUTS.value
+        )
+        if n_sigs > 1:
+            tags["n_sigs"] = str(n_sigs)
+
+        # Collect pubkeys from tags before blinding
+        additional_pubkeys = tags.get_tag_all("pubkeys")
+        refund_pubkeys = tags.get_tag_all("refund")
+
+        # P2BK single-receiver: all slots use the same ECDH (data == receiver).
+        # Multi-receiver multisig (each key has a distinct owner) is not supported
+        # here — each receiver would need their own ECDH and ephemeral keypair.
+        blinded_data, blinded_additional, blinded_refund, ephemeral_pubkey_hex = (
+            blind_pubkeys(
+                data_pubkey=data,
+                additional_pubkeys=additional_pubkeys,
+                refund_pubkeys=refund_pubkeys,
+                receiver_pubkey=data,
+                ephemeral_privkey=ephemeral_privkey,
+            )
+        )
+
+        # Rebuild tags with blinded keys.
+        # Tags stores multi-value as [key, v1, v2, ...]; list assignment is safe.
+        blinded_tags = Tags()
+        for tag in tags.root:
+            if tag[0] == "pubkeys":
+                blinded_tags["pubkeys"] = blinded_additional
+            elif tag[0] == "refund":
+                blinded_tags["refund"] = blinded_refund
+            else:
+                blinded_tags.root.append(tag)
+
+        return P2PKSecret(
+            kind=SecretKind.P2PK.value,
+            data=blinded_data,
+            tags=blinded_tags,
+        ), ephemeral_pubkey_hex
+
+    def _derive_p2bk_signing_key(self, proof: Proof) -> Optional[PrivateKey]:
+        """If proof has p2pk_e, derive the blinded private key for our slot.
+
+        Returns the blinded private key if we can unblind a slot, else None.
+        """
+        if not proof.p2pk_e:
+            return None
+        secret = P2PKSecret.deserialize(proof.secret)
+
+        all_blinded_pubkeys = (
+            [secret.data]
+            + secret.tags.get_tag_all("pubkeys")
+            + secret.tags.get_tag_all("refund")
+        )
+        for i, blinded_pk in enumerate(all_blinded_pubkeys):
+            derived = derive_blinded_private_key(
+                privkey=self.private_key,
+                ephemeral_pubkey_hex=proof.p2pk_e,
+                blinded_pubkey_hex=blinded_pk,
+                slot_index=i,
+            )
+            if derived is not None:
+                return derived
+        return None
+
+    def filter_p2bk_proofs(self, proofs: List[Proof]) -> List[Proof]:
+        """Filter P2BK proofs (those with p2pk_e) that we can unblind."""
+        return [
+            p for p in proofs
+            if p.p2pk_e and self._derive_p2bk_signing_key(p) is not None
+        ]

--- a/cashu/wallet/p2bk.py
+++ b/cashu/wallet/p2bk.py
@@ -47,15 +47,6 @@ class WalletP2BK(SupportsPrivateKey, SupportsDb):
         if not tags:
             tags = Tags()
 
-        if tags:
-            for refund_pk in tags.get_tag_all("refund"):
-                if refund_pk.lower() != data.lower():
-                    raise ValueError(
-                        "P2BK refund keys must match the receiver pubkey. "
-                        "Multi-party refund requires per-receiver ECDH which "
-                        "is not yet implemented."
-                    )
-
         if locktime_seconds:
             tags["locktime"] = str(
                 int((datetime.now() + timedelta(seconds=locktime_seconds)).timestamp())
@@ -70,15 +61,13 @@ class WalletP2BK(SupportsPrivateKey, SupportsDb):
         additional_pubkeys = tags.get_tag_all("pubkeys")
         refund_pubkeys = tags.get_tag_all("refund")
 
-        # P2BK single-receiver: all slots use the same ECDH (data == receiver).
-        # Multi-receiver multisig (each key has a distinct owner) is not supported
-        # here — each receiver would need their own ECDH and ephemeral keypair.
+        # Per-key ECDH: each pubkey P_i gets its own Zx_i = x(e * P_i).
+        # Multi-party refund keys are handled correctly by this approach.
         blinded_data, blinded_additional, blinded_refund, ephemeral_pubkey_hex = (
             blind_pubkeys(
                 data_pubkey=data,
                 additional_pubkeys=additional_pubkeys,
                 refund_pubkeys=refund_pubkeys,
-                receiver_pubkey=data,
                 ephemeral_privkey=ephemeral_privkey,
             )
         )

--- a/cashu/wallet/p2bk.py
+++ b/cashu/wallet/p2bk.py
@@ -104,12 +104,16 @@ class WalletP2BK(SupportsPrivateKey, SupportsDb):
             + secret.tags.get_tag_all("refund")
         )
         for i, blinded_pk in enumerate(all_blinded_pubkeys):
-            derived = derive_blinded_private_key(
-                privkey=self.private_key,
-                ephemeral_pubkey_hex=proof.p2pk_e,
-                blinded_pubkey_hex=blinded_pk,
-                slot_index=i,
-            )
+            try:
+                derived = derive_blinded_private_key(
+                    privkey=self.private_key,
+                    ephemeral_pubkey_hex=proof.p2pk_e,
+                    blinded_pubkey_hex=blinded_pk,
+                    slot_index=i,
+                )
+            except Exception:
+                # Slot value is not a valid pubkey (e.g. HTLC preimage hash)
+                continue
             if derived is not None:
                 return derived
         return None

--- a/cashu/wallet/p2bk.py
+++ b/cashu/wallet/p2bk.py
@@ -89,13 +89,15 @@ class WalletP2BK(SupportsPrivateKey, SupportsDb):
             tags=blinded_tags,
         ), ephemeral_pubkey_hex
 
-    def _derive_p2bk_signing_key(self, proof: Proof) -> Optional[PrivateKey]:
-        """If proof has p2pk_e, derive the blinded private key for our slot.
+    def _derive_p2bk_signing_keys(self, proof: Proof) -> List[PrivateKey]:
+        """If proof has p2pk_e, derive blinded private keys for every slot we own.
 
-        Returns the blinded private key if we can unblind a slot, else None.
+        Returns all derivable keys across [data, ...pubkeys, ...refund] slots.
+        A wallet may legitimately hold keys in multiple slots (e.g. co-signer
+        and refund holder), and each slot requires a distinct signature.
         """
         if not proof.p2pk_e:
-            return None
+            return []
         secret = P2PKSecret.deserialize(proof.secret)
 
         all_blinded_pubkeys = (
@@ -103,6 +105,7 @@ class WalletP2BK(SupportsPrivateKey, SupportsDb):
             + secret.tags.get_tag_all("pubkeys")
             + secret.tags.get_tag_all("refund")
         )
+        keys: List[PrivateKey] = []
         for i, blinded_pk in enumerate(all_blinded_pubkeys):
             try:
                 derived = derive_blinded_private_key(
@@ -115,12 +118,12 @@ class WalletP2BK(SupportsPrivateKey, SupportsDb):
                 # Slot value is not a valid pubkey (e.g. HTLC preimage hash)
                 continue
             if derived is not None:
-                return derived
-        return None
+                keys.append(derived)
+        return keys
 
     def filter_p2bk_proofs(self, proofs: List[Proof]) -> List[Proof]:
         """Filter P2BK proofs (those with p2pk_e) that we can unblind."""
         return [
             p for p in proofs
-            if p.p2pk_e and self._derive_p2bk_signing_key(p) is not None
+            if p.p2pk_e and self._derive_p2bk_signing_keys(p)
         ]

--- a/cashu/wallet/p2bk.py
+++ b/cashu/wallet/p2bk.py
@@ -101,28 +101,32 @@ class WalletP2BK(SupportsPrivateKey, SupportsDb):
         Returns all derivable keys across [data, ...pubkeys, ...refund] slots.
         A wallet may legitimately hold keys in multiple slots (e.g. co-signer
         and refund holder), and each slot requires a distinct signature.
+
+        Slot 0 is the `data` tag (NUT-28). For HTLC secrets that slot holds
+        the preimage hash, not a pubkey, so it is never blinded and is
+        excluded here; pubkeys/refund keys still start at slot index 1.
         """
         if not proof.p2pk_e:
             return []
         secret = P2PKSecret.deserialize(proof.secret)
 
-        all_blinded_pubkeys = (
-            [secret.data]
-            + secret.tags.get_tag_all("pubkeys")
-            + secret.tags.get_tag_all("refund")
-        )
+        slots: List[Tuple[int, str]] = []
+        if SecretKind(secret.kind) != SecretKind.HTLC:
+            slots.append((0, secret.data))
+        for i, pk in enumerate(secret.tags.get_tag_all("pubkeys"), start=1):
+            slots.append((i, pk))
+        offset = 1 + len(secret.tags.get_tag_all("pubkeys"))
+        for i, pk in enumerate(secret.tags.get_tag_all("refund")):
+            slots.append((offset + i, pk))
+
         keys: List[PrivateKey] = []
-        for i, blinded_pk in enumerate(all_blinded_pubkeys):
-            try:
-                derived = derive_blinded_private_key(
-                    privkey=self.private_key,
-                    ephemeral_pubkey_hex=proof.p2pk_e,
-                    blinded_pubkey_hex=blinded_pk,
-                    slot_index=i,
-                )
-            except Exception:
-                # Slot value is not a valid pubkey (e.g. HTLC preimage hash)
-                continue
+        for slot_index, blinded_pk in slots:
+            derived = derive_blinded_private_key(
+                privkey=self.private_key,
+                ephemeral_pubkey_hex=proof.p2pk_e,
+                blinded_pubkey_hex=blinded_pk,
+                slot_index=slot_index,
+            )
             if derived is not None:
                 keys.append(derived)
         return keys

--- a/cashu/wallet/p2bk.py
+++ b/cashu/wallet/p2bk.py
@@ -75,11 +75,17 @@ class WalletP2BK(SupportsPrivateKey, SupportsDb):
         # Rebuild tags with blinded keys.
         # Tags stores multi-value as [key, v1, v2, ...]; list assignment is safe.
         blinded_tags = Tags()
+        pubkeys_added = False
+        refund_added = False
         for tag in tags.root:
             if tag[0] == "pubkeys":
-                blinded_tags["pubkeys"] = blinded_additional
+                if not pubkeys_added:
+                    blinded_tags["pubkeys"] = blinded_additional
+                    pubkeys_added = True
             elif tag[0] == "refund":
-                blinded_tags["refund"] = blinded_refund
+                if not refund_added:
+                    blinded_tags["refund"] = blinded_refund
+                    refund_added = True
             else:
                 blinded_tags.root.append(tag)
 

--- a/cashu/wallet/p2bk.py
+++ b/cashu/wallet/p2bk.py
@@ -111,7 +111,7 @@ class WalletP2BK(SupportsPrivateKey, SupportsDb):
         secret = P2PKSecret.deserialize(proof.secret)
 
         slots: List[Tuple[int, str]] = []
-        if SecretKind(secret.kind) != SecretKind.HTLC:
+        if secret.kind != SecretKind.HTLC.value:
             slots.append((0, secret.data))
         for i, pk in enumerate(secret.tags.get_tag_all("pubkeys"), start=1):
             slots.append((i, pk))

--- a/cashu/wallet/p2pk.py
+++ b/cashu/wallet/p2pk.py
@@ -311,7 +311,9 @@ class WalletP2PK(WalletP2BK, SupportsPrivateKey, SupportsDb):
                 if secret.kind == SecretKind.HTLC.value and (
                     secret.tags.get_tag("pubkeys") or secret.tags.get_tag("refund")
                 ):
-                    # HTLC secret with pubkeys tag is a P2PK secret
+                    # NUT-28: P2BK is inherited here — HTLC reuses the P2PK
+                    # signature path which calls _derive_p2bk_signing_key.
+                    # No HTLC-specific P2BK handling is needed.
                     p2pk_proofs.append(p)
             except Exception:
                 pass

--- a/cashu/wallet/p2pk.py
+++ b/cashu/wallet/p2pk.py
@@ -19,10 +19,11 @@ from ..core.p2pk import (
     schnorr_sign,
 )
 from ..core.secret import Secret, SecretKind, Tags
+from .p2bk import WalletP2BK
 from .protocols import SupportsDb, SupportsPrivateKey
 
 
-class WalletP2PK(SupportsPrivateKey, SupportsDb):
+class WalletP2PK(WalletP2BK, SupportsPrivateKey, SupportsDb):
     db: Database
     private_key: PrivateKey
     # ---------- P2PK ----------
@@ -77,6 +78,7 @@ class WalletP2PK(SupportsPrivateKey, SupportsDb):
     def signatures_proofs_sig_inputs(self, proofs: List[Proof]) -> List[str]:
         """Signs proof secrets with the private key of the wallet.
         This method is used to sign P2PK SIG_INPUTS proofs.
+        For P2BK proofs (with p2pk_e), derives the blinded private key first.
 
         Args:
             proofs (List[Proof]): Proofs to sign
@@ -94,23 +96,25 @@ class WalletP2PK(SupportsPrivateKey, SupportsDb):
             logger.trace(f"Signing proof: {proof}")
             logger.trace(f"Signing message: {proof.secret}")
 
-        signatures = [
-            schnorr_sign(
-                message=proof.secret.encode("utf-8"),
-                private_key=private_key,
-            ).hex()
-            for proof in proofs
-        ]
+        signatures = []
+        for proof in proofs:
+            signing_key = self._derive_p2bk_signing_key(proof) or private_key
+            signatures.append(
+                schnorr_sign(
+                    message=proof.secret.encode("utf-8"),
+                    private_key=signing_key,
+                ).hex()
+            )
         logger.debug(f"Signatures: {signatures}")
         return signatures
 
-    def schnorr_sign_message(self, message: str) -> str:
-        """Sign a message with the private key of the wallet."""
-        private_key = self.private_key
-        assert private_key.public_key
+    def schnorr_sign_message(self, message: str, signing_key: Optional[PrivateKey] = None) -> str:
+        """Sign a message with the given key or the wallet's private key."""
+        key = signing_key or self.private_key
+        assert key.public_key
         return schnorr_sign(
             message=message.encode("utf-8"),
-            private_key=private_key,
+            private_key=key,
         ).hex()
 
     def _inputs_require_sigall(self, proofs: List[Proof]) -> bool:
@@ -157,7 +161,9 @@ class WalletP2PK(SupportsPrivateKey, SupportsDb):
             message_to_sign = message_to_sign or nut11.sigall_message_to_sign(
                 proofs, outputs
             )
-            signature = self.schnorr_sign_message(message_to_sign)
+            # For P2BK proofs, use the derived blinded signing key
+            signing_key = self._derive_p2bk_signing_key(proofs[0])
+            signature = self.schnorr_sign_message(message_to_sign, signing_key)
             # add witness to only the first proof
             signed_proofs = self.add_signatures_to_proofs([proofs[0]], [signature])
             proofs[0].witness = signed_proofs[0].witness
@@ -185,6 +191,11 @@ class WalletP2PK(SupportsPrivateKey, SupportsDb):
         # sign first proof if swap is SIG_ALL
         proofs = self.add_witness_swap_sig_all(proofs, outputs)
 
+        # p2pk_e stripped AFTER signing: add_witnesses_sig_inputs derives the
+        # blinded key via _derive_p2bk_signing_key before we clear the field.
+        for p in proofs:
+            p.p2pk_e = None
+
         return proofs
 
     def sign_proofs_inplace_melt(
@@ -194,7 +205,14 @@ class WalletP2PK(SupportsPrivateKey, SupportsDb):
         proofs = self.add_witnesses_sig_inputs(proofs)
         message_to_sign = nut11.sigall_message_to_sign(proofs, outputs) + quote_id
         # sign first proof if swap is SIG_ALL
-        return self.add_witness_swap_sig_all(proofs, outputs, message_to_sign)
+        proofs = self.add_witness_swap_sig_all(proofs, outputs, message_to_sign)
+
+        # p2pk_e stripped AFTER signing: add_witnesses_sig_inputs derives the
+        # blinded key via _derive_p2bk_signing_key before we clear the field.
+        for p in proofs:
+            p.p2pk_e = None
+
+        return proofs
 
     def add_signatures_to_proofs(
         self, proofs: List[Proof], signatures: List[str]
@@ -249,12 +267,17 @@ class WalletP2PK(SupportsPrivateKey, SupportsDb):
         return proofs
 
     def filter_proofs_locked_to_our_pubkey(self, proofs: List[Proof]) -> List[Proof]:
-        """This method assumes that secrets are all P2PK!"""
-        # filter proofs that require our pubkey
+        """Filter proofs locked to our pubkey. Handles both plain P2PK and P2BK proofs."""
         assert self.private_key.public_key
         our_pubkey = self.private_key.public_key.format().hex().lower()
         our_pubkey_proofs = []
         for p in proofs:
+            # P2BK: if p2pk_e is present, try to unblind and check
+            if p.p2pk_e:
+                if self._derive_p2bk_signing_key(p) is not None:
+                    our_pubkey_proofs.append(p)
+                continue
+            # Plain P2PK: check if our pubkey is in the secret
             secret = P2PKSecret.deserialize(p.secret)
             pubkeys = (
                 [secret.data]

--- a/cashu/wallet/p2pk.py
+++ b/cashu/wallet/p2pk.py
@@ -98,7 +98,8 @@ class WalletP2PK(WalletP2BK, SupportsPrivateKey, SupportsDb):
 
         signatures = []
         for proof in proofs:
-            signing_key = self._derive_p2bk_signing_key(proof) or private_key
+            p2bk_keys = self._derive_p2bk_signing_keys(proof)
+            signing_key = p2bk_keys[0] if p2bk_keys else private_key
             signatures.append(
                 schnorr_sign(
                     message=proof.secret.encode("utf-8"),
@@ -162,7 +163,8 @@ class WalletP2PK(WalletP2BK, SupportsPrivateKey, SupportsDb):
                 proofs, outputs
             )
             # For P2BK proofs, use the derived blinded signing key
-            signing_key = self._derive_p2bk_signing_key(proofs[0])
+            p2bk_keys = self._derive_p2bk_signing_keys(proofs[0])
+            signing_key = p2bk_keys[0] if p2bk_keys else None
             signature = self.schnorr_sign_message(message_to_sign, signing_key)
             # add witness to only the first proof
             signed_proofs = self.add_signatures_to_proofs([proofs[0]], [signature])
@@ -192,7 +194,7 @@ class WalletP2PK(WalletP2BK, SupportsPrivateKey, SupportsDb):
         proofs = self.add_witness_swap_sig_all(proofs, outputs)
 
         # p2pk_e stripped AFTER signing: add_witnesses_sig_inputs derives the
-        # blinded key via _derive_p2bk_signing_key before we clear the field.
+        # blinded key via _derive_p2bk_signing_keys before we clear the field.
         for p in proofs:
             p.p2pk_e = None
 
@@ -208,7 +210,7 @@ class WalletP2PK(WalletP2BK, SupportsPrivateKey, SupportsDb):
         proofs = self.add_witness_swap_sig_all(proofs, outputs, message_to_sign)
 
         # p2pk_e stripped AFTER signing: add_witnesses_sig_inputs derives the
-        # blinded key via _derive_p2bk_signing_key before we clear the field.
+        # blinded key via _derive_p2bk_signing_keys before we clear the field.
         for p in proofs:
             p.p2pk_e = None
 
@@ -274,7 +276,7 @@ class WalletP2PK(WalletP2BK, SupportsPrivateKey, SupportsDb):
         for p in proofs:
             # P2BK: if p2pk_e is present, try to unblind and check
             if p.p2pk_e:
-                if self._derive_p2bk_signing_key(p) is not None:
+                if self._derive_p2bk_signing_keys(p):
                     our_pubkey_proofs.append(p)
                 continue
             # Plain P2PK: check if our pubkey is in the secret
@@ -312,7 +314,7 @@ class WalletP2PK(WalletP2BK, SupportsPrivateKey, SupportsDb):
                     secret.tags.get_tag("pubkeys") or secret.tags.get_tag("refund")
                 ):
                     # NUT-28: P2BK is inherited here — HTLC reuses the P2PK
-                    # signature path which calls _derive_p2bk_signing_key.
+                    # signature path which calls _derive_p2bk_signing_keys.
                     # No HTLC-specific P2BK handling is needed.
                     p2pk_proofs.append(p)
             except Exception:
@@ -335,6 +337,16 @@ class WalletP2PK(WalletP2BK, SupportsPrivateKey, SupportsDb):
         signed_proofs = self.add_signatures_to_proofs(
             our_pubkey_proofs, p2pk_signatures
         )
+        # For P2BK proofs where the wallet holds keys in multiple slots (e.g.
+        # co-signer and refund holder), sign with every derivable key so the
+        # mint can satisfy whichever spending path is currently active.
+        for proof in signed_proofs:
+            if proof.p2pk_e:
+                for extra_key in self._derive_p2bk_signing_keys(proof)[1:]:
+                    extra_sig = schnorr_sign(
+                        proof.secret.encode("utf-8"), extra_key
+                    ).hex()
+                    self.add_signatures_to_proofs([proof], [extra_sig])
         return signed_proofs
 
     def add_witnesses_sig_inputs(self, proofs: List[Proof]) -> List[Proof]:

--- a/cashu/wallet/p2pk.py
+++ b/cashu/wallet/p2pk.py
@@ -172,6 +172,11 @@ class WalletP2PK(WalletP2BK, SupportsPrivateKey, SupportsDb):
             logger.debug(
                 f"SIGALL Adding witness to proof: {proofs[0].secret} with signature: {signature}"
             )
+            # Sign message_to_sign with remaining keys for SIG_ALL multi-key slots
+            if proofs[0].p2pk_e and len(p2bk_keys) > 1:
+                for extra_key in p2bk_keys[1:]:
+                    extra_sig = self.schnorr_sign_message(message_to_sign, extra_key)
+                    self.add_signatures_to_proofs([proofs[0]], [extra_sig])
         except Exception:
             logger.error("not all secrets are the same, skipping SIG_ALL signature")
             return proofs

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -731,6 +731,7 @@ class Wallet(
         amount: int,
         secret_lock: Optional[Secret] = None,
         include_fees: bool = False,
+        p2pk_e: Optional[str] = None,
     ) -> Tuple[List[Proof], List[Proof]]:
         """Calls the swap API to split the proofs into two sets of proofs, one for keeping and one for sending.
 
@@ -817,6 +818,12 @@ class Wallet(
 
         keep_proofs = new_proofs[: len(keep_outputs)]
         send_proofs = new_proofs[len(keep_outputs) :]
+
+        # P2BK: attach ephemeral pubkey to send proofs
+        if p2pk_e:
+            for p in send_proofs:
+                p.p2pk_e = p2pk_e
+
         return keep_proofs, send_proofs
 
     async def melt_quote(
@@ -1314,6 +1321,7 @@ class Wallet(
         secret_lock: Optional[Secret] = None,
         set_reserved: bool = False,
         include_fees: bool = False,
+        p2pk_e: Optional[str] = None,
     ) -> Tuple[List[Proof], List[Proof]]:
         """
         Swaps a set of proofs with the mint to get a set that sums up to a desired amount that can be sent. The remaining
@@ -1353,7 +1361,7 @@ class Wallet(
             f"Amount to send: {self.unit.str(amount)} (+ {self.unit.str(fees)} fees)"
         )
         keep_proofs, send_proofs = await self.split(
-            swap_proofs, amount, secret_lock, include_fees=include_fees
+            swap_proofs, amount, secret_lock, include_fees=include_fees, p2pk_e=p2pk_e
         )
         if set_reserved:
             await self.set_reserved_for_send(send_proofs, reserved=True)

--- a/tests/nuts/test_nut28_test_vectors.py
+++ b/tests/nuts/test_nut28_test_vectors.py
@@ -1,0 +1,163 @@
+import json
+
+import pytest
+
+from cashu.core.base import Proof
+from cashu.core.crypto.secp import PrivateKey, PublicKey
+from cashu.core.p2bk import (
+    blind_pubkeys,
+    derive_blinded_private_key,
+    derive_blinding_scalar,
+    ecdh_shared_secret,
+)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def mint():
+    # Override autouse server fixture from tests/conftest.py to avoid hanging
+    yield
+
+
+# --- Vector inputs (28-tests.md) ---
+
+E_PRIVKEY_HEX = "1cedb9df0c6872188b560ace9e35fd55c2532d53e19ae65b46159073886482ca"
+E_PUBKEY_HEX = "02a8cda4cf448bfce9a9e46e588c06ea1780fcb94e3bbdf3277f42995d403a8b0c"
+P_PRIVKEY_HEX = "ad37e8abd800be3e8272b14045873f4353327eedeb702b72ddcc5c5adff5129c"
+P_PUBKEY_HEX = "02771fed6cb88aaac38b8b32104a942bf4b8f4696bc361171b3c7d06fa2ebddf06"
+
+ZX_HEX = "40d6ba4430a6dfa915bb441579b0f4dee032307434e9957a092bbca73151df8b"
+
+R_HEX = [
+    "f43cfecf4d44e109872ed601156a01211c0d9eba0460d5be254a510782a2d4aa",
+    "4a57e6acb9db19344af5632aa45000cd2c643550bc63c7d5732221171ab0f5b3",
+    "d4a8b84b21f2b0ad31654e96eddbc32bfdedae2d05dc179bdd6cc20236b1104d",
+    "ecebf43123d1da3de611a05f5020085d63ca20829242cdc07f7c780e19594798",
+    "5f42d463ead44cbb20e51843d9eb3b8b0e0021566fd89852d23ae85f57d60858",
+    "a8f1c9d336954997ad571e5a5b59fe340c80902b10b9099d44e17abb3070118c",
+    "c39fa43b707215c163593fb8cadc0eddb4fe2f82c0c79c82a6fc2e3b6b051a7e",
+    "b17d6a51396eb926f4a901e20ff760a852563f90fd4b85e193888f34fd2ee523",
+    "4d4af85ea296457155b7ce328cf9accbe232e8ac23a1dfe901a36ab1b72ea04d",
+    "ce311248ea9f42a73fc874b3ce351d55964652840d695382f0018b36bb089dd1",
+    "9de35112d62e6343d02301d8f58fef87958e99bb68cfdfa855e04fe18b95b114",
+]
+
+BLINDED_PUBKEY_HEX = [
+    "03b7c03eb05a0a539cfc438e81bcf38b65b7bb8685e8790f9b853bfe3d77ad5315",
+    "0352fb6d93360b7c2538eedf3c861f32ea5883fceec9f3e573d9d84377420da838",
+    "03667361ca925065dcafea0a705ba49e75bdd7975751fcc933e05953463c79fff1",
+    "02aca3ed09382151250b38c85087ae0a1436a057b40f824a5569ba353d40347d08",
+    "02cd397bd6e326677128f1b0e5f1d745ad89b933b1b8671e947592778c9fc2301d",
+    "0394140369aae01dbaf74977ccbb09b3a9cf2252c274c791ac734a331716f1f7d4",
+    "03480f28e8f8775d56a4254c7e0dfdd5a6ecd6318c757fcec9e84c1b48ada0666d",
+    "02f8a7be813f7ba2253d09705cc68c703a9fd785a055bf8766057fc6695ec80efc",
+    "03aa5446aaf07ca9730b233f5c404fd024ef92e3787cd1c34c81c0778fe23c59e9",
+    "037f82d4e0a79b0624a58ef7181344b95afad8acf4275dad49bcd39c189b73ece2",
+    "032371fc0eef6885062581a3852494e2eab8f384b7dd196281b85b77f94770fac5",
+]
+
+# skNeg: negated derivation, (-p + r_i) mod n. The vectors' P has parity
+# mismatched against the natural pubkey pG, so this is the branch a
+# spec-correct receiver must select (see "Choosing Correct Secret Key
+# Derivation" in 28-tests.md).
+DERIVED_PRIVKEY_HEX = [
+    "47051623754422cb04bc24c0cfe2c1ddc8db1fcc18f0aa4b477df4aca2adc20e",
+    "9d1ffe00e1da5af5c882b1ea5ec8c18893e09349803c3c9e552823490af22458",
+    "2770cf9f49f1f26eaef29d56a85483e8aabb2f3f1a6bec28ffa065a756bbfdb1",
+    "3fb40b854bd11bff639eef1f0a98c91a1097a194a6d2a24da1b01bb3396434fc",
+    "b20aebb812d38e7c9e7267039463fc46757c7f4f33b10d1bb440ea91481736fd",
+    "fbb9e1275e948b592ae46d1a15d2beef73fcee23d4917e6626e77ced20b14031",
+    "1667bb8f98715782e0e68e788554cf9a61cbb094d557710fc92fd1e08b1007e2",
+    "044581a5616dfae8723650a1ca702164ff23c0a311db5a6eb5bc32da1d39d287",
+    "a0130fb2ca958732d3451cf247726d8749af46a4e77a54b1e3a96ce3a76fcef2",
+    "20f9299d129e8468bd55c37388adde124313d39621f9281012352edbdb138b35",
+    "f0ab6866fe2da5054db05098b008b042fd0af7b42ca8547137e652137bd6dfb9",
+]
+
+EXAMPLE_PROOF = {
+    "amount": 64,
+    "C": "0381855ddcc434a9a90b3564f29ef78e7271f8544d0056763b418b00e88525c0ff",
+    "id": "009a1f293253e41e",
+    "secret": '["P2PK",{"nonce":"d4a17a88f5d0c09001f7b453c42c1f9d5a87363b1f6637a5a83fc31a6a3b7266","data":"03b7c03eb05a0a539cfc438e81bcf38b65b7bb8685e8790f9b853bfe3d77ad5315","tags":[]}]',
+    "dleq": {
+        "s": "6178978456c42eee8eefb50830fc3146be27b05619f04e3490dc596005f0cc78",
+        "e": "23f2190b18bfd043d3a526103e15f4a938d646a6bf93b017e2bb7c85e1540b32",
+        "r": "d26a55aa39ca50957fdaf54036b01053b0de42048b96a6fb2a167e03f00d0a0f",
+    },
+    "p2pk_e": "02a8cda4cf448bfce9a9e46e588c06ea1780fcb94e3bbdf3277f42995d403a8b0c",
+}
+
+SLOTS = list(range(11))  # 0x00-0x0A
+
+
+def test_shared_secret_zx_from_sender_side():
+    e = PrivateKey(bytes.fromhex(E_PRIVKEY_HEX))
+    P = PublicKey(bytes.fromhex(P_PUBKEY_HEX))
+    assert ecdh_shared_secret(P, e).hex() == ZX_HEX
+
+
+def test_shared_secret_zx_from_receiver_side():
+    p = PrivateKey(bytes.fromhex(P_PRIVKEY_HEX))
+    E = PublicKey(bytes.fromhex(E_PUBKEY_HEX))
+    assert ecdh_shared_secret(E, p).hex() == ZX_HEX
+
+
+@pytest.mark.parametrize("slot", SLOTS)
+def test_blinding_scalar_per_slot(slot):
+    zx = bytes.fromhex(ZX_HEX)
+    r = derive_blinding_scalar(zx, slot)
+    assert format(r, "064x") == R_HEX[slot]
+
+
+def test_blinded_pubkeys_all_slots():
+    # NUT-28 slots are positional over [data, ...pubkeys, ...refund]; the
+    # vectors blind the *same* receiver pubkey P at every slot 0-10, so
+    # exercise blind_pubkeys() exactly as a sender would with 11 locking
+    # entries for the same key (cts's lead: extend to all defined slots).
+    e = PrivateKey(bytes.fromhex(E_PRIVKEY_HEX))
+    blinded_data, blinded_additional, blinded_refund, ephemeral_pubkey_hex = (
+        blind_pubkeys(
+            data_pubkey=P_PUBKEY_HEX,
+            additional_pubkeys=[P_PUBKEY_HEX] * 9,
+            refund_pubkeys=[P_PUBKEY_HEX],
+            ephemeral_privkey=e,
+        )
+    )
+    assert ephemeral_pubkey_hex == E_PUBKEY_HEX
+    all_blinded = [blinded_data] + blinded_additional + blinded_refund
+    assert all_blinded == BLINDED_PUBKEY_HEX
+
+
+@pytest.mark.parametrize("slot", SLOTS)
+def test_derived_secret_key_per_slot(slot):
+    p = PrivateKey(bytes.fromhex(P_PRIVKEY_HEX))
+    derived = derive_blinded_private_key(
+        privkey=p,
+        ephemeral_pubkey_hex=E_PUBKEY_HEX,
+        blinded_pubkey_hex=BLINDED_PUBKEY_HEX[slot],
+        slot_index=slot,
+    )
+    assert derived is not None
+    assert derived.to_hex() == DERIVED_PRIVKEY_HEX[slot]
+
+
+def test_example_proof_slot_0_round_trips():
+    proof = Proof(
+        amount=EXAMPLE_PROOF["amount"],
+        C=EXAMPLE_PROOF["C"],
+        id=EXAMPLE_PROOF["id"],
+        secret=EXAMPLE_PROOF["secret"],
+        p2pk_e=EXAMPLE_PROOF["p2pk_e"],
+    )
+    secret_data = json.loads(proof.secret)[1]["data"]
+    assert secret_data == BLINDED_PUBKEY_HEX[0]
+    assert proof.p2pk_e == E_PUBKEY_HEX
+
+    p = PrivateKey(bytes.fromhex(P_PRIVKEY_HEX))
+    derived = derive_blinded_private_key(
+        privkey=p,
+        ephemeral_pubkey_hex=proof.p2pk_e,
+        blinded_pubkey_hex=secret_data,
+        slot_index=0,
+    )
+    assert derived is not None
+    assert derived.to_hex() == DERIVED_PRIVKEY_HEX[0]

--- a/tests/wallet/test_wallet_crud_unit.py
+++ b/tests/wallet/test_wallet_crud_unit.py
@@ -61,6 +61,7 @@ def _proof(
     id: str = "keyset-id",
     mint_id: str | None = None,
     melt_id: str | None = None,
+    p2pk_e: str | None = None,
 ):
     return Proof(
         id=id,
@@ -69,6 +70,7 @@ def _proof(
         secret=secret,
         mint_id=mint_id,
         melt_id=melt_id,
+        p2pk_e=p2pk_e,
     )
 
 
@@ -156,6 +158,19 @@ async def test_proof_crud_update_and_invalidate_flow(wallet_db: Database):
     used = await get_proofs(db=wallet_db, table="proofs_used")
     assert len(used) == 1
     assert used[0].secret == proof.secret
+
+
+@pytest.mark.asyncio
+async def test_invalidate_proof_persists_p2pk_e(wallet_db: Database):
+    ephemeral_pubkey = PrivateKey().public_key.format(compressed=True).hex()
+    proof = _proof("secret-p2bk", p2pk_e=ephemeral_pubkey)
+    await store_proof(proof, db=wallet_db)
+
+    await invalidate_proof(proof, db=wallet_db)
+
+    used = await get_proofs(db=wallet_db, table="proofs_used")
+    assert len(used) == 1
+    assert used[0].p2pk_e == ephemeral_pubkey
 
 
 @pytest.mark.asyncio

--- a/tests/wallet/test_wallet_p2bk.py
+++ b/tests/wallet/test_wallet_p2bk.py
@@ -1,0 +1,517 @@
+"""Tests for NUT-28: Pay-to-Blinded-Key (P2BK)"""
+
+import copy
+import secrets
+from typing import List
+
+import pytest
+import pytest_asyncio
+
+from cashu.core.base import BlindedMessage, Proof
+from cashu.core.crypto.secp import PrivateKey, PublicKey
+from cashu.core.migrations import migrate_databases
+from cashu.core.p2bk import (
+    SECP256K1_ORDER,
+    _compressed_pubkey,
+    _pubkey_x,
+    blind_pubkeys,
+    derive_blinded_private_key,
+    derive_blinding_scalar,
+    ecdh_shared_secret,
+)
+from cashu.core.p2pk import P2PKSecret, SigFlags, schnorr_sign
+from cashu.core.secret import Secret, SecretKind
+from cashu.wallet import migrations
+from cashu.wallet.wallet import Wallet
+from tests.conftest import SERVER_ENDPOINT
+from tests.helpers import pay_if_regtest
+
+
+async def assert_err(f, msg):
+    """Compute f() and expect an error message 'msg'."""
+    try:
+        await f
+    except Exception as exc:
+        if msg not in str(exc.args[0]):
+            raise Exception(f"Expected error: {msg}, got: {exc.args[0]}")
+        return
+    raise Exception(f"Expected error: {msg}, got no error")
+
+
+@pytest_asyncio.fixture(scope="function")
+async def wallet1():
+    wallet1 = await Wallet.with_db(
+        SERVER_ENDPOINT, "test_data/wallet_p2bk_1", "wallet1"
+    )
+    await migrate_databases(wallet1.db, migrations)
+    await wallet1.load_mint()
+    yield wallet1
+
+
+@pytest_asyncio.fixture(scope="function")
+async def wallet2():
+    wallet2 = await Wallet.with_db(
+        SERVER_ENDPOINT, "test_data/wallet_p2bk_2", "wallet2"
+    )
+    await migrate_databases(wallet2.db, migrations)
+    wallet2.private_key = PrivateKey(secrets.token_bytes(32))
+    await wallet2.load_mint()
+    yield wallet2
+
+
+# ──────────────────────────────────────────────
+# Unit tests for core P2BK primitives
+# ──────────────────────────────────────────────
+
+
+def test_compressed_pubkey_32_bytes():
+    """x-only (32 byte) key gets an 02 prefix."""
+    priv = PrivateKey()
+    assert priv.public_key
+    x_only = priv.public_key.format(compressed=True)[1:].hex()
+    assert len(bytes.fromhex(x_only)) == 32
+    result = _compressed_pubkey(x_only)
+    assert result.startswith("02")
+    assert len(bytes.fromhex(result)) == 33
+
+
+def test_compressed_pubkey_33_bytes():
+    """Already compressed key passes through."""
+    priv = PrivateKey()
+    assert priv.public_key
+    compressed = priv.public_key.format(compressed=True).hex()
+    assert _compressed_pubkey(compressed) == compressed
+
+
+def test_compressed_pubkey_invalid():
+    """Invalid length raises ValueError."""
+    with pytest.raises(ValueError):
+        _compressed_pubkey("aabbccdd")  # 4 bytes
+
+
+def test_ecdh_shared_secret_commutative():
+    """Zx = x(e*P) == x(p*E)."""
+    e = PrivateKey()
+    p = PrivateKey()
+    assert e.public_key and p.public_key
+    E = e.public_key
+    P = p.public_key
+    zx_sender = ecdh_shared_secret(P, e)  # sender computes e*P
+    zx_receiver = ecdh_shared_secret(E, p)  # receiver computes p*E
+    assert zx_sender == zx_receiver
+    assert len(zx_sender) == 32
+
+
+def test_derive_blinding_scalar_deterministic():
+    """Same inputs always produce the same scalar."""
+    zx = secrets.token_bytes(32)
+    r1 = derive_blinding_scalar(zx, 0)
+    r2 = derive_blinding_scalar(zx, 0)
+    assert r1 == r2
+
+
+def test_derive_blinding_scalar_different_slots():
+    """Different slot indices produce different scalars."""
+    zx = secrets.token_bytes(32)
+    r0 = derive_blinding_scalar(zx, 0)
+    r1 = derive_blinding_scalar(zx, 1)
+    assert r0 != r1
+
+
+def test_derive_blinding_scalar_range():
+    """Scalar must be 1 <= r < n."""
+    zx = secrets.token_bytes(32)
+    for i in range(11):  # slots 0-10
+        r = derive_blinding_scalar(zx, i)
+        assert 1 <= r < SECP256K1_ORDER
+
+
+def test_blind_pubkeys_roundtrip():
+    """Blinded keys can be unblinded by the receiver."""
+    receiver_priv = PrivateKey()
+    assert receiver_priv.public_key
+    receiver_pub_hex = receiver_priv.public_key.format(compressed=True).hex()
+
+    blinded_data, blinded_add, blinded_refund, ephemeral_pub = blind_pubkeys(
+        data_pubkey=receiver_pub_hex,
+        additional_pubkeys=[],
+        refund_pubkeys=[],
+        receiver_pubkey=receiver_pub_hex,
+    )
+
+    # Receiver should be able to derive the private key for slot 0
+    derived_key = derive_blinded_private_key(
+        privkey=receiver_priv,
+        ephemeral_pubkey_hex=ephemeral_pub,
+        blinded_pubkey_hex=blinded_data,
+        slot_index=0,
+    )
+    assert derived_key is not None
+    # The derived key's public key should match the blinded pubkey
+    assert derived_key.public_key
+    # The x-coordinates must match (BIP-340 schnorr uses x-only)
+    assert _pubkey_x(derived_key.public_key) == _pubkey_x(
+        PublicKey(bytes.fromhex(_compressed_pubkey(blinded_data)))
+    )
+
+
+def test_blind_pubkeys_with_additional_and_refund():
+    """Blinding works with multiple pubkeys in different slots."""
+    receiver_priv = PrivateKey()
+    assert receiver_priv.public_key
+    receiver_pub = receiver_priv.public_key.format(compressed=True).hex()
+
+    # Additional pubkey (same receiver for simplicity)
+    add_pub = receiver_pub
+    refund_pub = receiver_pub
+
+    blinded_data, blinded_add, blinded_refund, E = blind_pubkeys(
+        data_pubkey=receiver_pub,
+        additional_pubkeys=[add_pub],
+        refund_pubkeys=[refund_pub],
+        receiver_pubkey=receiver_pub,
+    )
+
+    assert len(blinded_add) == 1
+    assert len(blinded_refund) == 1
+
+    # All three slots should produce valid derived keys
+    for slot_idx, blinded_pk in enumerate(
+        [blinded_data] + blinded_add + blinded_refund
+    ):
+        derived = derive_blinded_private_key(
+            privkey=receiver_priv,
+            ephemeral_pubkey_hex=E,
+            blinded_pubkey_hex=blinded_pk,
+            slot_index=slot_idx,
+        )
+        assert derived is not None, f"Failed to derive key for slot {slot_idx}"
+
+
+def test_wrong_receiver_cannot_unblind():
+    """A different private key cannot unblind."""
+    receiver_priv = PrivateKey()
+    wrong_priv = PrivateKey()
+    assert receiver_priv.public_key
+    receiver_pub = receiver_priv.public_key.format(compressed=True).hex()
+
+    blinded_data, _, _, E = blind_pubkeys(
+        data_pubkey=receiver_pub,
+        additional_pubkeys=[],
+        refund_pubkeys=[],
+        receiver_pubkey=receiver_pub,
+    )
+
+    derived = derive_blinded_private_key(
+        privkey=wrong_priv,
+        ephemeral_pubkey_hex=E,
+        blinded_pubkey_hex=blinded_data,
+        slot_index=0,
+    )
+    assert derived is None
+
+
+def test_blinded_pubkey_differs_from_original():
+    """Blinded pubkey P' != original pubkey P."""
+    priv = PrivateKey()
+    assert priv.public_key
+    pub = priv.public_key.format(compressed=True).hex()
+
+    blinded_data, _, _, _ = blind_pubkeys(
+        data_pubkey=pub,
+        additional_pubkeys=[],
+        refund_pubkeys=[],
+        receiver_pubkey=pub,
+    )
+    assert blinded_data.lower() != pub.lower()
+
+
+def test_different_ephemeral_keys_produce_different_blinding():
+    """Each fresh ephemeral key produces unique blinding."""
+    priv = PrivateKey()
+    assert priv.public_key
+    pub = priv.public_key.format(compressed=True).hex()
+
+    blinded1, _, _, E1 = blind_pubkeys(
+        data_pubkey=pub,
+        additional_pubkeys=[],
+        refund_pubkeys=[],
+        receiver_pubkey=pub,
+    )
+    blinded2, _, _, E2 = blind_pubkeys(
+        data_pubkey=pub,
+        additional_pubkeys=[],
+        refund_pubkeys=[],
+        receiver_pubkey=pub,
+    )
+    assert E1 != E2  # random ephemeral keys
+    assert blinded1 != blinded2  # different blinding
+
+
+def test_derived_key_can_sign_and_verify():
+    """Derived blinded private key can produce valid schnorr signatures."""
+    receiver_priv = PrivateKey()
+    assert receiver_priv.public_key
+    receiver_pub = receiver_priv.public_key.format(compressed=True).hex()
+
+    blinded_data, _, _, E = blind_pubkeys(
+        data_pubkey=receiver_pub,
+        additional_pubkeys=[],
+        refund_pubkeys=[],
+        receiver_pubkey=receiver_pub,
+    )
+
+    derived_key = derive_blinded_private_key(
+        privkey=receiver_priv,
+        ephemeral_pubkey_hex=E,
+        blinded_pubkey_hex=blinded_data,
+        slot_index=0,
+    )
+    assert derived_key is not None
+
+    # Sign a message
+    message = b"test message"
+    sig = schnorr_sign(message, derived_key)
+
+    # Verify against the blinded pubkey
+    from cashu.core.p2pk import verify_schnorr_signature
+
+    blinded_pk = PublicKey(bytes.fromhex(_compressed_pubkey(blinded_data)))
+    assert verify_schnorr_signature(message, blinded_pk, sig)
+
+
+def test_compressed_pubkey_x_only_nostr():
+    """Simulating a Nostr-style 32-byte hex key getting 02 prefix."""
+    # Use a real private key to derive an x-only pubkey (like Nostr npub)
+    priv = PrivateKey(secrets.token_bytes(32))
+    x_only_hex = priv.public_key.format(compressed=True).hex()[2:]  # strip 02/03
+    assert len(x_only_hex) == 64
+    result = _compressed_pubkey(x_only_hex)
+    assert result.startswith("02")
+    # Verify it's a valid point
+    PublicKey(bytes.fromhex(result))
+
+
+# ──────────────────────────────────────────────
+# Integration tests: P2BK with wallet + mint
+# ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_p2bk_basic(wallet1: Wallet, wallet2: Wallet):
+    """Basic P2BK: sender blinds, receiver unblinds and redeems."""
+    mint_quote = await wallet1.request_mint(64)
+    await pay_if_regtest(mint_quote.request)
+    await wallet1.mint(64, quote_id=mint_quote.quote)
+
+    pubkey_wallet2 = await wallet2.create_p2pk_pubkey()
+
+    # Sender creates a P2BK lock
+    secret_lock, ephemeral_pub = await wallet1.create_p2bk_lock(pubkey_wallet2)
+
+    _, send_proofs = await wallet1.swap_to_send(
+        wallet1.proofs, 8, secret_lock=secret_lock, p2pk_e=ephemeral_pub
+    )
+
+    # Verify proofs have p2pk_e
+    for p in send_proofs:
+        assert p.p2pk_e == ephemeral_pub
+
+    # Verify the secret contains blinded pubkeys (not the original)
+    for p in send_proofs:
+        secret = P2PKSecret.deserialize(p.secret)
+        assert secret.data.lower() != pubkey_wallet2.lower()
+
+    # Receiver redeems (the wallet should unblind via p2pk_e)
+    await wallet2.redeem(send_proofs)
+
+
+@pytest.mark.asyncio
+async def test_p2bk_wrong_receiver(wallet1: Wallet, wallet2: Wallet):
+    """P2BK: wrong private key cannot redeem."""
+    mint_quote = await wallet1.request_mint(64)
+    await pay_if_regtest(mint_quote.request)
+    await wallet1.mint(64, quote_id=mint_quote.quote)
+
+    pubkey_wallet2 = await wallet2.create_p2pk_pubkey()
+
+    secret_lock, ephemeral_pub = await wallet1.create_p2bk_lock(pubkey_wallet2)
+    _, send_proofs = await wallet1.swap_to_send(
+        wallet1.proofs, 8, secret_lock=secret_lock, p2pk_e=ephemeral_pub
+    )
+
+    # Set wrong private key on wallet2
+    wallet2.private_key = PrivateKey()
+    await assert_err(wallet2.redeem(send_proofs), "")
+
+
+@pytest.mark.asyncio
+async def test_p2bk_sig_all(wallet1: Wallet, wallet2: Wallet):
+    """P2BK with SIG_ALL spending condition."""
+    mint_quote = await wallet1.request_mint(64)
+    await pay_if_regtest(mint_quote.request)
+    await wallet1.mint(64, quote_id=mint_quote.quote)
+
+    pubkey_wallet2 = await wallet2.create_p2pk_pubkey()
+
+    secret_lock, ephemeral_pub = await wallet1.create_p2bk_lock(
+        pubkey_wallet2, sig_all=True
+    )
+    _, send_proofs = await wallet1.swap_to_send(
+        wallet1.proofs, 8, secret_lock=secret_lock, p2pk_e=ephemeral_pub
+    )
+
+    # Verify SIG_ALL flag
+    for p in send_proofs:
+        secret = P2PKSecret.deserialize(p.secret)
+        p2pk = P2PKSecret.from_secret(secret)
+        assert p2pk.sigflag == SigFlags.SIG_ALL
+
+    # All SIG_ALL proofs must carry the *same* ephemeral key
+    e_values = [p.p2pk_e for p in send_proofs]
+    assert all(e == ephemeral_pub for e in e_values), (
+        f"Expected identical p2pk_e across SIG_ALL proofs, got {e_values}"
+    )
+
+    await wallet2.redeem(send_proofs)
+
+
+@pytest.mark.asyncio
+async def test_p2bk_mint_sees_normal_p2pk(wallet1: Wallet, wallet2: Wallet):
+    """The mint sees a standard P2PK secret, not P2BK metadata."""
+    mint_quote = await wallet1.request_mint(64)
+    await pay_if_regtest(mint_quote.request)
+    await wallet1.mint(64, quote_id=mint_quote.quote)
+
+    pubkey_wallet2 = await wallet2.create_p2pk_pubkey()
+
+    secret_lock, ephemeral_pub = await wallet1.create_p2bk_lock(pubkey_wallet2)
+    _, send_proofs = await wallet1.swap_to_send(
+        wallet1.proofs, 8, secret_lock=secret_lock, p2pk_e=ephemeral_pub
+    )
+
+    # The secret kind is still P2PK
+    for p in send_proofs:
+        secret = Secret.deserialize(p.secret)
+        assert secret.kind == SecretKind.P2PK.value
+
+    # p2pk_e is stripped during signing/sending to mint
+    # (sign_proofs_inplace_swap strips it)
+    proofs_copy = copy.deepcopy(send_proofs)
+    outputs = await _create_outputs(wallet2, 8)
+    signed = wallet2.sign_proofs_inplace_swap(proofs_copy, outputs)
+    for p in signed:
+        assert p.p2pk_e is None
+
+
+@pytest.mark.asyncio
+async def test_p2bk_unique_ephemeral_per_output(wallet1: Wallet, wallet2: Wallet):
+    """Each output gets a unique ephemeral keypair when not SIG_ALL."""
+    mint_quote = await wallet1.request_mint(128)
+    await pay_if_regtest(mint_quote.request)
+    await wallet1.mint(128, quote_id=mint_quote.quote)
+
+    pubkey_wallet2 = await wallet2.create_p2pk_pubkey()
+
+    # Create two separate P2BK locks (each gets a fresh E)
+    lock1, E1 = await wallet1.create_p2bk_lock(pubkey_wallet2)
+    lock2, E2 = await wallet1.create_p2bk_lock(pubkey_wallet2)
+    assert E1 != E2  # unique ephemeral keys
+
+
+@pytest.mark.asyncio
+async def test_p2bk_token_v4_roundtrip(wallet1: Wallet, wallet2: Wallet):
+    """P2BK proofs survive Token V4 (CBOR) serialize/deserialize."""
+    from cashu.core.base import TokenV4
+
+    mint_quote = await wallet1.request_mint(64)
+    await pay_if_regtest(mint_quote.request)
+    await wallet1.mint(64, quote_id=mint_quote.quote)
+
+    pubkey_wallet2 = await wallet2.create_p2pk_pubkey()
+    secret_lock, ephemeral_pub = await wallet1.create_p2bk_lock(pubkey_wallet2)
+    _, send_proofs = await wallet1.swap_to_send(
+        wallet1.proofs, 8, secret_lock=secret_lock, p2pk_e=ephemeral_pub
+    )
+
+    # Serialize as Token V4
+    token_str = await wallet1.serialize_proofs(send_proofs)
+    assert token_str.startswith("cashuB") or token_str.startswith("cashuA")
+
+    # Deserialize
+    if token_str.startswith("cashuB"):
+        token = TokenV4.deserialize(token_str)
+        deserialized_proofs = token.proofs
+    else:
+        from cashu.core.base import TokenV3
+
+        token_v3 = TokenV3.deserialize(token_str)
+        deserialized_proofs = token_v3.proofs
+
+    # p2pk_e should survive roundtrip
+    for p in deserialized_proofs:
+        assert p.p2pk_e == ephemeral_pub
+
+
+@pytest.mark.asyncio
+async def test_p2bk_proof_dict_roundtrip(wallet1: Wallet, wallet2: Wallet):
+    """p2pk_e survives Proof.to_dict / Proof.from_dict roundtrip."""
+    mint_quote = await wallet1.request_mint(64)
+    await pay_if_regtest(mint_quote.request)
+    await wallet1.mint(64, quote_id=mint_quote.quote)
+
+    pubkey_wallet2 = await wallet2.create_p2pk_pubkey()
+    secret_lock, ephemeral_pub = await wallet1.create_p2bk_lock(pubkey_wallet2)
+    _, send_proofs = await wallet1.swap_to_send(
+        wallet1.proofs, 8, secret_lock=secret_lock, p2pk_e=ephemeral_pub
+    )
+
+    for p in send_proofs:
+        d = p.to_dict()
+        assert "p2pk_e" in d
+        assert d["p2pk_e"] == ephemeral_pub
+        restored = Proof.from_dict(d)
+        assert restored.p2pk_e == ephemeral_pub
+
+
+@pytest.mark.asyncio
+async def test_v4_roundtrip_without_pe(wallet1: Wallet, wallet2: Wallet):
+    """A non-P2BK V4 token must roundtrip cleanly with pe absent."""
+    from cashu.core.base import TokenV4
+
+    mint_quote = await wallet1.request_mint(64)
+    await pay_if_regtest(mint_quote.request)
+    await wallet1.mint(64, quote_id=mint_quote.quote)
+
+    # Plain P2PK (no P2BK), so no pe field
+    pubkey_wallet2 = await wallet2.create_p2pk_pubkey()
+    secret_lock = await wallet1.create_p2pk_lock(pubkey_wallet2)
+    _, send_proofs = await wallet1.swap_to_send(
+        wallet1.proofs, 8, secret_lock=secret_lock
+    )
+
+    # Sanity: no p2pk_e on plain P2PK proofs
+    for p in send_proofs:
+        assert p.p2pk_e is None
+
+    # Serialize → deserialize as V4
+    token_str = await wallet1.serialize_proofs(send_proofs)
+    if token_str.startswith("cashuB"):
+        token = TokenV4.deserialize(token_str)
+        deserialized_proofs = token.proofs
+    else:
+        from cashu.core.base import TokenV3
+        token_v3 = TokenV3.deserialize(token_str)
+        deserialized_proofs = token_v3.proofs
+
+    # pe must remain absent — not an empty string, not zero-bytes
+    for p in deserialized_proofs:
+        assert p.p2pk_e is None
+
+
+async def _create_outputs(wallet: Wallet, amount: int) -> List[BlindedMessage]:
+    """Helper to create blinded outputs."""
+    output_amounts = [amount]
+    secrets, rs, _ = await wallet.generate_n_secrets(len(output_amounts))
+    outputs, _ = wallet._construct_outputs(output_amounts, secrets, rs)
+    return outputs

--- a/tests/wallet/test_wallet_p2bk.py
+++ b/tests/wallet/test_wallet_p2bk.py
@@ -32,8 +32,9 @@ async def assert_err(f, msg):
     try:
         await f
     except Exception as exc:
-        if msg not in str(exc.args[0]):
-            raise Exception(f"Expected error: {msg}, got: {exc.args[0]}")
+        exc_msg = str(exc)
+        if msg and msg not in exc_msg:
+            raise Exception(f"Expected error: {msg}, got: {exc_msg}")
         return
     raise Exception(f"Expected error: {msg}, got no error")
 

--- a/tests/wallet/test_wallet_p2bk.py
+++ b/tests/wallet/test_wallet_p2bk.py
@@ -20,7 +20,7 @@ from cashu.core.p2bk import (
     ecdh_shared_secret,
 )
 from cashu.core.p2pk import P2PKSecret, SigFlags, schnorr_sign, verify_schnorr_signature
-from cashu.core.secret import Secret, SecretKind
+from cashu.core.secret import Secret, SecretKind, Tags
 from cashu.wallet import migrations
 from cashu.wallet.wallet import Wallet
 from tests.conftest import SERVER_ENDPOINT
@@ -564,6 +564,122 @@ def test_p2bk_refund_key_unblind():
     assert receiver_derived.public_key and sender_derived.public_key
     assert verify_schnorr_signature(msg, receiver_derived.public_key, sig_r)
     assert verify_schnorr_signature(msg, sender_derived.public_key, sig_s)
+
+
+def test_p2bk_multisig_slot_independence():
+    """Each receiver unblind only their own slot, not the other's."""
+    receiver1_priv = PrivateKey()
+    receiver2_priv = PrivateKey()
+    assert receiver1_priv.public_key and receiver2_priv.public_key
+
+    r1_pub = receiver1_priv.public_key.format(compressed=True).hex()
+    r2_pub = receiver2_priv.public_key.format(compressed=True).hex()
+
+    blinded_data, blinded_add, _, E = blind_pubkeys(
+        data_pubkey=r1_pub,
+        additional_pubkeys=[r2_pub],
+        refund_pubkeys=[],
+    )
+
+    # receiver1 unblind slot 0 only
+    assert derive_blinded_private_key(receiver1_priv, E, blinded_data, 0) is not None
+    assert derive_blinded_private_key(receiver1_priv, E, blinded_add[0], 1) is None
+
+    # receiver2 unblind slot 1 only
+    assert derive_blinded_private_key(receiver2_priv, E, blinded_add[0], 1) is not None
+    assert derive_blinded_private_key(receiver2_priv, E, blinded_data, 0) is None
+
+
+def test_p2bk_tampered_ephemeral_pubkey_fails():
+    """Tampered p2pk_e changes Zx, wrong scalars, signature fails."""
+    receiver_priv = PrivateKey()
+    assert receiver_priv.public_key
+    receiver_pub = receiver_priv.public_key.format(compressed=True).hex()
+
+    blinded_data, _, _, E = blind_pubkeys(
+        data_pubkey=receiver_pub,
+        additional_pubkeys=[],
+        refund_pubkeys=[],
+    )
+    # Generate a different ephemeral pubkey (tampered)
+    tampered_E = PrivateKey().public_key.format(compressed=True).hex()
+    assert tampered_E != E
+
+    derived = derive_blinded_private_key(
+        privkey=receiver_priv,
+        ephemeral_pubkey_hex=tampered_E,
+        blinded_pubkey_hex=blinded_data,
+        slot_index=0,
+    )
+    assert derived is None  # tampered E → wrong Zx → unblind fails
+
+
+def test_p2bk_non_sigall_outputs_have_distinct_ephemeral_keys():
+    """Two independent non-SIG_ALL outputs must carry distinct E values."""
+    priv = PrivateKey()
+    assert priv.public_key
+    pub = priv.public_key.format(compressed=True).hex()
+
+    _, _, _, E1 = blind_pubkeys(
+        data_pubkey=pub,
+        additional_pubkeys=[],
+        refund_pubkeys=[],
+    )
+    _, _, _, E2 = blind_pubkeys(
+        data_pubkey=pub,
+        additional_pubkeys=[],
+        refund_pubkeys=[],
+    )
+    assert E1 != E2
+
+
+@pytest.mark.asyncio
+async def test_p2bk_htlc_inheritance(wallet1: Wallet, wallet2: Wallet):
+    """HTLC proof with P2BK: blinded pubkey, preimage spend works."""
+    import hashlib as hl
+
+    from cashu.core.base import HTLCWitness
+    from cashu.core.htlc import HTLCSecret
+
+    mint_quote = await wallet1.request_mint(64)
+    await pay_if_regtest(mint_quote.request)
+    await wallet1.mint(64, quote_id=mint_quote.quote)
+
+    pubkey_wallet2 = await wallet2.create_p2pk_pubkey()
+    preimage = "00" * 32
+    preimage_hash = hl.sha256(bytes.fromhex(preimage)).hexdigest()
+
+    # Blind wallet2's pubkey at slot 1 (HTLC: slot 0 = data = preimage_hash)
+    dummy_pub = PrivateKey().public_key.format(compressed=True).hex()
+    _, blinded_hashlock, _, ephemeral_pub = blind_pubkeys(
+        data_pubkey=dummy_pub,
+        additional_pubkeys=[pubkey_wallet2],
+        refund_pubkeys=[],
+    )
+
+    # Build HTLC secret with the P2BK-blinded hashlock pubkey
+    tags = Tags()
+    tags["pubkeys"] = [blinded_hashlock[0]]
+    htlc_secret = HTLCSecret(
+        kind=SecretKind.HTLC.value,
+        data=preimage_hash,
+        tags=tags,
+    )
+    _, send_proofs = await wallet1.swap_to_send(
+        wallet1.proofs, 8, secret_lock=htlc_secret, p2pk_e=ephemeral_pub
+    )
+
+    # Verify wallet2 can derive the P2BK signing key for the HTLC proof
+    for p in send_proofs:
+        assert p.p2pk_e == ephemeral_pub
+        assert wallet2._derive_p2bk_signing_key(p) is not None
+
+    # Set preimage on witness before redemption
+    for p in send_proofs:
+        p.witness = HTLCWitness(preimage=preimage).model_dump_json()
+
+    # Redeem — sign_proofs_inplace_swap adds P2BK-derived signature alongside preimage
+    await wallet2.redeem(send_proofs)
 
 
 async def _create_outputs(wallet: Wallet, amount: int) -> List[BlindedMessage]:

--- a/tests/wallet/test_wallet_p2bk.py
+++ b/tests/wallet/test_wallet_p2bk.py
@@ -19,7 +19,7 @@ from cashu.core.p2bk import (
     derive_blinding_scalar,
     ecdh_shared_secret,
 )
-from cashu.core.p2pk import P2PKSecret, SigFlags, schnorr_sign
+from cashu.core.p2pk import P2PKSecret, SigFlags, schnorr_sign, verify_schnorr_signature
 from cashu.core.secret import Secret, SecretKind
 from cashu.wallet import migrations
 from cashu.wallet.wallet import Wallet
@@ -137,7 +137,6 @@ def test_blind_pubkeys_roundtrip():
         data_pubkey=receiver_pub_hex,
         additional_pubkeys=[],
         refund_pubkeys=[],
-        receiver_pubkey=receiver_pub_hex,
     )
 
     # Receiver should be able to derive the private key for slot 0
@@ -170,7 +169,6 @@ def test_blind_pubkeys_with_additional_and_refund():
         data_pubkey=receiver_pub,
         additional_pubkeys=[add_pub],
         refund_pubkeys=[refund_pub],
-        receiver_pubkey=receiver_pub,
     )
 
     assert len(blinded_add) == 1
@@ -200,7 +198,6 @@ def test_wrong_receiver_cannot_unblind():
         data_pubkey=receiver_pub,
         additional_pubkeys=[],
         refund_pubkeys=[],
-        receiver_pubkey=receiver_pub,
     )
 
     derived = derive_blinded_private_key(
@@ -222,7 +219,6 @@ def test_blinded_pubkey_differs_from_original():
         data_pubkey=pub,
         additional_pubkeys=[],
         refund_pubkeys=[],
-        receiver_pubkey=pub,
     )
     assert blinded_data.lower() != pub.lower()
 
@@ -237,13 +233,11 @@ def test_different_ephemeral_keys_produce_different_blinding():
         data_pubkey=pub,
         additional_pubkeys=[],
         refund_pubkeys=[],
-        receiver_pubkey=pub,
     )
     blinded2, _, _, E2 = blind_pubkeys(
         data_pubkey=pub,
         additional_pubkeys=[],
         refund_pubkeys=[],
-        receiver_pubkey=pub,
     )
     assert E1 != E2  # random ephemeral keys
     assert blinded1 != blinded2  # different blinding
@@ -259,7 +253,6 @@ def test_derived_key_can_sign_and_verify():
         data_pubkey=receiver_pub,
         additional_pubkeys=[],
         refund_pubkeys=[],
-        receiver_pubkey=receiver_pub,
     )
 
     derived_key = derive_blinded_private_key(
@@ -508,6 +501,69 @@ async def test_v4_roundtrip_without_pe(wallet1: Wallet, wallet2: Wallet):
     # pe must remain absent — not an empty string, not zero-bytes
     for p in deserialized_proofs:
         assert p.p2pk_e is None
+
+
+def test_p2bk_refund_key_unblind():
+    """Sender's refund key can be unblinded independently of receiver's key.
+
+    This verifies per-key ECDH: the sender uses their own private key
+    against the ephemeral public key E to derive the blinded refund
+    private key, without needing the receiver's secret.
+    """
+    receiver_priv = PrivateKey()
+    sender_priv = PrivateKey()
+    assert receiver_priv.public_key and sender_priv.public_key
+    receiver_pub = receiver_priv.public_key.format(compressed=True).hex()
+    sender_pub = sender_priv.public_key.format(compressed=True).hex()
+
+    # Blind with receiver as data, sender as refund
+    blinded_data, _, blinded_refund, E = blind_pubkeys(
+        data_pubkey=receiver_pub,
+        additional_pubkeys=[],
+        refund_pubkeys=[sender_pub],
+    )
+    assert len(blinded_refund) == 1
+
+    # Receiver can unblind the data slot (slot 0)
+    receiver_derived = derive_blinded_private_key(
+        privkey=receiver_priv,
+        ephemeral_pubkey_hex=E,
+        blinded_pubkey_hex=blinded_data,
+        slot_index=0,
+    )
+    assert receiver_derived is not None
+
+    # Sender can unblind the refund slot (slot 1)
+    sender_derived = derive_blinded_private_key(
+        privkey=sender_priv,
+        ephemeral_pubkey_hex=E,
+        blinded_pubkey_hex=blinded_refund[0],
+        slot_index=1,
+    )
+    assert sender_derived is not None
+
+    # Cross-check: sender CANNOT unblind data slot, receiver CANNOT unblind refund slot
+    assert derive_blinded_private_key(
+        privkey=sender_priv,
+        ephemeral_pubkey_hex=E,
+        blinded_pubkey_hex=blinded_data,
+        slot_index=0,
+    ) is None
+    assert derive_blinded_private_key(
+        privkey=receiver_priv,
+        ephemeral_pubkey_hex=E,
+        blinded_pubkey_hex=blinded_refund[0],
+        slot_index=1,
+    ) is None
+
+    # Both derived keys can sign and verify
+    msg = b"refund path works"
+    sig_r = schnorr_sign(msg, receiver_derived)
+    sig_s = schnorr_sign(msg, sender_derived)
+
+    assert receiver_derived.public_key and sender_derived.public_key
+    assert verify_schnorr_signature(msg, receiver_derived.public_key, sig_r)
+    assert verify_schnorr_signature(msg, sender_derived.public_key, sig_s)
 
 
 async def _create_outputs(wallet: Wallet, amount: int) -> List[BlindedMessage]:

--- a/tests/wallet/test_wallet_p2bk.py
+++ b/tests/wallet/test_wallet_p2bk.py
@@ -566,6 +566,73 @@ def test_p2bk_refund_key_unblind():
     assert verify_schnorr_signature(msg, sender_derived.public_key, sig_s)
 
 
+def test_p2bk_cosigner_refund_path():
+    """Wallet holding keys in both pubkeys (slot 1) and refund (slot 2) derives
+    both signing keys and produces a valid signature for each slot independently.
+
+    Regression test for: first-match early-return in _derive_p2bk_signing_keys
+    would discard the refund key, locking funds when only the refund path is active.
+    """
+    bob_priv = PrivateKey()
+    alice_priv = PrivateKey()
+    assert bob_priv.public_key and alice_priv.public_key
+    bob_pub = bob_priv.public_key.format(compressed=True).hex()
+    alice_pub = alice_priv.public_key.format(compressed=True).hex()
+
+    # Alice is co-signer (slot 1) AND the sole refund holder (slot 2)
+    e = PrivateKey()
+    blinded_data, blinded_add, blinded_refund, E = blind_pubkeys(
+        data_pubkey=bob_pub,
+        additional_pubkeys=[alice_pub],
+        refund_pubkeys=[alice_pub],
+        ephemeral_privkey=e,
+    )
+
+    # Build a minimal Proof so _derive_p2bk_signing_keys can be called on it
+    secret = P2PKSecret(
+        kind=SecretKind.P2PK.value,
+        data=blinded_data,
+        tags=Tags(),
+    )
+    secret.tags["pubkeys"] = [blinded_add[0]]
+    secret.tags["refund"] = [blinded_refund[0]]
+    proof = Proof(
+        id="test", amount=1,
+        secret=secret.serialize(),
+        C="02" + "aa" * 32,
+        p2pk_e=E,
+    )
+
+    # Simulate what _derive_p2bk_signing_keys does via wallet2 fixture equivalent
+    # We call the function directly via a minimal duck-typed object
+    class _FakeWallet:
+        private_key = alice_priv
+
+        def _derive_p2bk_signing_keys(self, proof):
+            from cashu.wallet.p2bk import WalletP2BK
+            return WalletP2BK._derive_p2bk_signing_keys(self, proof)  # type: ignore[arg-type]
+
+    wallet = _FakeWallet()
+    keys = wallet._derive_p2bk_signing_keys(proof)
+
+    # Alice must yield exactly TWO keys: one for slot 1, one for slot 2
+    assert len(keys) == 2, f"Expected 2 keys, got {len(keys)}"
+
+    msg = b"test"
+    sig1 = schnorr_sign(msg, keys[0])
+    sig2 = schnorr_sign(msg, keys[1])
+
+    # Each signature must validate against its own blinded pubkey
+    pk1 = PublicKey(bytes.fromhex(blinded_add[0]))
+    pk2 = PublicKey(bytes.fromhex(blinded_refund[0]))
+    assert verify_schnorr_signature(msg, pk1, sig1), "slot-1 sig must be valid for slot-1 pk"
+    assert verify_schnorr_signature(msg, pk2, sig2), "slot-2 sig must be valid for slot-2 pk"
+
+    # Cross-validation must fail: slot-1 sig is wrong for slot-2 pk, and vice versa
+    assert not verify_schnorr_signature(msg, pk2, sig1), "slot-1 sig must NOT validate for slot-2 pk"
+    assert not verify_schnorr_signature(msg, pk1, sig2), "slot-2 sig must NOT validate for slot-1 pk"
+
+
 def test_p2bk_multisig_slot_independence():
     """Each receiver unblind only their own slot, not the other's."""
     receiver1_priv = PrivateKey()
@@ -672,7 +739,7 @@ async def test_p2bk_htlc_inheritance(wallet1: Wallet, wallet2: Wallet):
     # Verify wallet2 can derive the P2BK signing key for the HTLC proof
     for p in send_proofs:
         assert p.p2pk_e == ephemeral_pub
-        assert wallet2._derive_p2bk_signing_key(p) is not None
+        assert wallet2._derive_p2bk_signing_keys(p)
 
     # Set preimage on witness before redemption
     for p in send_proofs:

--- a/tests/wallet/test_wallet_p2bk.py
+++ b/tests/wallet/test_wallet_p2bk.py
@@ -749,6 +749,56 @@ async def test_p2bk_htlc_inheritance(wallet1: Wallet, wallet2: Wallet):
     await wallet2.redeem(send_proofs)
 
 
+@pytest.mark.asyncio
+async def test_p2bk_sig_all_multisig(wallet1: Wallet, wallet2: Wallet):
+    """P2BK with SIG_ALL spending condition and multiple signatures required."""
+    mint_quote = await wallet1.request_mint(64)
+    await pay_if_regtest(mint_quote.request)
+    await wallet1.mint(64, quote_id=mint_quote.quote)
+
+    pubkey_wallet2 = await wallet2.create_p2pk_pubkey()
+
+    # Create a lock where wallet2 holds both keys (slot 0 and slot 1)
+    # and requires 2 signatures to spend (n_sigs=2).
+    tags = Tags()
+    tags["pubkeys"] = [pubkey_wallet2]
+    secret_lock, ephemeral_pub = await wallet1.create_p2bk_lock(
+        pubkey_wallet2, tags=tags, sig_all=True, n_sigs=2
+    )
+    _, send_proofs = await wallet1.swap_to_send(
+        wallet1.proofs, 8, secret_lock=secret_lock, p2pk_e=ephemeral_pub
+    )
+
+    # Verify SIG_ALL and n_sigs flags
+    for p in send_proofs:
+        secret = P2PKSecret.deserialize(p.secret)
+        p2pk = P2PKSecret.from_secret(secret)
+        assert p2pk.sigflag == SigFlags.SIG_ALL
+        assert p2pk.n_sigs == 2
+
+    # Under our fix, wallet2 will derive 2 signing keys, sign with both,
+    # and redeem successfully.
+    await wallet2.redeem(send_proofs)
+
+
+@pytest.mark.asyncio
+async def test_p2bk_lock_no_tag_duplication(wallet1: Wallet):
+    """Verify that create_p2bk_lock does not duplicate tags when rebuilding with multiple input tags."""
+    pubkey = await wallet1.create_p2pk_pubkey()
+    tags = Tags()
+    tags.root.append(["pubkeys", pubkey])
+    tags.root.append(["pubkeys", pubkey])
+
+    secret_lock, _ = await wallet1.create_p2bk_lock(
+        pubkey, tags=tags
+    )
+
+    # Check that there is only one "pubkeys" tag in secret_lock.tags.root
+    pubkeys_tags = [t for t in secret_lock.tags.root if t[0] == "pubkeys"]
+
+    assert len(pubkeys_tags) == 1, f"Expected exactly 1 pubkeys tag, got {len(pubkeys_tags)}"
+
+
 async def _create_outputs(wallet: Wallet, amount: int) -> List[BlindedMessage]:
     """Helper to create blinded outputs."""
     output_amounts = [amount]

--- a/tests/wallet/test_wallet_p2bk.py
+++ b/tests/wallet/test_wallet_p2bk.py
@@ -2,7 +2,7 @@
 
 import copy
 import secrets
-from typing import List
+from typing import List, Optional, Tuple
 
 import pytest
 import pytest_asyncio
@@ -25,6 +25,39 @@ from cashu.wallet import migrations
 from cashu.wallet.wallet import Wallet
 from tests.conftest import SERVER_ENDPOINT
 from tests.helpers import pay_if_regtest
+
+
+def blind_pubkeys_from_slot(
+    pubkeys: List[str],
+    start_slot: int,
+    ephemeral_privkey: Optional[PrivateKey] = None,
+) -> Tuple[List[str], str]:
+    """Blind pubkeys starting at an explicit slot index.
+
+    NUT-28 numbers slots positionally over [data, ...pubkeys, ...refund];
+    for HTLC secrets slot 0 (`data`) is a preimage hash and is never
+    blinded, so pubkeys/refund naturally start at slot 1. This mirrors
+    blind_pubkeys()'s per-key ECDH math without needing a throwaway slot-0
+    pubkey, letting HTLC+P2BK secrets be built the way a sender actually
+    would (no dummy data pubkey to discard).
+    """
+    if ephemeral_privkey is None:
+        ephemeral_privkey = PrivateKey(secrets.token_bytes(32))
+    assert ephemeral_privkey.public_key
+    ephemeral_pubkey_hex = ephemeral_privkey.public_key.format(compressed=True).hex()
+
+    blinded = []
+    for offset, pk_hex in enumerate(pubkeys):
+        slot_index = start_slot + offset
+        pk_hex = _compressed_pubkey(pk_hex)
+        pk = PublicKey(bytes.fromhex(pk_hex))
+        zx = ecdh_shared_secret(pk, ephemeral_privkey)
+        r = derive_blinding_scalar(zx, slot_index)
+        blinding_point = PrivateKey(r.to_bytes(32, "big")).public_key
+        assert blinding_point
+        blinded_pk = pk + blinding_point  # type: ignore[operator]
+        blinded.append(blinded_pk.format(compressed=True).hex())
+    return blinded, ephemeral_pubkey_hex
 
 
 async def assert_err(f, msg):
@@ -702,7 +735,12 @@ def test_p2bk_non_sigall_outputs_have_distinct_ephemeral_keys():
 
 @pytest.mark.asyncio
 async def test_p2bk_htlc_inheritance(wallet1: Wallet, wallet2: Wallet):
-    """HTLC proof with P2BK: blinded pubkey, preimage spend works."""
+    """HTLC proof with P2BK: blinded pubkey, preimage spend works.
+
+    Built via the natural HTLC+P2BK slot layout (data = raw preimage hash
+    at slot 0, unblinded; pubkeys tag blinded starting at slot 1) rather
+    than a throwaway slot-0 pubkey.
+    """
     import hashlib as hl
 
     from cashu.core.base import HTLCWitness
@@ -716,17 +754,13 @@ async def test_p2bk_htlc_inheritance(wallet1: Wallet, wallet2: Wallet):
     preimage = "00" * 32
     preimage_hash = hl.sha256(bytes.fromhex(preimage)).hexdigest()
 
-    # Blind wallet2's pubkey at slot 1 (HTLC: slot 0 = data = preimage_hash)
-    dummy_pub = PrivateKey().public_key.format(compressed=True).hex()
-    _, blinded_hashlock, _, ephemeral_pub = blind_pubkeys(
-        data_pubkey=dummy_pub,
-        additional_pubkeys=[pubkey_wallet2],
-        refund_pubkeys=[],
+    # HTLC: slot 0 = data = preimage_hash (never blinded), pubkeys start at slot 1
+    blinded_pubkeys, ephemeral_pub = blind_pubkeys_from_slot(
+        [pubkey_wallet2], start_slot=1
     )
 
-    # Build HTLC secret with the P2BK-blinded hashlock pubkey
     tags = Tags()
-    tags["pubkeys"] = [blinded_hashlock[0]]
+    tags["pubkeys"] = blinded_pubkeys
     htlc_secret = HTLCSecret(
         kind=SecretKind.HTLC.value,
         data=preimage_hash,
@@ -747,6 +781,73 @@ async def test_p2bk_htlc_inheritance(wallet1: Wallet, wallet2: Wallet):
 
     # Redeem — sign_proofs_inplace_swap adds P2BK-derived signature alongside preimage
     await wallet2.redeem(send_proofs)
+
+
+@pytest.mark.asyncio
+async def test_p2bk_htlc_refund_slot_offset(wallet1: Wallet, wallet2: Wallet):
+    """HTLC+P2BK refund key derives at the correct offset (1 + len(pubkeys))."""
+    import hashlib as hl
+
+    from cashu.core.htlc import HTLCSecret
+
+    mint_quote = await wallet1.request_mint(64)
+    await pay_if_regtest(mint_quote.request)
+    await wallet1.mint(64, quote_id=mint_quote.quote)
+
+    pubkey_wallet1 = await wallet1.create_p2pk_pubkey()
+    pubkey_wallet2 = await wallet2.create_p2pk_pubkey()
+    preimage_hash = hl.sha256(b"\x00" * 32).hexdigest()
+
+    # HTLC slots: 0 = data (hash, unblinded), 1 = pubkeys[0] (wallet1), 2 = refund[0] (wallet2)
+    blinded, ephemeral_pub = blind_pubkeys_from_slot(
+        [pubkey_wallet1, pubkey_wallet2], start_slot=1
+    )
+    blinded_pubkey, blinded_refund = blinded[0], blinded[1]
+
+    tags = Tags()
+    tags["pubkeys"] = [blinded_pubkey]
+    tags["refund"] = [blinded_refund]
+    htlc_secret = HTLCSecret(
+        kind=SecretKind.HTLC.value,
+        data=preimage_hash,
+        tags=tags,
+    )
+    _, send_proofs = await wallet1.swap_to_send(
+        wallet1.proofs, 8, secret_lock=htlc_secret, p2pk_e=ephemeral_pub
+    )
+
+    for p in send_proofs:
+        # wallet1 holds the pubkeys-tag key (slot 1)
+        wallet1_keys = wallet1._derive_p2bk_signing_keys(p)
+        assert len(wallet1_keys) == 1
+        # wallet2 holds the refund-tag key (slot 2)
+        wallet2_keys = wallet2._derive_p2bk_signing_keys(p)
+        assert len(wallet2_keys) == 1
+        assert wallet1_keys[0].to_hex() != wallet2_keys[0].to_hex()
+
+
+@pytest.mark.asyncio
+async def test_p2bk_derive_signing_keys_raises_on_corrupted_ephemeral_key(
+    wallet1: Wallet, wallet2: Wallet
+):
+    """A genuine derivation error (corrupted p2pk_e) must propagate, not be
+    silently swallowed as an HTLC slot-0 skip would be."""
+    pubkey_wallet2 = await wallet2.create_p2pk_pubkey()
+    blinded_data, _, _, ephemeral_pub = blind_pubkeys(
+        data_pubkey=pubkey_wallet2,
+        additional_pubkeys=[],
+        refund_pubkeys=[],
+    )
+    secret = P2PKSecret(kind=SecretKind.P2PK.value, data=blinded_data, tags=Tags())
+    proof = Proof(
+        id="009a1f293253e41e",
+        amount=8,
+        secret=secret.serialize(),
+        C="02" + "00" * 32,
+        p2pk_e="not-a-valid-pubkey",
+    )
+    with pytest.raises(Exception):
+        wallet2._derive_p2bk_signing_keys(proof)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #856

## Summary
Implements NUT-28 (Pay-to-Blinded-Key) across Nutshell's core and wallet layers. P2BK extends NUT-11 (P2PK) spending conditions by ECDH-blinding each locking pubkey with an ECDH-derived scalar before the secret is written.  The mint sees a standard P2PK secret, enforces standard BIP-340 signatures, and learns nothing about the real receiver pubkey.

## What P2BK enables
- `Silent payments for Cashu` as sender locks ecash to a receiver pubkey without that pubkey ever appearing at the mint
- `Payment unlinkability` as each proof carries a fresh ephemeral pubkey E, making proofs from the same sender to the same receiver cryptographically unlinkable
- `True multi-party slots` as per-key ECDH means each pubkey in a multisig proof is independently blinded; slot owners cannot be linked or identified by position

## Changes
- Per-key ECDH in blind_pubkeys
- `p2pk_e` on Proof, `pe` on TokenV4Proof, V3/V4 serialization
- `create_p2bk_lock`, `_derive_p2bk_signing_key` with HTLC-safe try/except
- P2BK signing on swap + melt, HTLC inheritance comment, strip before mint
- P2BK: and P2BK-SIGALL: lock prefixes
