### PR TITLE
fix(mint): preserve change promises order in paid melt quotes

### DIFF
--- a/cashu/mint/crud.py
+++ b/cashu/mint/crud.py
@@ -162,6 +162,7 @@ class LedgerCrud(ABC):
         mint_id: Optional[str] = None,
         melt_id: Optional[str] = None,
         swap_id: Optional[str] = None,
+        order_index: int = 0,
         conn: Optional[Connection] = None,
     ) -> None: ...
 
@@ -345,13 +346,14 @@ class LedgerCrudSqlite(LedgerCrud):
         mint_id: Optional[str] = None,
         melt_id: Optional[str] = None,
         swap_id: Optional[str] = None,
+        order_index: int = 0,
         conn: Optional[Connection] = None,
     ) -> None:
         await (conn or db).execute(
             f"""
             INSERT INTO {db.table_with_schema('promises')}
-            (amount, b_, id, created, mint_quote, melt_quote, swap_id)
-            VALUES (:amount, :b_, :id, :created, :mint_quote, :melt_quote, :swap_id)
+            (amount, b_, id, created, mint_quote, melt_quote, swap_id, order_index)
+            VALUES (:amount, :b_, :id, :created, :mint_quote, :melt_quote, :swap_id, :order_index)
             """,
             {
                 "amount": amount,
@@ -361,6 +363,7 @@ class LedgerCrudSqlite(LedgerCrud):
                 "mint_quote": mint_id,
                 "melt_quote": melt_id,
                 "swap_id": swap_id,
+                "order_index": order_index,
             },
         )
 
@@ -375,6 +378,7 @@ class LedgerCrudSqlite(LedgerCrud):
             f"""
             SELECT * from {db.table_with_schema('promises')}
             WHERE melt_quote = :melt_id AND c_ IS NULL
+            ORDER BY order_index ASC
             """,
             {"melt_id": melt_id},
         )
@@ -391,6 +395,7 @@ class LedgerCrudSqlite(LedgerCrud):
             f"""
                 SELECT * from {db.table_with_schema('promises')}
                 WHERE melt_quote = :melt_id AND c_ IS NOT NULL
+                ORDER BY order_index ASC
                 """,
             {"melt_id": melt_id},
         )

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -1121,7 +1121,7 @@ class Ledger(
             conn: (Optional[Connection], optional): Database connection to reuse. Will create a new one if not given. Defaults to None.
         """
         async with self.db.get_connection(conn) as conn:
-            for output in outputs:
+            for i, output in enumerate(outputs):
                 keyset = keyset or self.keysets[output.id]
                 if output.id not in self.keysets:
                     raise TransactionError(f"keyset {output.id} not found")
@@ -1137,6 +1137,7 @@ class Ledger(
                     mint_id=mint_id,
                     melt_id=melt_id,
                     swap_id=swap_id,
+                    order_index=i,
                     db=self.db,
                     conn=conn,
                 )

--- a/cashu/mint/migrations.py
+++ b/cashu/mint/migrations.py
@@ -1234,3 +1234,13 @@ async def m033_add_issued_time_to_mint_quote(db: Database):
         await conn.execute(
             f"ALTER TABLE {db.table_with_schema('mint_quotes')} ADD COLUMN issued_time TIMESTAMP"
         )
+
+async def m034_promises_order_index(db: Database):
+    """
+    Add order_index to promises table to preserve the original order of outputs.
+    """
+    async with db.connect() as conn:
+        await conn.execute(
+            f"ALTER TABLE {db.table_with_schema('promises')} ADD COLUMN order_index INTEGER DEFAULT 0"
+        )
+

--- a/tests/mint/test_mint_db_operations.py
+++ b/tests/mint/test_mint_db_operations.py
@@ -653,6 +653,67 @@ async def test_get_blind_signatures_by_melt_id_returns_signed(
 
 
 @pytest.mark.asyncio
+async def test_get_melt_quote_preserves_change_signatures_order(
+    wallet: Wallet, ledger: Ledger
+):
+    from cashu.core.crypto.b_dhke import step1_alice, step2_bob
+    from cashu.core.crypto.secp import PublicKey
+
+    amount = 8
+    keyset_id = ledger.keyset.id
+
+    mint_quote = await wallet.request_mint(64)
+    melt_quote = await ledger.melt_quote(
+        PostMeltQuoteRequest(request=mint_quote.request, unit="sat")
+    )
+    melt_id = melt_quote.quote
+
+    # Create 5 blinded messages
+    b_values = []
+    for i in range(5):
+        B, _ = step1_alice(f"melt_quote_change_{i}")
+        b_values.append(B.format().hex())
+
+    # Store them out of order of insertion, but with correct order_index
+    # We will insert index 4, 1, 3, 0, 2
+    insert_order = [4, 1, 3, 0, 2]
+    for idx in insert_order:
+        await ledger.crud.store_blinded_message(
+            db=ledger.db,
+            amount=amount,
+            b_=b_values[idx],
+            id=keyset_id,
+            melt_id=melt_id,
+            order_index=idx,
+        )
+        
+        # Sign it right away so it is returned in change
+        priv = ledger.keyset.private_keys[amount]
+        _, e, s = step2_bob(PublicKey(bytes.fromhex(b_values[idx])), priv)
+        await ledger.crud.update_blinded_message_signature(
+            db=ledger.db,
+            amount=amount,
+            b_=b_values[idx],
+            c_=PublicKey(bytes.fromhex(b_values[idx])).format().hex(), # Mock C_ just to not be NULL
+            e=e.to_hex(),
+            s=s.to_hex()
+        )
+
+    # Act
+    quote_db = await ledger.crud.get_melt_quote(quote_id=melt_id, db=ledger.db)
+
+    # Assert: change contains the signed promises IN CORRECT ORDER
+    assert quote_db is not None
+    assert quote_db.change is not None
+    assert len(quote_db.change) == 5
+    
+    # We check if we can reconstruct the original B_ mapping using the DB again (to verify test mock is valid)
+    # However we can just verify that C_ values matches what we inserted
+    # Since we mocked C_ to be the same as B_ in our test
+    for i in range(5):
+        assert quote_db.change[i].C_ == b_values[i], f"Change signature at index {i} is out of order"
+
+@pytest.mark.asyncio
 async def test_get_melt_quote_includes_change_signatures(
     wallet: Wallet, ledger: Ledger
 ):

--- a/tests/mint/test_mint_operations.py
+++ b/tests/mint/test_mint_operations.py
@@ -465,6 +465,73 @@ async def test_check_proof_state(wallet1: Wallet, ledger: Ledger):
     proof_states = await ledger.db_read.get_proofs_states(Ys=[p.Y for p in send_proofs])
     assert all([p.state.value == "UNSPENT" for p in proof_states])
 
+@pytest.mark.asyncio
+@pytest.mark.skipif(is_regtest, reason="only works with FakeWallet")
+async def test_melt_preserves_change_signatures_order_integration(wallet1: Wallet, ledger: Ledger):
+    # mint enough to pay invoice
+    mint_quote = await wallet1.request_mint(128)
+    await pay_if_regtest(mint_quote.request)
+    await wallet1.mint(128, quote_id=mint_quote.quote)
+    assert wallet1.balance >= 64
+
+    invoice_dict = get_real_invoice(64)
+    invoice_payment_request = invoice_dict["payment_request"] if is_regtest else "lnbcrt640n1pn0r3tfpp5e30xac756gvd26cn3tgsh8ug6ct555zrvl7vsnma5cwp4g7auq5qdqqcqzzsxqyz5vqsp5xfhtzg0y3mekv6nsdnj43c346smh036t4f8gcfa2zwpxzwcryqvs9qxpqysgqw5juev8y3zxpdu0mvdrced5c6a852f9x7uh57g6fgjgcg5muqzd5474d7xgh770frazel67eejfwelnyr507q46hxqehala880rhlqspw07ta0"
+    if type(invoice_payment_request) is dict:
+        invoice_payment_request = invoice_payment_request["payment_request"]
+
+    # wallet asks for quote
+    _ = await wallet1.melt_quote(invoice_payment_request)
+    
+    # Force the fee_reserve in the DB to be larger so we get multiple change outputs
+    # Let's say overpaid_fee = 7 -> [4, 2, 1]
+    total_amount = 64 + 7
+    _, send_proofs = await wallet1.swap_to_send(wallet1.proofs, total_amount)
+    
+    melt_quote_internal = await ledger.melt_quote(
+        PostMeltQuoteRequest(request=invoice_payment_request, unit="sat")
+    )
+    # forcefully update the fee_reserve and amount to allow 7 sat overpayment
+    await ledger.db.execute(f"UPDATE {ledger.db.table_with_schema('melt_quotes')} SET fee_reserve = 7 WHERE quote = '{melt_quote_internal.quote}'")
+    melt_quote_internal.fee_reserve = 7
+
+    # prepare outputs for change
+    output_amounts = [1, 2, 4, 8] # Provide change outputs
+    secrets, rs, derivation_paths = await wallet1.generate_n_secrets(len(output_amounts))
+    outputs, rs = wallet1._construct_outputs(output_amounts, secrets, rs)
+    
+    # We force pending state by tricking fakewallet
+    from cashu.lightning.base import PaymentResult
+    settings.fakewallet_pay_invoice_state = PaymentResult.PENDING.name
+    settings.fakewallet_payment_state = PaymentResult.PENDING.name
+    
+    # Call melt with outputs
+    melt_response = await ledger.melt(proofs=send_proofs, quote=melt_quote_internal.quote, outputs=outputs)
+    assert melt_response.state == MeltQuoteState.pending.value
+    
+    # Now fake that payment settled
+    settings.fakewallet_payment_state = PaymentResult.SETTLED.name
+    
+    # get_melt_quote will now settle the payment and generate the change
+    quote_post = await ledger.get_melt_quote(melt_quote_internal.quote)
+    assert quote_post.state == MeltQuoteState.paid
+    assert quote_post.change is not None
+    assert len(quote_post.change) == 3 # 7 splits into [4, 2, 1]
+    
+    # Verify the order of change corresponds strictly to the B_ order of outputs
+    # To do this, we can unblind them sequentially and see if the amounts match the expected amounts
+    # If they were out of order, the wallet mapping would assign the wrong amount or fail unblinding
+    change_proofs = await wallet1._construct_proofs(
+        quote_post.change,
+        secrets[: len(quote_post.change)],
+        rs[: len(quote_post.change)],
+        derivation_paths[: len(quote_post.change)],
+    )
+    
+    # The returned change proofs must have the exact same amounts as our outputs IN ORDER
+    # The mint assigns amounts from largest to smallest, so [4, 2, 1]
+    expected_amounts = [4, 2, 1]
+    for i, proof in enumerate(change_proofs):
+        assert proof.amount == expected_amounts[i]
 
 # TODO: test keeps running forever, needs to be fixed
 # @pytest.mark.asyncio

--- a/tests/mint/test_mint_operations.py
+++ b/tests/mint/test_mint_operations.py
@@ -503,6 +503,7 @@ async def test_melt_preserves_change_signatures_order_integration(wallet1: Walle
     from cashu.lightning.base import PaymentResult
     settings.fakewallet_pay_invoice_state = PaymentResult.PENDING.name
     settings.fakewallet_payment_state = PaymentResult.PENDING.name
+    settings.fakewallet_payment_state_exception = False
     
     # Call melt with outputs
     melt_response = await ledger.melt(proofs=send_proofs, quote=melt_quote_internal.quote, outputs=outputs)


### PR DESCRIPTION
Fixes #986 

## Summary
- Fixes a bug where `get_blinded_messages_melt_id` retrieved `outputs` from the database without an `ORDER BY` clause, leading to incorrectly mapped change signatures.
- Adds an `order_index` column to the `promises` table via a database schema migration (`m034_promises_order_index`).
- Updates `Ledger._store_blinded_messages` to record the original insertion order of the `outputs` correctly.
- Ensures `crud.get_blinded_messages_melt_id` and `crud.get_blind_signatures_melt_id` retrieve data sequentially via `ORDER BY order_index ASC`.
- Adds comprehensive unit and integration tests to verify the stable mapping and correct unblinding of multi-change denominations during delayed/asynchronous melt quote settlements.