### PR TITLE
chore: remove stale TODO, HTLC pubkey signing already wired up

### DIFF
--- a/cashu/wallet/p2pk.py
+++ b/cashu/wallet/p2pk.py
@@ -336,6 +336,4 @@ class WalletP2PK(SupportsPrivateKey, SupportsDb):
                     signed_proofs_secrets.index(p.secret)
                 ]
 
-        # TODO: Sign HTLCs that require signatures as well
-
         return proofs

--- a/tests/wallet/test_wallet_htlc.py
+++ b/tests/wallet/test_wallet_htlc.py
@@ -580,3 +580,25 @@ async def test_htlc_n_sigs_refund_locktime(wallet1: Wallet, wallet2: Wallet):
 
     # Should succeed with 2 of 3 signatures after locktime
     await wallet1.redeem(send_proofs_copy2)
+
+
+@pytest.mark.asyncio
+async def test_htlc_redeem_with_automatic_signature(wallet1: Wallet, wallet2: Wallet):
+    mint_quote = await wallet1.request_mint(64)
+    await pay_if_regtest(mint_quote.request)
+    await wallet1.mint(64, quote_id=mint_quote.quote)
+    preimage = "0000000000000000000000000000000000000000000000000000000000000000"
+    pubkey_wallet1 = await wallet1.create_p2pk_pubkey()
+    secret = await wallet1.create_htlc_lock(
+        preimage=preimage, hashlock_pubkeys=[pubkey_wallet1]
+    )
+    _, send_proofs = await wallet1.swap_to_send(wallet1.proofs, 8, secret_lock=secret)
+
+    # manually set the preimage on each proof's witness
+    for p in send_proofs:
+        p.witness = HTLCWitness(preimage=preimage).model_dump_json()
+
+    # let the wallet automatically add the signature
+    send_proofs = wallet1.sign_proofs_inplace_swap(send_proofs, [])
+
+    await wallet1.redeem(send_proofs)

--- a/tests/wallet/test_wallet_htlc.py
+++ b/tests/wallet/test_wallet_htlc.py
@@ -601,4 +601,10 @@ async def test_htlc_redeem_with_automatic_signature(wallet1: Wallet, wallet2: Wa
     # let the wallet automatically add the signature
     send_proofs = wallet1.sign_proofs_inplace_swap(send_proofs, [])
 
+    # ensure the signer appended HTLC signatures without clobbering the preimage
+    for p in send_proofs:
+        witness = HTLCWitness.from_witness(p.witness)
+        assert witness.preimage == preimage
+        assert witness.signatures
+
     await wallet1.redeem(send_proofs)


### PR DESCRIPTION
Fixes #955

## Summary

The TODO comment on line 339 of `wallet_p2pk.py`:

    # TODO: Sign HTLCs that require signatures as well

implied that HTLC proofs with pubkey locks weren't being signed automatically. They are, the TODO was written before this HTLC handling was added to those two methods. It was never removed.

`sign_p2pk_sig_inputs` explicitly collects HTLC proofs that carry a `pubkeys` or `refund` tag. These pass the `SIG_INPUTS` sigflag filter because `P2PKSecret.deserialize` reads tags without checking `kind`, and `sigflag` defaults to `SIG_INPUTS` when no explicit tag is present. `filter_proofs_locked_to_our_pubkey` then finds our key in the `pubkeys`/`refund` tags. Finally, `add_signatures_to_proofs` handles the HTLC branch by deserializing the existing witness, preserving the preimage, and appending the new signature.

## Changes

- Removed the stale TODO comment
- Added `test_htlc_redeem_with_automatic_signature` to confirm the wallet auto-signs an HTLC proof with a pubkey lock end-to-end, without the caller manually building the full witness.