### PR TITLE
fix: update .env.example to reflect rate limiting enabled by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,13 +137,15 @@ MINT_RPC_SERVER_CA="./ca_cert.pem"
 # Disable melting of BOLT11 invoices
 # MINT_BOLT11_DISABLE_MELT=FALSE
 
-# Rate limit requests to mint. Make sure that you can see request IPs in the logs.
+# Rate limit requests to mint (enabled by default).
+# Set MINT_RATE_LIMIT=FALSE to disable.
+# Make sure that you can see request IPs in the logs.
 # You may need to adjust your reverse proxy if you only see requests originating from 127.0.0.1
-# MINT_RATE_LIMIT=TRUE
+MINT_RATE_LIMIT=TRUE
 # Determines the number of all requests allowed per minute per IP
-# MINT_GLOBAL_RATE_LIMIT_PER_MINUTE=60
+MINT_GLOBAL_RATE_LIMIT_PER_MINUTE=60
 # Determines the number of transactions (mint, melt, swap) allowed per minute per IP
-# MINT_TRANSACTION_RATE_LIMIT_PER_MINUTE=20
+MINT_TRANSACTION_RATE_LIMIT_PER_MINUTE=20
 
 # Authentication
 # These settings allow you to enable blind authentication to limit the user of your mint to a group of authenticated users.


### PR DESCRIPTION
Fixes #982 - rate limiting has been on by default since commit 44f0abd but .env.example still showed all rate-limit vars commented out, giving operators the wrong impression that it was disabled by default.