### PR TITLE
fix: UpdateQuoteTtl writes to quote TTL settings, not Redis cache TTL 

### DIFF
--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -63,6 +63,8 @@ class MintSettings(CashuSettings):
 
     mint_input_fee_ppk: int = Field(default=100)
     mint_disable_melt_on_error: bool = Field(default=False)
+    mint_quote_ttl: Optional[int] = Field(default=None)
+    melt_quote_ttl: Optional[int] = Field(default=None)
 
     mint_regular_tasks_interval_seconds: int = Field(
         default=3600,

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -63,8 +63,18 @@ class MintSettings(CashuSettings):
 
     mint_input_fee_ppk: int = Field(default=100)
     mint_disable_melt_on_error: bool = Field(default=False)
-    mint_quote_ttl: Optional[int] = Field(default=None)
-    melt_quote_ttl: Optional[int] = Field(default=None)
+    mint_quote_ttl: Optional[int] = Field(
+        default=None,
+        ge=0,
+        title="Mint quote TTL",
+        description="Time-to-live in seconds for newly created mint quotes.",
+    )
+    melt_quote_ttl: Optional[int] = Field(
+        default=None,
+        ge=0,
+        title="Melt quote TTL",
+        description="Time-to-live in seconds for newly created melt quotes.",
+    )
 
     mint_regular_tasks_interval_seconds: int = Field(
         default=3600,

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -350,9 +350,10 @@ class Ledger(
         # This works with Lightning but might not work with other methods
         request = invoice_response.payment_request.lower()
 
+        now = int(time.time())
         expiry = None
         if settings.mint_quote_ttl is not None:
-            expiry = int(time.time()) + settings.mint_quote_ttl
+            expiry = now + settings.mint_quote_ttl
         elif invoice_obj.expiry is not None:
             expiry = invoice_obj.date + invoice_obj.expiry
 
@@ -364,7 +365,7 @@ class Ledger(
             unit=quote_request.unit,
             amount=quote_request.amount,
             state=MintQuoteState.unpaid,
-            created_time=int(time.time()),
+            created_time=now,
             expiry=expiry,
             pubkey=quote_request.pubkey,
         )
@@ -615,9 +616,10 @@ class Ledger(
         if not invoice_obj.amount_msat:
             raise TransactionError("invoice has no amount.")
         # we set the expiry of this quote to the expiry of the bolt11 invoice
+        now = int(time.time())
         expiry = None
         if settings.melt_quote_ttl is not None:
-            expiry = int(time.time()) + settings.melt_quote_ttl
+            expiry = now + settings.melt_quote_ttl
         elif invoice_obj.expiry is not None:
             expiry = invoice_obj.date + invoice_obj.expiry
 
@@ -630,7 +632,7 @@ class Ledger(
             amount=payment_quote.amount.to(unit).amount,
             state=MeltQuoteState.unpaid,
             fee_reserve=payment_quote.fee.to(unit).amount,
-            created_time=int(time.time()),
+            created_time=now,
             expiry=expiry,
         )
         await self.db_write._store_melt_quote(quote)

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -351,7 +351,9 @@ class Ledger(
         request = invoice_response.payment_request.lower()
 
         expiry = None
-        if invoice_obj.expiry is not None:
+        if settings.mint_quote_ttl is not None:
+            expiry = int(time.time()) + settings.mint_quote_ttl
+        elif invoice_obj.expiry is not None:
             expiry = invoice_obj.date + invoice_obj.expiry
 
         quote = MintQuote(
@@ -614,7 +616,9 @@ class Ledger(
             raise TransactionError("invoice has no amount.")
         # we set the expiry of this quote to the expiry of the bolt11 invoice
         expiry = None
-        if invoice_obj.expiry is not None:
+        if settings.melt_quote_ttl is not None:
+            expiry = int(time.time()) + settings.melt_quote_ttl
+        elif invoice_obj.expiry is not None:
             expiry = invoice_obj.date + invoice_obj.expiry
 
         quote = MeltQuote(

--- a/cashu/mint/management_rpc/management_rpc.py
+++ b/cashu/mint/management_rpc/management_rpc.py
@@ -104,12 +104,12 @@ class MintManagementRPC(management_pb2_grpc.MintServicer):
 
     async def UpdateQuoteTtl(self, request, context):
         logger.debug("gRPC UpdateQuoteTtl has been called")
-        if request.mint_ttl:
-            settings.mint_redis_cache_ttl = request.mint_ttl
-        elif request.melt_ttl:
-            settings.mint_redis_cache_ttl = request.melt_ttl
-        else:
+        if not request.mint_ttl and not request.melt_ttl:
             raise Exception("No quote ttl was specified")
+        if request.mint_ttl:
+            settings.mint_quote_ttl = request.mint_ttl
+        if request.melt_ttl:
+            settings.melt_quote_ttl = request.melt_ttl
         return management_pb2.UpdateResponse()
     
     async def GetQuoteTtl(self, request, context):

--- a/tests/mint/test_mint.py
+++ b/tests/mint/test_mint.py
@@ -1,3 +1,4 @@
+import time
 from typing import List
 
 import pytest
@@ -363,3 +364,34 @@ async def test_generate_change_promises_zero_fee_deletes_all_blanks(ledger: Ledg
         )
     assert len(rows) == n_blank
     assert all(row["c_"] is None for row in rows)
+
+
+@pytest.mark.asyncio
+async def test_mint_quote_ttl_setting_overrides_invoice_expiry(ledger: Ledger):
+    ttl = 900  # 15 minutes
+    settings.mint_quote_ttl = ttl
+    try:
+        before = int(time.time())
+        quote = await ledger.mint_quote(PostMintQuoteRequest(amount=8, unit="sat"))
+        after = int(time.time())
+        assert quote.expiry is not None
+        assert before + ttl <= quote.expiry <= after + ttl
+    finally:
+        settings.mint_quote_ttl = None
+
+
+@pytest.mark.asyncio
+async def test_melt_quote_ttl_setting_overrides_invoice_expiry(ledger: Ledger):
+    ttl = 600  # 10 minutes
+    settings.melt_quote_ttl = ttl
+    try:
+        mint_quote = await ledger.mint_quote(PostMintQuoteRequest(amount=64, unit="sat"))
+        before = int(time.time())
+        melt_quote = await ledger.melt_quote(
+            PostMeltQuoteRequest(request=mint_quote.request, unit="sat")
+        )
+        after = int(time.time())
+        assert melt_quote.expiry is not None
+        assert before + ttl <= melt_quote.expiry <= after + ttl
+    finally:
+        settings.melt_quote_ttl = None

--- a/tests/mint/test_mint_management_rpc.py
+++ b/tests/mint/test_mint_management_rpc.py
@@ -108,12 +108,18 @@ async def test_update_quote_ttl(rpc_servicer):
     # Test updating mint ttl
     request = management_pb2.UpdateQuoteTtlRequest(mint_ttl=12345)
     await rpc_servicer.UpdateQuoteTtl(request, None)
-    assert settings.mint_redis_cache_ttl == 12345
+    assert settings.mint_quote_ttl == 12345
 
     # Test updating melt ttl
     request = management_pb2.UpdateQuoteTtlRequest(melt_ttl=54321)
     await rpc_servicer.UpdateQuoteTtl(request, None)
-    assert settings.mint_redis_cache_ttl == 54321
+    assert settings.melt_quote_ttl == 54321
+
+    # Test both fields set in one request (ensures if/if not elif)
+    request_both = management_pb2.UpdateQuoteTtlRequest(mint_ttl=111, melt_ttl=222)
+    await rpc_servicer.UpdateQuoteTtl(request_both, None)
+    assert settings.mint_quote_ttl == 111
+    assert settings.melt_quote_ttl == 222
 
     # Test no ttl specified
     request_empty = management_pb2.UpdateQuoteTtlRequest()


### PR DESCRIPTION
### Fixes #978 

## Summary
`UpdateQuoteTtl` was writing both `mint_ttl` and `melt_ttl` to `settings.mint_redis_cache_ttl` (the Redis response cache duration) leaving actual quote expiry unaffected. Additionally, an `elif` meant that if both fields were provided in a single request, `melt_ttl` was silently ignored.

## Changes
- `management_rpc.py` now writes `mint_ttl` to `settings.mint_quote_ttl` and `melt_ttl` to `settings.melt_quote_ttl`
- use `if`/`if` so both can be set in one request
- in `ledger.py` when computing quote expiry in `mint_quote()` and `melt_quote()`, prefer the operator-configured TTL setting (`now + ttl`) over the Bolt11 invoice expiry if set; fall back to invoice expiry as before
- `tests/mint/test_mint_management_rpc.py` now adds tests verifying `UpdateQuoteTtl` updates the correct settings independently

## Notes
- No proto changes because `UpdateQuoteTtlRequest` already defines separate `mint_ttl` and `melt_ttl` fields
- `GetQuoteTtl` is untouched
- For mint quotes, `store_mint_quote()` does not persist `expiry`, so `GetQuoteTtl` will still return `NOT_FOUND` for mint quotes.