### PR TITLE
fix(mint): do not roll back melt on UNKNOWN payment status

### DIFF
--- a/cashu/lightning/corelightningrest.py
+++ b/cashu/lightning/corelightningrest.py
@@ -186,8 +186,7 @@ class CoreLightningRestWallet(LightningBackend):
             data={
                 "invoice": quote.request,
                 "maxfeepercent": f"{fee_limit_percent:.11}",
-                "exemptfee": 0,  # so fee_limit_percent is applied even on payments
-                # with fee < 5000 millisatoshi (which is default value of exemptfee)
+                "exemptfee": 0,
             },
             timeout=None,
         )

--- a/cashu/lightning/corelightningrest.py
+++ b/cashu/lightning/corelightningrest.py
@@ -186,7 +186,8 @@ class CoreLightningRestWallet(LightningBackend):
             data={
                 "invoice": quote.request,
                 "maxfeepercent": f"{fee_limit_percent:.11}",
-                "exemptfee": 0,
+                "exemptfee": 0,  # so fee_limit_percent is applied even on payments
+                # with fee < 5000 millisatoshi (which is default value of exemptfee)
             },
             timeout=None,
         )

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -948,7 +948,7 @@ class Ledger(
                         return PostMeltQuoteResponse.from_melt_quote(melt_quote)
 
                     match status.result:
-                        case PaymentResult.FAILED | PaymentResult.UNKNOWN:
+                        case PaymentResult.FAILED:
                             # Everything as expected. Payment AND a status check both agree on a failure. We roll back the transaction.
                             await self.db_write.unset_melt_quote_pending_and_proofs(
                                 quote=melt_quote,

--- a/tests/mint/test_mint_melt.py
+++ b/tests/mint/test_mint_melt.py
@@ -402,11 +402,8 @@ async def test_melt_lightning_pay_invoice_failed_failed(ledger: Ledger, wallet: 
 
     settings.fakewallet_payment_state = PaymentResult.UNKNOWN.name
     settings.fakewallet_pay_invoice_state = PaymentResult.FAILED.name
-    try:
-        await ledger.melt(proofs=wallet.proofs, quote=quote_id)
-        raise AssertionError("Expected LightningPaymentFailedError")
-    except LightningPaymentFailedError:
-        pass
+    melt_response = await ledger.melt(proofs=wallet.proofs, quote=quote_id)
+    assert melt_response.state == MeltQuoteState.pending.value
 
     settings.fakewallet_payment_state = PaymentResult.FAILED.name
     settings.fakewallet_pay_invoice_state = PaymentResult.UNKNOWN.name
@@ -418,11 +415,10 @@ async def test_melt_lightning_pay_invoice_failed_failed(ledger: Ledger, wallet: 
 
     settings.fakewallet_payment_state = PaymentResult.UNKNOWN.name
     settings.fakewallet_pay_invoice_state = PaymentResult.UNKNOWN.name
-    try:
-        await ledger.melt(proofs=wallet.proofs, quote=quote_id)
-        raise AssertionError("Expected LightningPaymentFailedError")
-    except LightningPaymentFailedError:
-        pass
+    
+    # In the new logic, UNKNOWN -> UNKNOWN leaves the melt pending and disables melt
+    melt_response = await ledger.melt(proofs=wallet.proofs, quote=quote_id)
+    assert melt_response.state == MeltQuoteState.pending.value
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Prevents the mint from refunding a `melt` when the backend returns `PaymentResult.UNKNOWN`.
- Backends (like LND, LNbits, Strike) often return `UNKNOWN` for in-flight or timed out payments, which caused a race condition where users could be refunded while a Lightning payment was actually still routing.
- With this change, `UNKNOWN` falls through to the default error handling, leaving the ecash `PENDING` and locking the funds for safety.