### PR TITLE
feat(crypto): deterministic DLEQ nonce derivation (NUT-12)

### DIFF
--- a/cashu/core/crypto/b_dhke.py
+++ b/cashu/core/crypto/b_dhke.py
@@ -160,8 +160,7 @@ def derive_dleq_nonce(
         r = x - SECP256K1_N if x >= SECP256K1_N else x
         if r != 0:
             return PrivateKey(r.to_bytes(32, "big"))
-    # Practically unreachable
-    raise ValueError("DLEQ nonce derivation failed")
+    raise ValueError("DLEQ nonce derivation failed")  # pragma: no cover
 
 
 def step2_bob_dleq(

--- a/cashu/core/crypto/b_dhke.py
+++ b/cashu/core/crypto/b_dhke.py
@@ -154,11 +154,11 @@ def derive_dleq_nonce(
     )
     for ctr in range(256):
         h = hmac.new(a.secret, base + bytes([ctr]), hashlib.sha256).digest()
-        x = int.from_bytes(h, "big")
-        # Rejection sampling: accept x only if it is a valid scalar in [1, n-1].
+        r = int.from_bytes(h, "big")
+        # Rejection sampling: accept r only if it is a valid scalar in [1, n-1].
         # Reducing mod n instead would bias the nonce toward small values.
-        if 0 < x < SECP256K1_N:
-            return PrivateKey(x.to_bytes(32, "big"))
+        if 0 < r < SECP256K1_N:
+            return PrivateKey(r.to_bytes(32, "big"))
     raise ValueError("DLEQ nonce derivation failed")  # pragma: no cover
 
 

--- a/cashu/core/crypto/b_dhke.py
+++ b/cashu/core/crypto/b_dhke.py
@@ -51,11 +51,17 @@ If true, a in A = a*G must be equal to a in C' = a*B'
 """
 
 import hashlib
+import hmac
 from typing import Optional, Tuple
 
 from .secp import PrivateKey, PublicKey
 
 DOMAIN_SEPARATOR = b"Secp256k1_HashToCurve_Cashu_"
+
+# Domain separation tag for deterministic DLEQ nonce derivation (NUT-12).
+DLEQ_NONCE_DST = b"Cashu_DLEQ_R_v1"
+# Order of the secp256k1 group.
+SECP256K1_N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
 
 
 def hash_to_curve(message: bytes) -> PublicKey:
@@ -125,22 +131,55 @@ def hash_e(*publickeys: PublicKey) -> bytes:
     return e
 
 
+def derive_dleq_nonce(
+    a: PrivateKey, A: PublicKey, B_: PublicKey, C_: PublicKey
+) -> PrivateKey:
+    """Derives the DLEQ nonce `r` deterministically from the private key and proof context.
+
+    Per NUT-12:
+        r = HMAC-SHA256(key=a, "Cashu_DLEQ_R_v1" || A || B' || C' || ctr) mod n
+
+    `a` is the 32-byte secp256k1 private key scalar (big-endian). `A`, `B_` and `C_`
+    are encoded as uncompressed SEC1 points (65 bytes each). `ctr` is a single byte
+    starting at 0x00, incremented if the reduced value is 0 (max 256 attempts).
+
+    This removes any dependency on RNG quality: reusing `r` across two proofs with
+    different challenges would leak the private key.
+    """
+    base = (
+        DLEQ_NONCE_DST
+        + A.format(compressed=False)
+        + B_.format(compressed=False)
+        + C_.format(compressed=False)
+    )
+    for ctr in range(256):
+        h = hmac.new(a.secret, base + bytes([ctr]), hashlib.sha256).digest()
+        x = int.from_bytes(h, "big")
+        # Reduce modulo the curve order. A single subtraction suffices: the HMAC
+        # output is 256 bits and SECP256K1_N is ~2^256, so x exceeds N at most once.
+        r = x - SECP256K1_N if x >= SECP256K1_N else x
+        if r != 0:
+            return PrivateKey(r.to_bytes(32, "big"))
+    # Practically unreachable
+    raise ValueError("DLEQ nonce derivation failed")
+
+
 def step2_bob_dleq(
     B_: PublicKey, a: PrivateKey, p_bytes: bytes = b""
 ) -> Tuple[PrivateKey, PrivateKey]:
+    C_: PublicKey = B_ * a  # type: ignore
+    A = a.public_key
+    assert A
     if p_bytes:
         # deterministic p for testing
         p = PrivateKey(p_bytes)
     else:
-        # normally, we generate a random p
-        p = PrivateKey()
+        # derive the nonce deterministically from the private key and proof context
+        p = derive_dleq_nonce(a, A, B_, C_)
 
     R1 = p.public_key  # R1 = pG
     assert R1
     R2: PublicKey = B_ * p  # type: ignore
-    C_: PublicKey = B_ * a  # type: ignore
-    A = a.public_key
-    assert A
     e = hash_e(R1, R2, A, C_)  # e = hash(R1, R2, A, C_)
     s = p.add(bytes.fromhex(a.multiply(e).to_hex()))  # s = p + ek
     spk = PrivateKey(bytes.fromhex(s.to_hex()))

--- a/cashu/core/crypto/b_dhke.py
+++ b/cashu/core/crypto/b_dhke.py
@@ -137,11 +137,11 @@ def derive_dleq_nonce(
     """Derives the DLEQ nonce `r` deterministically from the private key and proof context.
 
     Per NUT-12:
-        r = HMAC-SHA256(key=a, "Cashu_DLEQ_R_v1" || A || B' || C' || ctr) mod n
+        r = HMAC-SHA256(key=a, "Cashu_DLEQ_R_v1" || A || B' || C' || ctr)
 
     `a` is the 32-byte secp256k1 private key scalar (big-endian). `A`, `B_` and `C_`
     are encoded as uncompressed SEC1 points (65 bytes each). `ctr` is a single byte
-    starting at 0x00, incremented if the reduced value is 0 (max 256 attempts).
+    starting at 0x00, incremented if the reduced value is 0 or >= n (max 256 attempts).
 
     This removes any dependency on RNG quality: reusing `r` across two proofs with
     different challenges would leak the private key.
@@ -155,11 +155,10 @@ def derive_dleq_nonce(
     for ctr in range(256):
         h = hmac.new(a.secret, base + bytes([ctr]), hashlib.sha256).digest()
         x = int.from_bytes(h, "big")
-        # Reduce modulo the curve order. A single subtraction suffices: the HMAC
-        # output is 256 bits and SECP256K1_N is ~2^256, so x exceeds N at most once.
-        r = x - SECP256K1_N if x >= SECP256K1_N else x
-        if r != 0:
-            return PrivateKey(r.to_bytes(32, "big"))
+        # Rejection sampling: accept x only if it is a valid scalar in [1, n-1].
+        # Reducing mod n instead would bias the nonce toward small values.
+        if 0 < x < SECP256K1_N:
+            return PrivateKey(x.to_bytes(32, "big"))
     raise ValueError("DLEQ nonce derivation failed")  # pragma: no cover
 
 

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -2,6 +2,7 @@ from cashu.core.base import Proof
 from cashu.core.crypto.b_dhke import (
     alice_verify_dleq,
     carol_verify_dleq,
+    derive_dleq_nonce,
     hash_e,
     hash_to_curve,
     hash_to_curve_deprecated,
@@ -186,6 +187,82 @@ def test_dleq_step2_bob_dleq():
     assert (
         s.to_hex()
         == "b6d41ac1e12415862bf8cace95e5355e9262eab8a11d201dadd3b6e41584ea6e"
+    )
+
+
+def test_dleq_deterministic_nonce_spec_vector():
+    # NUT-12 deterministic DLEQ test vector (cashubtc/nuts#368). All values are
+    # fixed; the implementation MUST reproduce e and s exactly.
+    a = PrivateKey(
+        bytes.fromhex(
+            "0000000000000000000000000000000000000000000000000000000000000002"
+        )
+    )
+    B_ = PublicKey(
+        bytes.fromhex(
+            "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2"
+        )
+    )
+
+    A = a.public_key
+    assert A
+    C_: PublicKey = B_ * a  # type: ignore
+    assert (
+        A.format(compressed=True).hex()
+        == "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
+    )
+    assert (
+        C_.format(compressed=True).hex()
+        == "0244eccfc7a348274458bb38044c7f3c389b3c2086c7ec18b5812d2877ab937787"
+    )
+
+    e, s = step2_bob_dleq(B_, a)
+    assert (
+        e.to_hex()
+        == "2a16ffee280aff3c429045607f9b8e0bf8b35910c44c1b20b9dfaf01b263d7b3"
+    )
+    assert (
+        s.to_hex()
+        == "9df27731238334718d120d4f74611a7c668233f988e687ac3fb188f0a34a2dab"
+    )
+
+    # Verification (e == hash(R1, R2, A, C_)) MUST pass.
+    assert alice_verify_dleq(B_, C_, e, s, A)
+
+
+def test_dleq_deterministic_nonce_is_reproducible():
+    # Same key + same B_ must always yield the same (e, s).
+    B_, _ = step1_alice("test_message")
+    a = PrivateKey()
+    e1, s1 = step2_bob_dleq(B_, a)
+    e2, s2 = step2_bob_dleq(B_, a)
+    assert e1.to_hex() == e2.to_hex()
+    assert s1.to_hex() == s2.to_hex()
+
+
+def test_dleq_deterministic_nonce_varies_with_context():
+    a = PrivateKey()
+    other = PrivateKey()
+    B1, _ = step1_alice("message_one")
+    B2, _ = step1_alice("message_two")
+
+    A = a.public_key
+    assert A
+    C1: PublicKey = B1 * a  # type: ignore
+    C2: PublicKey = B2 * a  # type: ignore
+
+    # Different B_ -> different nonce.
+    assert (
+        derive_dleq_nonce(a, A, B1, C1).to_hex()
+        != derive_dleq_nonce(a, A, B2, C2).to_hex()
+    )
+    # Different private key -> different nonce for the same context.
+    other_A = other.public_key
+    assert other_A
+    other_C1: PublicKey = B1 * other  # type: ignore
+    assert (
+        derive_dleq_nonce(a, A, B1, C1).to_hex()
+        != derive_dleq_nonce(other, other_A, B1, other_C1).to_hex()
     )
 
 


### PR DESCRIPTION
Implements the deterministic nonce derivation from cashubtc/nuts#368.

## Summary

Derives the DLEQ nonce `r` deterministically from the mint's private key and the proof context, instead of sourcing it from the RNG:

```
r = HMAC-SHA256(key=a, "Cashu_DLEQ_R_v1" || A || B' || C' || ctr)
```

`a` is the 32-byte secp256k1 private key scalar (big-endian); `A`, `B'`, `C'` are uncompressed SEC1 points (65 bytes each); `ctr` is a single byte starting at `0x00`, incremented if the reduced value is `0` or >= n (max 256 attempts).

This removes the dependency on RNG quality. Reusing `r` across two proofs with different challenges leaks the private key immediately via `a = (s₁ - s₂)·(e₁ - e₂)⁻¹ mod n`.

## Changes

- **`cashu/core/crypto/b_dhke.py`** — new `derive_dleq_nonce(a, A, B_, C_)`. `step2_bob_dleq` computes `C_`/`A` first, then derives `p` deterministically. The `p_bytes` override is retained for existing test vectors.
- **`tests/test_crypto.py`** — adds the NUT-12 deterministic-nonce test vector (asserts every fixed value plus `e == hash(R1, R2, A, C_)` verification), reproducibility, and context-sensitivity tests.

## Notes

- `step2_bob` (used by the mint in `ledger.py`) now emits deterministic nonces for every signature. DLEQ verification is unaffected — `(e, s)` remain valid proofs. No on-disk format or API change.
- Cross-checked against the canonical cashu-ts NUT12 implementation; the Python output reproduces `e`, `s`, `A`, and `C_` from the spec vector exactly.

## Test plan

- `tests/test_crypto.py` — 19 passed, including the new NUT-12 vector and the two new determinism tests.
- `make check` (ruff + mypy) passes.