### PR TITLE
feat: add support for Redis Cluster

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,7 @@ MINT_BACKEND_BOLT11_SAT=FakeWallet
 #
 # MINT_REDIS_CACHE_ENABLED=TRUE
 # MINT_REDIS_CACHE_URL="redis://localhost:6379"
+# MINT_REDIS_CACHE_CLUSTER=FALSE
 
 # Funding source settings
 

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -339,6 +339,7 @@ class MintRedisCache(MintSettings):
     mint_redis_cache_enabled: bool = Field(default=False)
     mint_redis_cache_url: Optional[str] = Field(default=None)
     mint_redis_cache_ttl: Optional[int] = Field(default=60 * 60 * 24 * 7)  # 1 week
+    mint_redis_cache_cluster: bool = Field(default=False)
 
 
 class Settings(

--- a/cashu/mint/cache.py
+++ b/cashu/mint/cache.py
@@ -1,10 +1,12 @@
 import functools
 import json
+from typing import Any, Union
 
 from fastapi import Request
 from loguru import logger
 from pydantic import BaseModel
-from redis.asyncio import from_url
+from redis.asyncio import Redis, from_url
+from redis.asyncio.cluster import RedisCluster
 from redis.exceptions import ConnectionError
 
 from ..core.errors import CashuError
@@ -13,12 +15,16 @@ from ..core.settings import settings
 
 class RedisCache:
     initialized = False
+    redis: Union[Redis, Any]
 
     def __init__(self):
         if settings.mint_redis_cache_enabled:
             if settings.mint_redis_cache_url is None:
                 raise CashuError("Redis cache url not provided")
-            self.redis = from_url(settings.mint_redis_cache_url)
+            if settings.mint_redis_cache_cluster:
+                self.redis = RedisCluster.from_url(settings.mint_redis_cache_url)
+            else:
+                self.redis = from_url(settings.mint_redis_cache_url)
 
     async def test_connection(self):
         # PING


### PR DESCRIPTION
## Summary
- Adds `mint_redis_cache_cluster` setting (default False) to enable connecting to Redis Cluster deployments
- Updates `RedisCache` instantiation in `cashu/mint/cache.py` to dynamically use `RedisCluster.from_url` when configured
- Resolves mypy type check issues by using `Union[Redis, Any]` for the initialized client

This PR enables users to run nutshelf with highly available Redis Cluster infrastructure.