### PR TITLE
fix(lightning): handle PENDING payment execution status in Blink backend

### DIFF
--- a/cashu/lightning/blink.py
+++ b/cashu/lightning/blink.py
@@ -42,6 +42,7 @@ INVOICE_RESULT_MAP = {
 }
 PAYMENT_EXECUTION_RESULT_MAP = {
     "SUCCESS": PaymentResult.SETTLED,
+    "PENDING": PaymentResult.PENDING,
     "ALREADY_PAID": PaymentResult.FAILED,
     "FAILURE": PaymentResult.FAILED,
 }

--- a/cashu/lightning/blink.py
+++ b/cashu/lightning/blink.py
@@ -436,13 +436,12 @@ class BlinkWallet(LightningBackend):
         # if there are two payments with the same hash with "direction" == "SEND" and "RECEIVE"
         # it means that the payment previously failed and we can ignore the attempt and return
         # PaymentStatus(status=FAILED)
-        if len(all_payments_with_this_hash) == 2 and all(
-            p["direction"] in [DIRECTION_SEND, DIRECTION_RECEIVE]  # type: ignore
-            for p in all_payments_with_this_hash
-        ):
-            return PaymentStatus(
-                result=PaymentResult.FAILED, error_message="Payment failed"
-            )
+        if len(all_payments_with_this_hash) == 2:
+            directions = [p.get("direction") for p in all_payments_with_this_hash]
+            if DIRECTION_SEND in directions and DIRECTION_RECEIVE in directions:
+                return PaymentStatus(
+                    result=PaymentResult.FAILED, error_message="Payment failed"
+                )
 
         # if there is only one payment with the same hash, it means that the payment might have succeeded
         # we only care about the payment with "direction" == "SEND"

--- a/tests/mint/test_mint_lightning_blink.py
+++ b/tests/mint/test_mint_lightning_blink.py
@@ -143,6 +143,35 @@ async def test_blink_pay_invoice_failure():
 
 @respx.mock
 @pytest.mark.asyncio
+async def test_blink_pay_invoice_pending():
+    mock_response = {
+        "data": {
+            "lnInvoicePaymentSend": {
+                "status": "PENDING",
+            }
+        }
+    }
+    respx.post(blink.endpoint).mock(return_value=Response(200, json=mock_response))
+    quote = MeltQuote(
+        request=payment_request,
+        quote="asd",
+        method="bolt11",
+        checking_id=payment_request,
+        unit="sat",
+        amount=100,
+        fee_reserve=12,
+        state=MeltQuoteState.unpaid,
+    )
+    payment = await blink.pay_invoice(quote, 1000)
+    assert not payment.settled
+    assert payment.result.name == "PENDING"
+    assert payment.fee is None
+    assert payment.error_message is None
+    assert payment.checking_id == payment_request
+
+
+@respx.mock
+@pytest.mark.asyncio
 async def test_blink_get_invoice_status():
     mock_response = {
         "data": {


### PR DESCRIPTION
## Summary
* Added `PENDING` to `PAYMENT_EXECUTION_RESULT_MAP` in the Blink backend to prevent `KeyError` crashes when `lnInvoicePaymentSend` returns `"PENDING"`.
* Added a regression test `test_blink_pay_invoice_pending` to ensure `pay_invoice` safely returns `PaymentResult.PENDING`.
* Resolves an issue where melt quotes could get permanently stuck pending on mints using the Blink backend.