### PR TITLE
fix(mint): batch subscription initialization to prevent db connection exhaustion

### DIFF
--- a/cashu/mint/events/client.py
+++ b/cashu/mint/events/client.py
@@ -215,6 +215,7 @@ class LedgerEventClientManager:
     async def _init_subscriptions(
         self, subId: str, filters: List[str], kind: JSONRPCSubscriptionKinds
     ):
+        results = []
         async with self.db_read.db.connect() as conn:
             if kind == JSONRPCSubscriptionKinds.BOLT11_MINT_QUOTE:
                 for filter in filters:
@@ -222,15 +223,18 @@ class LedgerEventClientManager:
                         quote_id=filter, db=self.db_read.db, conn=conn
                     )
                     if mint_quote:
-                        await self._send_obj(PostMintQuoteResponse.from_mint_quote(mint_quote).model_dump(), subId)
+                        results.append(PostMintQuoteResponse.from_mint_quote(mint_quote).model_dump())
             elif kind == JSONRPCSubscriptionKinds.BOLT11_MELT_QUOTE:
                 for filter in filters:
                     melt_quote = await self.db_read.crud.get_melt_quote(
                         quote_id=filter, db=self.db_read.db, conn=conn
                     )
                     if melt_quote:
-                        await self._send_obj(PostMeltQuoteResponse.from_melt_quote(melt_quote).model_dump(), subId)
+                        results.append(PostMeltQuoteResponse.from_melt_quote(melt_quote).model_dump())
             elif kind == JSONRPCSubscriptionKinds.PROOF_STATE:
                 proofs = await self.db_read.get_proofs_states(Ys=filters, conn=conn)
                 for proof in proofs:
-                    await self._send_obj(proof.model_dump(), subId)
+                    results.append(proof.model_dump())
+        
+        for result in results:
+            await self._send_obj(result, subId)

--- a/cashu/mint/events/client.py
+++ b/cashu/mint/events/client.py
@@ -215,21 +215,22 @@ class LedgerEventClientManager:
     async def _init_subscriptions(
         self, subId: str, filters: List[str], kind: JSONRPCSubscriptionKinds
     ):
-        if kind == JSONRPCSubscriptionKinds.BOLT11_MINT_QUOTE:
-            for filter in filters:
-                mint_quote = await self.db_read.crud.get_mint_quote(
-                    quote_id=filter, db=self.db_read.db
-                )
-                if mint_quote:
-                    await self._send_obj(PostMintQuoteResponse.from_mint_quote(mint_quote).model_dump(), subId)
-        elif kind == JSONRPCSubscriptionKinds.BOLT11_MELT_QUOTE:
-            for filter in filters:
-                melt_quote = await self.db_read.crud.get_melt_quote(
-                    quote_id=filter, db=self.db_read.db
-                )
-                if melt_quote:
-                    await self._send_obj(PostMeltQuoteResponse.from_melt_quote(melt_quote).model_dump(), subId)
-        elif kind == JSONRPCSubscriptionKinds.PROOF_STATE:
-            proofs = await self.db_read.get_proofs_states(Ys=filters)
-            for proof in proofs:
-                await self._send_obj(proof.model_dump(), subId)
+        async with self.db_read.db.connect() as conn:
+            if kind == JSONRPCSubscriptionKinds.BOLT11_MINT_QUOTE:
+                for filter in filters:
+                    mint_quote = await self.db_read.crud.get_mint_quote(
+                        quote_id=filter, db=self.db_read.db, conn=conn
+                    )
+                    if mint_quote:
+                        await self._send_obj(PostMintQuoteResponse.from_mint_quote(mint_quote).model_dump(), subId)
+            elif kind == JSONRPCSubscriptionKinds.BOLT11_MELT_QUOTE:
+                for filter in filters:
+                    melt_quote = await self.db_read.crud.get_melt_quote(
+                        quote_id=filter, db=self.db_read.db, conn=conn
+                    )
+                    if melt_quote:
+                        await self._send_obj(PostMeltQuoteResponse.from_melt_quote(melt_quote).model_dump(), subId)
+            elif kind == JSONRPCSubscriptionKinds.PROOF_STATE:
+                proofs = await self.db_read.get_proofs_states(Ys=filters, conn=conn)
+                for proof in proofs:
+                    await self._send_obj(proof.model_dump(), subId)

--- a/cashu/mint/events/client.py
+++ b/cashu/mint/events/client.py
@@ -187,8 +187,9 @@ class LedgerEventClientManager:
         for f in filters:
             logger.debug(f"Adding subscription {subId} for filter {f}")
             self.subscriptions[kind].setdefault(f, []).append(subId)
-            # Initialize the subscription
-            asyncio.create_task(self._init_subscription(subId, f, kind))
+            
+        # Initialize the subscriptions in batch
+        asyncio.create_task(self._init_subscriptions(subId, filters, kind))
 
     def remove_subscription(self, subId: str) -> None:
         for kind, sub_filters in self.subscriptions.items():
@@ -211,22 +212,24 @@ class LedgerEventClientManager:
             return_dict = event.model_dump(exclude_unset=True, exclude_none=True)
         return return_dict
 
-    async def _init_subscription(
-        self, subId: str, filter: str, kind: JSONRPCSubscriptionKinds
+    async def _init_subscriptions(
+        self, subId: str, filters: List[str], kind: JSONRPCSubscriptionKinds
     ):
         if kind == JSONRPCSubscriptionKinds.BOLT11_MINT_QUOTE:
-            mint_quote = await self.db_read.crud.get_mint_quote(
-                quote_id=filter, db=self.db_read.db
-            )
-            if mint_quote:
-                await self._send_obj(PostMintQuoteResponse.from_mint_quote(mint_quote).model_dump(), subId)
+            for filter in filters:
+                mint_quote = await self.db_read.crud.get_mint_quote(
+                    quote_id=filter, db=self.db_read.db
+                )
+                if mint_quote:
+                    await self._send_obj(PostMintQuoteResponse.from_mint_quote(mint_quote).model_dump(), subId)
         elif kind == JSONRPCSubscriptionKinds.BOLT11_MELT_QUOTE:
-            melt_quote = await self.db_read.crud.get_melt_quote(
-                quote_id=filter, db=self.db_read.db
-            )
-            if melt_quote:
-                await self._send_obj(PostMeltQuoteResponse.from_melt_quote(melt_quote).model_dump(), subId)
+            for filter in filters:
+                melt_quote = await self.db_read.crud.get_melt_quote(
+                    quote_id=filter, db=self.db_read.db
+                )
+                if melt_quote:
+                    await self._send_obj(PostMeltQuoteResponse.from_melt_quote(melt_quote).model_dump(), subId)
         elif kind == JSONRPCSubscriptionKinds.PROOF_STATE:
-            proofs = await self.db_read.get_proofs_states(Ys=[filter])
-            if len(proofs):
-                await self._send_obj(proofs[0].model_dump(), subId)
+            proofs = await self.db_read.get_proofs_states(Ys=filters)
+            for proof in proofs:
+                await self._send_obj(proof.model_dump(), subId)

--- a/tests/mint/test_mint_websocket_protocol.py
+++ b/tests/mint/test_mint_websocket_protocol.py
@@ -160,10 +160,16 @@ async def test_init_subscription_sends_initial_snapshots():
     )
     proof_state = ProofState(Y="Y1", state=ProofSpentState.unspent)
 
+    from contextlib import asynccontextmanager
+    
+    @asynccontextmanager
+    async def mock_connect():
+        yield object()
+
     manager.db_read = cast(
         Any,
         SimpleNamespace(
-            db=object(),
+            db=SimpleNamespace(connect=mock_connect),
             crud=SimpleNamespace(
                 get_mint_quote=None,
                 get_melt_quote=None,
@@ -172,13 +178,13 @@ async def test_init_subscription_sends_initial_snapshots():
         ),
     )
 
-    async def get_mint_quote(quote_id, db):
+    async def get_mint_quote(quote_id, db, conn=None):
         return mint_quote if quote_id == "quote-1" else None
 
-    async def get_melt_quote(quote_id, db):
+    async def get_melt_quote(quote_id, db, conn=None):
         return melt_quote if quote_id == "melt-1" else None
 
-    async def get_proofs_states(Ys):
+    async def get_proofs_states(Ys, conn=None):
         return [proof_state]
 
     cast(Any, manager.db_read).crud.get_mint_quote = get_mint_quote

--- a/tests/mint/test_mint_websocket_protocol.py
+++ b/tests/mint/test_mint_websocket_protocol.py
@@ -192,14 +192,14 @@ async def test_init_subscription_sends_initial_snapshots():
 
     cast(Any, manager)._send_obj = send_obj
 
-    await manager._init_subscription(
-        "sub-mint", "quote-1", JSONRPCSubscriptionKinds.BOLT11_MINT_QUOTE
+    await manager._init_subscriptions(
+        "sub-mint", ["quote-1"], JSONRPCSubscriptionKinds.BOLT11_MINT_QUOTE
     )
-    await manager._init_subscription(
-        "sub-melt", "melt-1", JSONRPCSubscriptionKinds.BOLT11_MELT_QUOTE
+    await manager._init_subscriptions(
+        "sub-melt", ["melt-1"], JSONRPCSubscriptionKinds.BOLT11_MELT_QUOTE
     )
-    await manager._init_subscription(
-        "sub-proof", "Y1", JSONRPCSubscriptionKinds.PROOF_STATE
+    await manager._init_subscriptions(
+        "sub-proof", ["Y1"], JSONRPCSubscriptionKinds.PROOF_STATE
     )
 
     payloads = [json.loads(msg) for msg in websocket.sent]


### PR DESCRIPTION
Fixes #902 

## Summary
- Optimized `LedgerEventClientManager` to initialize subscriptions in batches instead of individual tasks.
- This prevents database connection exhaustion when handling multiple subscription filters in a single request.
- Updated `tests/mint/test_mint_websocket_protocol.py` to reflect the new batch initialization logic.