### PR TITLE
fix: correct 'occured' to 'occurred' in docstring

### DIFF
--- a/cashu/lightning/lnd_grpc/protos/lightning_pb2_grpc.py
+++ b/cashu/lightning/lnd_grpc/protos/lightning_pb2_grpc.py
@@ -996,7 +996,7 @@ class LightningServicer(object):
         all HTLCs forwarded within the target time range, and integer offset
         within that time range, for a maximum number of events. If no maximum number
         of events is specified, up to 100 events will be returned. If no time-range
-        is specified, then events will be returned in the order that they occured.
+        is specified, then events will be returned in the order that they occurred.
 
         A list of forwarding events are returned. The size of each forwarding event
         is 40 bytes, and the max message size able to be returned in gRPC is 4 MiB.


### PR DESCRIPTION
## Summary

Fixed a spelling typo in the LND gRPC protobuf Python stub documentation: `occured` → `occurred`.