### PR TITLE
fix(mint): enforce unique x-coordinates in p2pk pubkey deduplication

### DIFF
--- a/cashu/mint/conditions.py
+++ b/cashu/mint/conditions.py
@@ -123,6 +123,12 @@ class LedgerSpendingConditions:
 
         if len(set(pubkeys)) != len(pubkeys):
             raise TransactionError("pubkeys must be unique.")
+        
+        # enforce that x-coordinates are unique
+        x_only_pubkeys = [p[2:66] if len(p) in [66, 130] else p for p in pubkeys]
+        if len(set(x_only_pubkeys)) != len(x_only_pubkeys):
+            raise TransactionError("pubkeys must have unique x-coordinates.")
+
         logger.trace(f"pubkeys: {pubkeys}")
         unique_pubkeys = set(pubkeys)
 
@@ -339,6 +345,12 @@ class LedgerSpendingConditions:
         # validation
         if len(set(pubkeys)) != len(pubkeys):
             raise TransactionError("pubkeys must be unique.")
+            
+        # enforce that x-coordinates are unique
+        x_only_pubkeys = [p[2:66] if len(p) in [66, 130] else p for p in pubkeys]
+        if len(set(x_only_pubkeys)) != len(x_only_pubkeys):
+            raise TransactionError("pubkeys must have unique x-coordinates.")
+
         logger.trace(f"pubkeys: {pubkeys}")
         unique_pubkeys = set(pubkeys)
 

--- a/tests/mint/test_mint_conditions.py
+++ b/tests/mint/test_mint_conditions.py
@@ -287,3 +287,26 @@ async def test_verify_inputs_and_outputs_htlc_custom_sigflag_fails_without_outpu
             ledger.verify_inputs_and_outputs(proofs=[proof], outputs=None),
             InvalidProofsError(),
         )
+
+def test_verify_p2pk_signatures_rejects_same_x_coord_different_prefix():
+    cond = LedgerSpendingConditions()
+    message = "msg-1"
+    
+    # Generate one private key
+    priv = PrivateKey()
+    pubkey = priv.public_key.format().hex()
+    
+    # Generate the 02 and 03 version of the same pubkey
+    if pubkey.startswith("02"):
+        pub1 = pubkey
+        pub2 = "03" + pubkey[2:]
+    else:
+        pub1 = pubkey
+        pub2 = "02" + pubkey[2:]
+        
+    # Generate two different signatures for the same message using different nonces
+    sig1 = priv.sign_schnorr(sha256(message.encode()).digest(), b"1"*32).hex()
+    sig2 = priv.sign_schnorr(sha256(message.encode()).digest(), b"2"*32).hex()
+    
+    with pytest.raises(TransactionError, match="pubkeys must have unique x-coordinates"):
+        cond._verify_p2pk_signatures(message, [pub1, pub2], [sig1, sig2], 2)


### PR DESCRIPTION
## Summary
* Updates P2PK pubkey deduplication logic to use the 32-byte x-coordinate rather than the full hex string.
* Because Schnorr signatures verify against the x-only representation, different SEC-1 prefixes for the same pubkey (e.g., `02` and `03`) would previously pass the uniqueness check.
* Added a test verifying `LedgerSpendingConditions` correctly enforces x-coordinate uniqueness.