### PR TITLE
chore(docker): add redis caching server to docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,4 +11,15 @@ services:
       - MINT_LISTEN_HOST=0.0.0.0
       - MINT_LISTEN_PORT=3338
       - MINT_PRIVATE_KEY=TEST_PRIVATE_KEY
+      - MINT_REDIS_CACHE_ENABLED=TRUE
+      - MINT_REDIS_CACHE_URL=redis://redis:6379
+    depends_on:
+      - redis
     command: ["poetry", "run", "mint"]
+
+  redis:
+    image: redis:latest
+    container_name: redis
+    ports:
+      - "6379:6379"
+    restart: always


### PR DESCRIPTION
## Summary
* Added a `redis` service using the `redis:latest` image to `docker-compose.yaml`.
* Configured the `mint` service to depend on the `redis` service.
* Enabled Redis caching for the mint by default in `docker-compose.yaml` by setting `MINT_REDIS_CACHE_ENABLED=TRUE` and providing the `MINT_REDIS_CACHE_URL`.

This ensures the mint runs with Redis caching locally by default when using `docker compose up`.