### PR TITLE
⚡ Add Merit — pay contributors in Bitcoin when PRs merge

### DIFF
--- a/.github/workflows/merit.yml
+++ b/.github/workflows/merit.yml
@@ -1,0 +1,18 @@
+name: Merit ⚡
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  merit:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ericscalibur/Merit@v1
+        with:
+          nwc-connection-string: ${{ secrets.NWC_CONNECTION_STRING }}
+          treasury-lightning-address: ""  # add your Lightning address here


### PR DESCRIPTION
Hey! I built Merit — a GitHub Action that automatically sends Lightning payments to contributors the moment their PR is merged.

**No server. No platform account. No intermediary.** Runs entirely inside GitHub's own infrastructure.

## How it works

- Contributor adds a Lightning address to their GitHub bio
- Maintainer types `⚡ 10000` in a PR comment to zap, or adds a `bounty: 5000` label to an issue for automatic payouts
- PR merges → sats fly instantly
- Every payment is publicly recorded on the PR as an audit trail

## Why this matters for your project

Merit turns your repo into a fundraising mechanism. When contributors see you're paying in sats, they show up. When the Bitcoin community sees you're using Merit, they fund your treasury. Your development accelerates because the incentive loop is finally closed.

**Use Merit to attract outside funding that pays your contributors.**

## Setup (~5 minutes)

1. Get an [Alby](https://getalby.com) wallet and grab your NWC connection string
2. Add `NWC_CONNECTION_STRING` to your repo secrets
3. Add your Lightning address to `treasury-lightning-address` in the yml
4. Merge this PR

## Links

- [Merit on GitHub Marketplace](https://github.com/marketplace/actions/zap_merit)
- [Merit repo](https://github.com/ericscalibur/Merit)
- [Documentation](https://github.com/ericscalibur/Merit#readme)

---
*Merit is open source, MIT licensed, and runs on your infrastructure. The merge is the payment.*