### PR TITLE
fix v3 Proof.Y hash-to-curve and BlindedSignature dleq=None

### DIFF
--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -282,7 +282,7 @@ class BlindedSignature(BaseModel):
         # Match the model's `dleq: Optional[DLEQ] = None` declaration and skip construction.
         dleq_e = row["dleq_e"]
         dleq_s = row["dleq_s"]
-        dleq = DLEQ(e=dleq_e, s=dleq_s) if dleq_e is not None and dleq_s is not None else None
+        dleq = DLEQ(e=dleq_e, s=dleq_s) if None not in (dleq_e, dleq_s) else None
         return cls(
             id=row["id"],
             amount=row["amount"],

--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -20,6 +20,7 @@ from ..mint.events.event_model import LedgerEvent
 from .crypto.aes import AESCipher
 from .crypto.b_dhke import hash_to_curve
 from .crypto.bls import PublicKey as BlsPublicKey
+from .crypto.bls_dhke import hash_to_curve as bls_hash_to_curve
 from .crypto.interfaces import PrivateKey, PublicKey
 from .crypto.keys import (
     derive_keys,
@@ -151,7 +152,13 @@ class Proof(BaseModel):
 
     def __init__(self, **data):
         super().__init__(**data)
-        self.Y = hash_to_curve(self.secret.encode("utf-8")).format().hex()
+        # v3 (BLS12-381) keysets compute Y on G1; v0/v1/v2 keep secp256k1 hash-to-curve.
+        # Y is used purely as a lookup index for proofs_used / checkstate / subscriptions,
+        # so the wallet must compute the same hex for the same (secret, keyset_version).
+        if self.id and self.id.startswith("02"):
+            self.Y = bls_hash_to_curve(self.secret.encode("utf-8")).format().hex()
+        else:
+            self.Y = hash_to_curve(self.secret.encode("utf-8")).format().hex()
 
     @classmethod
     def from_dict(cls, proof_dict: dict):
@@ -271,11 +278,16 @@ class BlindedSignature(BaseModel):
 
     @classmethod
     def from_row(cls, row: Row):
+        # v3 (BLS) promises store dleq_e / dleq_s as NULL because pairings replace DLEQ.
+        # Match the model's `dleq: Optional[DLEQ] = None` declaration and skip construction.
+        dleq_e = row["dleq_e"]
+        dleq_s = row["dleq_s"]
+        dleq = DLEQ(e=dleq_e, s=dleq_s) if dleq_e is not None and dleq_s is not None else None
         return cls(
             id=row["id"],
             amount=row["amount"],
             C_=row["c_"],
-            dleq=DLEQ(e=row["dleq_e"], s=row["dleq_s"]),
+            dleq=dleq,
         )
 
 

--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -20,6 +20,7 @@ from ..mint.events.event_model import LedgerEvent
 from .crypto.aes import AESCipher
 from .crypto.b_dhke import hash_to_curve
 from .crypto.bls import PublicKey as BlsPublicKey
+from .crypto.bls_dhke import hash_to_curve as bls_hash_to_curve
 from .crypto.interfaces import PrivateKey, PublicKey
 from .crypto.keys import (
     derive_keys,
@@ -151,7 +152,13 @@ class Proof(BaseModel):
 
     def __init__(self, **data):
         super().__init__(**data)
-        self.Y = hash_to_curve(self.secret.encode("utf-8")).format().hex()
+        # v3 (BLS12-381) keysets compute Y on G1; v0/v1/v2 keep secp256k1 hash-to-curve.
+        # Y is used purely as a lookup index for proofs_used / checkstate / subscriptions,
+        # so the wallet must compute the same hex for the same (secret, keyset_version).
+        if self.id and is_bls_keyset(self.id):
+            self.Y = bls_hash_to_curve(self.secret.encode("utf-8")).format().hex()
+        else:
+            self.Y = hash_to_curve(self.secret.encode("utf-8")).format().hex()
 
     @classmethod
     def from_dict(cls, proof_dict: dict):
@@ -271,11 +278,16 @@ class BlindedSignature(BaseModel):
 
     @classmethod
     def from_row(cls, row: Row):
+        # v3 (BLS) promises store dleq_e / dleq_s as NULL because pairings replace DLEQ.
+        # Match the model's `dleq: Optional[DLEQ] = None` declaration and skip construction.
+        dleq_e = row["dleq_e"]
+        dleq_s = row["dleq_s"]
+        dleq = DLEQ(e=dleq_e, s=dleq_s) if dleq_e is not None and dleq_s is not None else None
         return cls(
             id=row["id"],
             amount=row["amount"],
             C_=row["c_"],
-            dleq=DLEQ(e=row["dleq_e"], s=row["dleq_s"]),
+            dleq=dleq,
         )
 
 


### PR DESCRIPTION
## Stacked on #999 

This PR is a fix for BLS implementation PR #999.

## Summary

Two small but blocking gaps in the v3 (BLS12-381) wiring, both in `cashu/core/base.py`, surfaced while planning the BLS Cashu-TS implementation.

### 1. `Proof.Y` always uses secp256k1 hash-to-curve

`Proof.__init__` unconditionally calls `b_dhke.hash_to_curve` even for v3 (`02…`) keyset IDs. `Y` is the index used by `proofs_used`, `/v1/checkstate`, and websocket proof-state subscriptions; v3 wallets would presumably compute `Y` on G1, so lookups would not match: `checkstate` would always return `UNSPENT` for v3 proofs that were just spent, and websocket subscriptions never fire.

### 2. `BlindedSignature.from_row` crashes on v3 promises

`step2_bob` in `bls_dhke.py` returns `(C_, None, None)` as DLEQ proofs are redundant under pairings, so v3 promises are stored with NULL `dleq_e` / `dleq_s`. But `BlindedSignature.from_row` unconditionally constructs a `DLEQ(e=..., s=...)`, which Pydantic rejects since the model declares `e: str` / `s: str`.

Symptom: `POST /v1/restore` returns 500 against a v3 mint with `2 validation errors for DLEQ: Input should be a valid string [input_value=None]`.

Patch constructs the `DLEQ` only when both fields are non-null — matches the existing `dleq: Optional[DLEQ] = None` model declaration.

