### PR TITLE
fix: add ORDER BY id to blind signatures and blinded messages melt queries

### DIFF
--- a/cashu/mint/crud.py
+++ b/cashu/mint/crud.py
@@ -375,6 +375,7 @@ class LedgerCrudSqlite(LedgerCrud):
             f"""
             SELECT * from {db.table_with_schema('promises')}
             WHERE melt_quote = :melt_id AND c_ IS NULL
+            ORDER BY id
             """,
             {"melt_id": melt_id},
         )
@@ -391,6 +392,7 @@ class LedgerCrudSqlite(LedgerCrud):
             f"""
                 SELECT * from {db.table_with_schema('promises')}
                 WHERE melt_quote = :melt_id AND c_ IS NOT NULL
+                ORDER BY id
                 """,
             {"melt_id": melt_id},
         )


### PR DESCRIPTION
Fixes #986 - both SQL queries fetched rows without ORDER BY clause returning non-deterministic order. Wrong denominations were being assigned to wrong B_ values producing mismatched signatures on melt quote responses.