### PR TITLE
fix(mint): clean up pending proofs (NULL melt_quote) on mint startup

### DIFF
--- a/cashu/mint/crud.py
+++ b/cashu/mint/crud.py
@@ -78,6 +78,14 @@ class LedgerCrud(ABC):
     ) -> List[Proof]: ...
 
     @abstractmethod
+    async def get_pending_proofs_without_melt_quote(
+        self,
+        *,
+        db: Database,
+        conn: Optional[Connection] = None,
+    ) -> List[Proof]: ...
+
+    @abstractmethod
     async def get_proofs_pending(
         self,
         *,
@@ -536,6 +544,17 @@ class LedgerCrudSqlite(LedgerCrud):
             WHERE melt_quote = :quote_id
             """,
             {"quote_id": quote_id},
+        )
+        return [Proof(**r) for r in rows]
+
+    async def get_pending_proofs_without_melt_quote(
+        self,
+        *,
+        db: Database,
+        conn: Optional[Connection] = None,
+    ) -> List[Proof]:
+        rows = await (conn or db).fetchall(
+            f"SELECT * from {db.table_with_schema('proofs_pending')} WHERE melt_quote IS NULL"
         )
         return [Proof(**r) for r in rows]
 

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -144,6 +144,7 @@ class Ledger(
         await self._startup_keysets()
         await self._check_backends()
         await self._check_pending_proofs_and_melt_quotes()
+        await self._cleanup_orphaned_pending_proofs()
         self.regular_tasks.append(asyncio.create_task(self._run_regular_tasks()))
         self.invoice_listener_tasks = await self.dispatch_listeners()
         if settings.mint_watchdog_enabled:
@@ -203,29 +204,40 @@ class Ledger(
     async def _check_pending_proofs_and_melt_quotes(self):
         """Startup routine that checks all pending melt quotes and either invalidates
         their pending proofs for a successful melt or deletes them if the melt failed.
-        Also removes any pending proofs that have no associated melt quote (orphaned
-        swap proofs from aborted operations where no Lightning payment is in flight).
         """
         # get all pending melt quotes
         pending_melt_quotes = await self.crud.get_all_melt_quotes_from_pending_proofs(
             db=self.db
         )
-        if pending_melt_quotes:
-            logger.info(f"Checking {len(pending_melt_quotes)} pending melt quotes")
-            for quote in pending_melt_quotes:
-                quote = await self.get_melt_quote(quote_id=quote.quote)
-                logger.info(f"Melt quote {quote.quote} state: {quote.state}")
+        if not pending_melt_quotes:
+            return
+        logger.info(f"Checking {len(pending_melt_quotes)} pending melt quotes")
+        for quote in pending_melt_quotes:
+            quote = await self.get_melt_quote(quote_id=quote.quote)
+            logger.info(f"Melt quote {quote.quote} state: {quote.state}")
 
-        # remove orphaned pending proofs that have no associated melt quote
+    async def _cleanup_orphaned_pending_proofs(self) -> None:
+        """Startup-only routine that removes pending proofs with no associated melt quote.
+
+        These are orphaned swap proofs left over from an interrupted swap operation.
+        No Lightning payment is in flight for them, so they can be safely removed.
+        Keyset balances are restored via _unset_proofs_pending.
+
+        This must only be called at startup, never from the periodic task, because
+        during normal operation swap proofs are legitimately pending with a NULL
+        melt_quote while the swap transaction is in progress.
+        """
         orphaned_proofs = await self.crud.get_pending_proofs_without_melt_quote(
             db=self.db
         )
-        if orphaned_proofs:
-            logger.info(
-                f"Removing {len(orphaned_proofs)} pending proofs without a melt quote"
-            )
-            for proof in orphaned_proofs:
-                await self.crud.unset_proof_pending(proof=proof, db=self.db)
+        if not orphaned_proofs:
+            return
+        logger.info(
+            f"Removing {len(orphaned_proofs)} pending proofs without a melt quote"
+        )
+        await self.db_write._unset_proofs_pending(
+            proofs=orphaned_proofs, keysets=self.keysets, spent=False
+        )
 
     # ------- ECASH -------
 

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -143,6 +143,7 @@ class Ledger(
     async def startup_ledger(self) -> None:
         await self._startup_keysets()
         await self._check_backends()
+        await self._check_pending_proofs_and_melt_quotes()
         self.regular_tasks.append(asyncio.create_task(self._run_regular_tasks()))
         self.invoice_listener_tasks = await self.dispatch_listeners()
         if settings.mint_watchdog_enabled:
@@ -202,17 +203,29 @@ class Ledger(
     async def _check_pending_proofs_and_melt_quotes(self):
         """Startup routine that checks all pending melt quotes and either invalidates
         their pending proofs for a successful melt or deletes them if the melt failed.
+        Also removes any pending proofs that have no associated melt quote (orphaned
+        swap proofs from aborted operations where no Lightning payment is in flight).
         """
         # get all pending melt quotes
         pending_melt_quotes = await self.crud.get_all_melt_quotes_from_pending_proofs(
             db=self.db
         )
-        if not pending_melt_quotes:
-            return
-        logger.info(f"Checking {len(pending_melt_quotes)} pending melt quotes")
-        for quote in pending_melt_quotes:
-            quote = await self.get_melt_quote(quote_id=quote.quote)
-            logger.info(f"Melt quote {quote.quote} state: {quote.state}")
+        if pending_melt_quotes:
+            logger.info(f"Checking {len(pending_melt_quotes)} pending melt quotes")
+            for quote in pending_melt_quotes:
+                quote = await self.get_melt_quote(quote_id=quote.quote)
+                logger.info(f"Melt quote {quote.quote} state: {quote.state}")
+
+        # remove orphaned pending proofs that have no associated melt quote
+        orphaned_proofs = await self.crud.get_pending_proofs_without_melt_quote(
+            db=self.db
+        )
+        if orphaned_proofs:
+            logger.info(
+                f"Removing {len(orphaned_proofs)} pending proofs without a melt quote"
+            )
+            for proof in orphaned_proofs:
+                await self.crud.unset_proof_pending(proof=proof, db=self.db)
 
     # ------- ECASH -------
 

--- a/cashu/mint/migrations.py
+++ b/cashu/mint/migrations.py
@@ -1240,8 +1240,24 @@ async def m034_cleanup_pending_proofs_without_melt_quote(db: Database):
     Remove pending proofs that have no associated melt quote (melt_quote IS NULL).
     These are orphaned swap proofs from aborted operations. No outgoing payment is
     in flight for them, so they can be safely deleted.
+    Keyset balances are restored by adding back the reserved amounts before deleting.
     """
     async with db.connect() as conn:
+        await conn.execute(
+            f"""
+            UPDATE {db.table_with_schema('keysets')}
+            SET balance = balance + COALESCE((
+                SELECT SUM(amount)
+                FROM {db.table_with_schema('proofs_pending')}
+                WHERE melt_quote IS NULL
+                AND id = {db.table_with_schema('keysets')}.id
+            ), 0)
+            WHERE id IN (
+                SELECT DISTINCT id FROM {db.table_with_schema('proofs_pending')}
+                WHERE melt_quote IS NULL
+            )
+            """
+        )
         await conn.execute(
             f"DELETE FROM {db.table_with_schema('proofs_pending')} WHERE melt_quote IS NULL"
         )

--- a/cashu/mint/migrations.py
+++ b/cashu/mint/migrations.py
@@ -1234,3 +1234,14 @@ async def m033_add_issued_time_to_mint_quote(db: Database):
         await conn.execute(
             f"ALTER TABLE {db.table_with_schema('mint_quotes')} ADD COLUMN issued_time TIMESTAMP"
         )
+
+async def m034_cleanup_pending_proofs_without_melt_quote(db: Database):
+    """
+    Remove pending proofs that have no associated melt quote (melt_quote IS NULL).
+    These are orphaned swap proofs from aborted operations. No outgoing payment is
+    in flight for them, so they can be safely deleted.
+    """
+    async with db.connect() as conn:
+        await conn.execute(
+            f"DELETE FROM {db.table_with_schema('proofs_pending')} WHERE melt_quote IS NULL"
+        )

--- a/tests/mint/test_mint_init.py
+++ b/tests/mint/test_mint_init.py
@@ -526,3 +526,94 @@ async def test_regtest_check_nonexisting_melt_quote(wallet: Wallet, ledger: Ledg
     )
     assert melt_quotes
     assert melt_quotes.state == MeltQuoteState.unpaid
+
+
+# ---- orphaned pending proofs (NULL melt_quote) tests ----
+
+async def create_orphaned_pending_proof(ledger: Ledger) -> Proof:
+    """Insert a pending proof with no associated melt quote (simulates an aborted swap)."""
+    proof = Proof(amount=64, C="orphan_C", secret="orphan_secret", id=ledger.keyset.id)
+    await ledger.crud.set_proof_pending(db=ledger.db, proof=proof, quote_id=None)
+    return proof
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(is_regtest, reason="only fake wallet")
+async def test_startup_cleans_orphaned_pending_proofs(ledger: Ledger):
+    """Startup routine must remove pending proofs that have no associated melt quote.
+    These are left over from aborted swap operations and no Lightning payment is in flight."""
+    proof = await create_orphaned_pending_proof(ledger)
+
+    # confirm proof is in pending table
+    states = await ledger.db_read.get_proofs_states([proof.Y])
+    assert states[0].pending
+
+    # confirm it shows up in the dedicated query
+    orphaned = await ledger.crud.get_pending_proofs_without_melt_quote(db=ledger.db)
+    assert any(p.secret == proof.secret for p in orphaned)
+
+    # run startup routine
+    await ledger._check_pending_proofs_and_melt_quotes()
+
+    # proof must be gone from pending
+    states = await ledger.db_read.get_proofs_states([proof.Y])
+    assert states[0].unspent
+
+    # orphan query must return empty
+    orphaned = await ledger.crud.get_pending_proofs_without_melt_quote(db=ledger.db)
+    assert not any(p.secret == proof.secret for p in orphaned)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(is_regtest, reason="only fake wallet")
+async def test_startup_cleans_orphaned_proofs_but_leaves_melt_pending(ledger: Ledger):
+    """When both orphaned swap proofs AND a genuinely in-flight melt exist, the startup
+    routine must remove the orphaned proofs but leave the in-flight melt proofs untouched."""
+    # create an in-flight melt (PENDING state, backend will return PENDING)
+    settings.fakewallet_payment_state = PaymentResult.PENDING.name
+    melt_proof, melt_quote = await create_pending_melts(ledger)
+
+    # create an orphaned swap proof alongside it
+    orphan = await create_orphaned_pending_proof(ledger)
+
+    # both are pending before cleanup
+    states = await ledger.db_read.get_proofs_states([melt_proof.Y, orphan.Y])
+    assert all(s.pending for s in states)
+
+    await ledger._check_pending_proofs_and_melt_quotes()
+
+    # melt proof is still pending (payment in flight)
+    melt_states = await ledger.db_read.get_proofs_states([melt_proof.Y])
+    assert melt_states[0].pending
+
+    # orphan is gone
+    orphan_states = await ledger.db_read.get_proofs_states([orphan.Y])
+    assert orphan_states[0].unspent
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(is_regtest, reason="only fake wallet")
+async def test_get_pending_proofs_without_melt_quote_empty(ledger: Ledger):
+    """With no orphaned proofs in the table, the query returns an empty list."""
+    orphaned = await ledger.crud.get_pending_proofs_without_melt_quote(db=ledger.db)
+    assert orphaned == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(is_regtest, reason="only fake wallet")
+async def test_get_pending_proofs_without_melt_quote_only_returns_null_rows(
+    ledger: Ledger,
+):
+    """get_pending_proofs_without_melt_quote must NOT return proofs that do have a
+    melt_quote set."""
+    # insert a melt-linked proof
+    melt_proof, _ = await create_pending_melts(ledger)
+    # insert an orphaned proof
+    orphan = await create_orphaned_pending_proof(ledger)
+
+    result = await ledger.crud.get_pending_proofs_without_melt_quote(db=ledger.db)
+
+    # only the orphan (NULL melt_quote) should be returned
+    secrets = [p.secret for p in result]
+    assert orphan.secret in secrets
+    assert melt_proof.secret not in secrets

--- a/tests/mint/test_mint_init.py
+++ b/tests/mint/test_mint_init.py
@@ -552,8 +552,12 @@ async def test_startup_cleans_orphaned_pending_proofs(ledger: Ledger):
     orphaned = await ledger.crud.get_pending_proofs_without_melt_quote(db=ledger.db)
     assert any(p.secret == proof.secret for p in orphaned)
 
-    # run startup routine
-    await ledger._check_pending_proofs_and_melt_quotes()
+    # record keyset balance before cleanup
+    keyset = ledger.keysets[proof.id]
+    balance_before, _ = await ledger.crud.get_balance(keyset=keyset, db=ledger.db)
+
+    # run startup-only orphan cleanup
+    await ledger._cleanup_orphaned_pending_proofs()
 
     # proof must be gone from pending
     states = await ledger.db_read.get_proofs_states([proof.Y])
@@ -562,6 +566,10 @@ async def test_startup_cleans_orphaned_pending_proofs(ledger: Ledger):
     # orphan query must return empty
     orphaned = await ledger.crud.get_pending_proofs_without_melt_quote(db=ledger.db)
     assert not any(p.secret == proof.secret for p in orphaned)
+
+    # keyset balance must be restored by the proof amount
+    balance_after, _ = await ledger.crud.get_balance(keyset=keyset, db=ledger.db)
+    assert balance_after.amount == balance_before.amount + proof.amount
 
 
 @pytest.mark.asyncio
@@ -580,7 +588,7 @@ async def test_startup_cleans_orphaned_proofs_but_leaves_melt_pending(ledger: Le
     states = await ledger.db_read.get_proofs_states([melt_proof.Y, orphan.Y])
     assert all(s.pending for s in states)
 
-    await ledger._check_pending_proofs_and_melt_quotes()
+    await ledger._cleanup_orphaned_pending_proofs()
 
     # melt proof is still pending (payment in flight)
     melt_states = await ledger.db_read.get_proofs_states([melt_proof.Y])


### PR DESCRIPTION
Follow up PR from https://github.com/cashubtc/nutshell/pull/839

Pending proofs created during swap operations are written to `proofs_pending` with `melt_quote = NULL`. If the mint crashes mid-swap, these proofs are never cleaned up, the existing startup check only processes proofs that have an associated melt quote (i.e. outgoing Lightning payments).

## Changes

Extend `_check_pending_proofs_and_melt_quotes` to also query and remove pending proofs where `melt_quote IS NULL`. These are safe to delete on startup because:
-  if the mint is starting up, no swap is mid-flight
- Only melts involve an in-flight Lightning payment, and melts always write a non-NULL `melt_quote`

- A migration (`m034`) performs a one-time bulk cleanup of any existing orphaned rows for upgrading mints.

- `migrations.py`: `m034` deletes all `proofs_pending` rows with `melt_quote IS NULL`
- `crud.py`: adds `get_pending_proofs_without_melt_quote` query
- `ledger.py`: startup routine now unsets orphaned proofs after processing melt quotes
- `tests`: four new tests covering the cleanup logic and the query