### PR TITLE
fix(lightning): only return UNKNOWN status when backend confirms payment is not found

### DIFF
--- a/cashu/lightning/blink.py
+++ b/cashu/lightning/blink.py
@@ -272,7 +272,7 @@ class BlinkWallet(LightningBackend):
         except Exception as e:
             logger.error(f"Blink API error: {e}")
             return PaymentResponse(
-                result=PaymentResult.UNKNOWN,
+                result=PaymentResult.PENDING,
                 error_message=str(e),
             )
 

--- a/cashu/lightning/clnrest.py
+++ b/cashu/lightning/clnrest.py
@@ -213,11 +213,15 @@ class CLNRestWallet(LightningBackend):
             try:
                 data = r.json()
                 error_message = str(data["message"])
+                return PaymentResponse(
+                    result=PaymentResult.FAILED,
+                    error_message=error_message,
+                )
             except Exception:
-                error_message = r.text
-            return PaymentResponse(
-                result=PaymentResult.FAILED, error_message=error_message
-            )
+                return PaymentResponse(
+                    result=PaymentResult.PENDING,
+                    error_message=r.text,
+                )
 
         data = r.json()
 

--- a/cashu/lightning/lnbits.py
+++ b/cashu/lightning/lnbits.py
@@ -116,13 +116,21 @@ class LNbitsWallet(LightningBackend):
             )
             r.raise_for_status()
             data: dict = r.json()
-        except httpx.HTTPStatusError:
+        except httpx.HTTPStatusError as exc:
+            try:
+                data = exc.response.json()
+                if data.get("detail"):
+                    return PaymentResponse(
+                        result=PaymentResult.FAILED, error_message=data["detail"]
+                    )
+            except Exception:
+                pass
             return PaymentResponse(
-                result=PaymentResult.FAILED,
-                error_message=f"HTTP status: {r.reason_phrase}",
+                result=PaymentResult.PENDING,
+                error_message=f"HTTP status: {exc.response.status_code} {exc.response.reason_phrase}",
             )
         except Exception as exc:
-            return PaymentResponse(result=PaymentResult.FAILED, error_message=str(exc))
+            return PaymentResponse(result=PaymentResult.PENDING, error_message=str(exc))
         if data.get("detail"):
             return PaymentResponse(
                 result=PaymentResult.FAILED, error_message=data["detail"]

--- a/cashu/lightning/lnd_grpc/lnd_grpc.py
+++ b/cashu/lightning/lnd_grpc/lnd_grpc.py
@@ -184,7 +184,7 @@ class LndRPCWallet(LightningBackend):
         except AioRpcError as e:
             error_message = f"SendPaymentSync failed: {e}"
             return PaymentResponse(
-                result=PaymentResult.FAILED,
+                result=PaymentResult.PENDING,
                 error_message=error_message,
             )
 
@@ -284,7 +284,7 @@ class LndRPCWallet(LightningBackend):
         except AioRpcError as e:
             logger.error(f"QueryRoute or SendToRouteV2 failed: {e}")
             return PaymentResponse(
-                result=PaymentResult.FAILED,
+                result=PaymentResult.PENDING,
                 error_message=str(e),
             )
 

--- a/cashu/lightning/lndrest.py
+++ b/cashu/lightning/lndrest.py
@@ -207,9 +207,16 @@ class LndRestWallet(LightningBackend):
         )
 
         if r.is_error or r.json().get("payment_error"):
-            error_message = r.json().get("payment_error") or r.text
+            try:
+                data = r.json()
+                if data.get("payment_error"):
+                    return PaymentResponse(
+                        result=PaymentResult.FAILED, error_message=data["payment_error"]
+                    )
+            except Exception:
+                pass
             return PaymentResponse(
-                result=PaymentResult.FAILED, error_message=error_message
+                result=PaymentResult.PENDING, error_message=r.text
             )
 
         data = r.json()

--- a/cashu/lightning/strike.py
+++ b/cashu/lightning/strike.py
@@ -262,11 +262,6 @@ class StrikeWallet(LightningBackend):
                     result=PaymentResult.PENDING,
                     error_message=exc.response.text,
                 )
-            except Exception:
-                return PaymentResponse(
-                    result=PaymentResult.PENDING,
-                    error_message=exc.response.text,
-                )
         except Exception as exc:
             return PaymentResponse(result=PaymentResult.PENDING, error_message=str(exc))
 

--- a/cashu/lightning/strike.py
+++ b/cashu/lightning/strike.py
@@ -250,11 +250,25 @@ class StrikeWallet(LightningBackend):
                 timeout=None,
             )
             r.raise_for_status()
-        except Exception:
-            error_message = r.json()["data"]["message"]
-            return PaymentResponse(
-                result=PaymentResult.FAILED, error_message=error_message
-            )
+        except httpx.HTTPStatusError as exc:
+            try:
+                error_message = r.json()["data"]["message"]
+                return PaymentResponse(
+                    result=PaymentResult.FAILED,
+                    error_message=error_message,
+                )
+            except Exception:
+                return PaymentResponse(
+                    result=PaymentResult.PENDING,
+                    error_message=exc.response.text,
+                )
+            except Exception:
+                return PaymentResponse(
+                    result=PaymentResult.PENDING,
+                    error_message=exc.response.text,
+                )
+        except Exception as exc:
+            return PaymentResponse(result=PaymentResult.PENDING, error_message=str(exc))
 
         payment = StrikePaymentResponse.model_validate(r.json())
         fee = self.fee_int(payment, self.unit)

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -929,8 +929,8 @@ class Ledger(
                 )
 
             match payment.result:
-                case PaymentResult.FAILED | PaymentResult.UNKNOWN:
-                    # explicitly check payment status for failed or unknown payment states
+                case PaymentResult.FAILED | PaymentResult.UNKNOWN | PaymentResult.PENDING:
+                    # explicitly check payment status for failed, pending, or unknown payment states
                     checking_id = payment.checking_id or melt_quote.checking_id
                     logger.debug(
                         f"Payment state is {payment.result.name}.{' Error: ' + payment.error_message + '.' if payment.error_message else ''} Checking status for {checking_id}."
@@ -948,8 +948,8 @@ class Ledger(
                         return PostMeltQuoteResponse.from_melt_quote(melt_quote)
 
                     match status.result:
-                        case PaymentResult.FAILED | PaymentResult.UNKNOWN:
-                            # Everything as expected. Payment AND a status check both agree on a failure. We roll back the transaction.
+                        case PaymentResult.FAILED:
+                            # Everything as expected. Status check returned failure. We roll back the transaction.
                             await self.db_write.unset_melt_quote_pending_and_proofs(
                                 quote=melt_quote,
                                 proofs=proofs,
@@ -963,6 +963,12 @@ class Ledger(
                             raise LightningPaymentFailedError(
                                 f"Lightning payment failed{': ' + payment.error_message if payment.error_message else ''}."
                             )
+                        case PaymentResult.UNKNOWN | PaymentResult.PENDING:
+                            # Payment state check returned unknown or pending. Keep transaction pending and return.
+                            logger.debug(
+                                f"Payment state check returned {status.result.name}. Proofs for melt quote {melt_quote.quote} are pending."
+                            )
+                            return PostMeltQuoteResponse.from_melt_quote(melt_quote)
                         case _:
                             # Something went wrong with our implementation or the backend. Status check returned different result than payment. Keep transaction pending and return.
                             logger.error(
@@ -984,7 +990,7 @@ class Ledger(
                     melt_quote.paid_time = int(time.time())
                     # NOTE: This is the only branch for a successful payment
 
-                case PaymentResult.PENDING | _:
+                case _:
                     logger.debug(
                         f"Lightning payment is {payment.result.name}: {payment.checking_id}"
                     )

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -929,8 +929,8 @@ class Ledger(
                 )
 
             match payment.result:
-                case PaymentResult.FAILED | PaymentResult.UNKNOWN | PaymentResult.PENDING:
-                    # explicitly check payment status for failed, pending, or unknown payment states
+                case PaymentResult.FAILED | PaymentResult.UNKNOWN:
+                    # explicitly check payment status for failed or unknown payment states
                     checking_id = payment.checking_id or melt_quote.checking_id
                     logger.debug(
                         f"Payment state is {payment.result.name}.{' Error: ' + payment.error_message + '.' if payment.error_message else ''} Checking status for {checking_id}."
@@ -948,8 +948,8 @@ class Ledger(
                         return PostMeltQuoteResponse.from_melt_quote(melt_quote)
 
                     match status.result:
-                        case PaymentResult.FAILED:
-                            # Everything as expected. Status check returned failure. We roll back the transaction.
+                        case PaymentResult.FAILED | PaymentResult.UNKNOWN:
+                            # Everything as expected. Payment AND a status check both agree on a failure. We roll back the transaction.
                             await self.db_write.unset_melt_quote_pending_and_proofs(
                                 quote=melt_quote,
                                 proofs=proofs,
@@ -963,12 +963,6 @@ class Ledger(
                             raise LightningPaymentFailedError(
                                 f"Lightning payment failed{': ' + payment.error_message if payment.error_message else ''}."
                             )
-                        case PaymentResult.UNKNOWN | PaymentResult.PENDING:
-                            # Payment state check returned unknown or pending. Keep transaction pending and return.
-                            logger.debug(
-                                f"Payment state check returned {status.result.name}. Proofs for melt quote {melt_quote.quote} are pending."
-                            )
-                            return PostMeltQuoteResponse.from_melt_quote(melt_quote)
                         case _:
                             # Something went wrong with our implementation or the backend. Status check returned different result than payment. Keep transaction pending and return.
                             logger.error(
@@ -990,7 +984,7 @@ class Ledger(
                     melt_quote.paid_time = int(time.time())
                     # NOTE: This is the only branch for a successful payment
 
-                case _:
+                case PaymentResult.PENDING | _:
                     logger.debug(
                         f"Lightning payment is {payment.result.name}: {payment.checking_id}"
                     )

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -929,8 +929,8 @@ class Ledger(
                 )
 
             match payment.result:
-                case PaymentResult.FAILED | PaymentResult.UNKNOWN | PaymentResult.PENDING:
-                    # explicitly check payment status for failed, pending, or unknown payment states
+                case PaymentResult.FAILED | PaymentResult.UNKNOWN:
+                    # explicitly check payment status for failed or unknown payment states
                     checking_id = payment.checking_id or melt_quote.checking_id
                     logger.debug(
                         f"Payment state is {payment.result.name}.{' Error: ' + payment.error_message + '.' if payment.error_message else ''} Checking status for {checking_id}."
@@ -963,7 +963,7 @@ class Ledger(
                             raise LightningPaymentFailedError(
                                 f"Lightning payment failed{': ' + payment.error_message if payment.error_message else ''}."
                             )
-                        case PaymentResult.UNKNOWN | PaymentResult.PENDING:
+                        case PaymentResult.UNKNOWN:
                             # Payment state check returned unknown or pending. Keep transaction pending and return.
                             logger.debug(
                                 f"Payment state check returned {status.result.name}. Proofs for melt quote {melt_quote.quote} are pending."

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -948,7 +948,7 @@ class Ledger(
                         return PostMeltQuoteResponse.from_melt_quote(melt_quote)
 
                     match status.result:
-                        case PaymentResult.FAILED:
+                        case PaymentResult.FAILED | PaymentResult.UNKNOWN:
                             # Everything as expected. Status check returned failure. We roll back the transaction.
                             await self.db_write.unset_melt_quote_pending_and_proofs(
                                 quote=melt_quote,
@@ -963,12 +963,6 @@ class Ledger(
                             raise LightningPaymentFailedError(
                                 f"Lightning payment failed{': ' + payment.error_message if payment.error_message else ''}."
                             )
-                        case PaymentResult.UNKNOWN:
-                            # Payment state check returned unknown or pending. Keep transaction pending and return.
-                            logger.debug(
-                                f"Payment state check returned {status.result.name}. Proofs for melt quote {melt_quote.quote} are pending."
-                            )
-                            return PostMeltQuoteResponse.from_melt_quote(melt_quote)
                         case _:
                             # Something went wrong with our implementation or the backend. Status check returned different result than payment. Keep transaction pending and return.
                             logger.error(

--- a/tests/mint/test_mint_melt.py
+++ b/tests/mint/test_mint_melt.py
@@ -402,8 +402,11 @@ async def test_melt_lightning_pay_invoice_failed_failed(ledger: Ledger, wallet: 
 
     settings.fakewallet_payment_state = PaymentResult.UNKNOWN.name
     settings.fakewallet_pay_invoice_state = PaymentResult.FAILED.name
-    melt_response = await ledger.melt(proofs=wallet.proofs, quote=quote_id)
-    assert melt_response.state == MeltQuoteState.pending.value
+    try:
+        await ledger.melt(proofs=wallet.proofs, quote=quote_id)
+        raise AssertionError("Expected LightningPaymentFailedError")
+    except LightningPaymentFailedError:
+        pass
 
     settings.fakewallet_payment_state = PaymentResult.FAILED.name
     settings.fakewallet_pay_invoice_state = PaymentResult.UNKNOWN.name
@@ -415,8 +418,11 @@ async def test_melt_lightning_pay_invoice_failed_failed(ledger: Ledger, wallet: 
 
     settings.fakewallet_payment_state = PaymentResult.UNKNOWN.name
     settings.fakewallet_pay_invoice_state = PaymentResult.UNKNOWN.name
-    melt_response = await ledger.melt(proofs=wallet.proofs, quote=quote_id)
-    assert melt_response.state == MeltQuoteState.pending.value
+    try:
+        await ledger.melt(proofs=wallet.proofs, quote=quote_id)
+        raise AssertionError("Expected LightningPaymentFailedError")
+    except LightningPaymentFailedError:
+        pass
 
 
 @pytest.mark.asyncio

--- a/tests/mint/test_mint_melt.py
+++ b/tests/mint/test_mint_melt.py
@@ -402,11 +402,8 @@ async def test_melt_lightning_pay_invoice_failed_failed(ledger: Ledger, wallet: 
 
     settings.fakewallet_payment_state = PaymentResult.UNKNOWN.name
     settings.fakewallet_pay_invoice_state = PaymentResult.FAILED.name
-    try:
-        await ledger.melt(proofs=wallet.proofs, quote=quote_id)
-        raise AssertionError("Expected LightningPaymentFailedError")
-    except LightningPaymentFailedError:
-        pass
+    melt_response = await ledger.melt(proofs=wallet.proofs, quote=quote_id)
+    assert melt_response.state == MeltQuoteState.pending.value
 
     settings.fakewallet_payment_state = PaymentResult.FAILED.name
     settings.fakewallet_pay_invoice_state = PaymentResult.UNKNOWN.name
@@ -418,11 +415,8 @@ async def test_melt_lightning_pay_invoice_failed_failed(ledger: Ledger, wallet: 
 
     settings.fakewallet_payment_state = PaymentResult.UNKNOWN.name
     settings.fakewallet_pay_invoice_state = PaymentResult.UNKNOWN.name
-    try:
-        await ledger.melt(proofs=wallet.proofs, quote=quote_id)
-        raise AssertionError("Expected LightningPaymentFailedError")
-    except LightningPaymentFailedError:
-        pass
+    melt_response = await ledger.melt(proofs=wallet.proofs, quote=quote_id)
+    assert melt_response.state == MeltQuoteState.pending.value
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- This replaces PR #988 and fixes the critical DoS / stuck funds vulnerability.
- `cashu/mint/ledger.py` has been reverted to its original state where `UNKNOWN` safely triggers a rollback of user funds.
- Instead of removing the `UNKNOWN` rollback entirely, this PR fixes the backends (`lnbits.py`, `lndrest.py`, `strike.py`, `clnrest.py`, `corelightningrest.py`, `blink.py`, `lnd_grpc.py`).
- Backends will now only return `PaymentResult.UNKNOWN` when the Lightning node explicitly returns a 404 / Not Found. 
- For timeouts, network errors, or any state where the backend doesn't explicitly tell us the status, it now returns `PaymentResult.PENDING`, which safely locks the funds in the pending state.