### PR TITLE
fix(core): use cls instead of self in PostMeltResponse.from_melt_quote

### DIFF
--- a/cashu/core/models/melt_quote.py
+++ b/cashu/core/models/melt_quote.py
@@ -55,10 +55,10 @@ class PostMeltQuoteResponse(BaseModel):
     change: Union[List[BlindedSignature], None] = None  # NUT-08 change
 
     @classmethod
-    def from_melt_quote(self, melt_quote: MeltQuote) -> "PostMeltQuoteResponse":
+    def from_melt_quote(cls, melt_quote: MeltQuote) -> "PostMeltQuoteResponse":
         to_dict = melt_quote.model_dump()
         # turn state into string
         to_dict["state"] = melt_quote.state.value
         # add deprecated "paid" field
         to_dict["paid"] = melt_quote.paid
-        return PostMeltQuoteResponse.model_validate(to_dict)
+        return cls.model_validate(to_dict)


### PR DESCRIPTION
## Fixes #1006

## Summary

`PostMeltQuoteResponse.from_melt_quote` was decorated with `@classmethod` but had two bugs:

- The first parameter was named `self` instead of `cls`, inconsistent with Python classmethod conventions.
- The return statement hardcoded `PostMeltQuoteResponse.model_validate(to_dict)` instead of `cls.model_validate(to_dict)`, silently returning a `PostMeltQuoteResponse` instance even when called on a subclass.

## Changes

- Renamed first parameter from `self` to `cls`
- Replaced `PostMeltQuoteResponse.model_validate(to_dict)` with `cls.model_validate(to_dict)`

This now matches the existing pattern in `PostMintQuoteResponse.from_mint_quote` in `cashu/core/models/mint_quote.py`.