### PR TITLE
Avoid Postgres test fixture deadlocks

### DIFF
--- a/.github/workflows/regtest-mint.yml
+++ b/.github/workflows/regtest-mint.yml
@@ -61,6 +61,7 @@ jobs:
           # LndRestWallet
           MINT_LND_REST_ENDPOINT: https://localhost:8081/
           MINT_LND_REST_CERT: ./regtest/data/lnd-3/tls.cert
+          MINT_LND_REST_CERT_VERIFY: false
           MINT_LND_REST_MACAROON: ./regtest/data/lnd-3/data/chain/bitcoin/regtest/admin.macaroon
           # LndRPCWallet
           MINT_LND_RPC_ENDPOINT: localhost:10009
@@ -70,10 +71,12 @@ jobs:
           MINT_CORELIGHTNING_REST_URL: https://localhost:3001
           MINT_CORELIGHTNING_REST_MACAROON: ./regtest/data/clightning-2-rest/access.macaroon
           MINT_CORELIGHTNING_REST_CERT: ./regtest/data/clightning-2-rest/certificate.pem
+          MINT_CORELIGHTNING_REST_CERT_VERIFY: false
           # CLNRestWallet
           MINT_CLNREST_URL: https://localhost:3010
           MINT_CLNREST_RUNE: ./regtest/data/clightning-2/rune
           MINT_CLNREST_CERT: ./regtest/data/clightning-2/regtest/ca.pem
+          MINT_CLNREST_CERT_VERIFY: false
         run: |
           sudo chmod -R 777 .
           make test-mint

--- a/.github/workflows/regtest-wallet.yml
+++ b/.github/workflows/regtest-wallet.yml
@@ -61,6 +61,7 @@ jobs:
           # LndRestWallet
           MINT_LND_REST_ENDPOINT: https://localhost:8081/
           MINT_LND_REST_CERT: ./regtest/data/lnd-3/tls.cert
+          MINT_LND_REST_CERT_VERIFY: false
           MINT_LND_REST_MACAROON: ./regtest/data/lnd-3/data/chain/bitcoin/regtest/admin.macaroon
           # LndRPCWallet
           MINT_LND_RPC_ENDPOINT: localhost:10009
@@ -70,10 +71,12 @@ jobs:
           MINT_CORELIGHTNING_REST_URL: https://localhost:3001
           MINT_CORELIGHTNING_REST_MACAROON: ./regtest/data/clightning-2-rest/access.macaroon
           MINT_CORELIGHTNING_REST_CERT: ./regtest/data/clightning-2-rest/certificate.pem
+          MINT_CORELIGHTNING_REST_CERT_VERIFY: false
           # CLNRestWallet
           MINT_CLNREST_URL: https://localhost:3010
           MINT_CLNREST_RUNE: ./regtest/data/clightning-2/rune
           MINT_CLNREST_CERT: ./regtest/data/clightning-2/regtest/ca.pem
+          MINT_CLNREST_CERT_VERIFY: false
         run: |
           sudo chmod -R 777 .
           make test-wallet

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -315,6 +315,7 @@ class LndRPCFundingSource(MintSettings):
 class CLNRestFundingSource(MintSettings):
     mint_clnrest_url: Optional[str] = Field(default=None)
     mint_clnrest_cert: Optional[str] = Field(default=None)
+    mint_clnrest_cert_verify: bool = Field(default=True)
     mint_clnrest_rune: Optional[str] = Field(default=None)
     mint_clnrest_enable_mpp: bool = Field(default=True)
 
@@ -323,6 +324,7 @@ class CoreLightningRestFundingSource(MintSettings):
     mint_corelightning_rest_url: Optional[str] = Field(default=None)
     mint_corelightning_rest_macaroon: Optional[str] = Field(default=None)
     mint_corelightning_rest_cert: Optional[str] = Field(default=None)
+    mint_corelightning_rest_cert_verify: bool = Field(default=True)
 
 
 class AuthSettings(MintSettings):

--- a/cashu/lightning/clnrest.py
+++ b/cashu/lightning/clnrest.py
@@ -79,8 +79,9 @@ class CLNRestWallet(LightningBackend):
         }
 
         self.cert = settings.mint_clnrest_cert or False
+        verify = self.cert if settings.mint_clnrest_cert_verify else False
         self.client = httpx.AsyncClient(
-            base_url=self.url, verify=self.cert, headers=self.auth, timeout=None,
+            base_url=self.url, verify=verify, headers=self.auth, timeout=None,
         )
         self.last_pay_index = 0
 

--- a/cashu/lightning/corelightningrest.py
+++ b/cashu/lightning/corelightningrest.py
@@ -72,8 +72,9 @@ class CoreLightningRestWallet(LightningBackend):
         }
 
         self.cert = settings.mint_corelightning_rest_cert or False
+        verify = self.cert if settings.mint_corelightning_rest_cert_verify else False
         self.client = httpx.AsyncClient(
-            base_url=self.url, verify=self.cert, headers=self.auth
+            base_url=self.url, verify=verify, headers=self.auth
         )
         self.last_pay_index = 0
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,7 +84,8 @@ class UvicornServer(multiprocessing.Process):
 async def ledger():
     async def start_mint_init(ledger: Ledger) -> Ledger:
         await migrate_databases(ledger.db, migrations_mint)
-        await ledger.startup_ledger()
+        await ledger._startup_keysets()
+        await ledger._check_backends()
         return ledger
 
     if not settings.mint_database.startswith("postgres"):


### PR DESCRIPTION
While working on https://github.com/cashubtc/nutshell/pull/1008 , I found that some existing tests would hang locally.

This is a test-only change.

This PR avoids deadlocks in the function-scoped ledger test fixture when running the suite against Postgres. The fixture previously called ledger.startup_ledger(), which starts background tasks such as the regular maintenance loop and invoice listeners. In Postgres-backed test runs, those long-lived tasks could keep transactions open while the next test tried to reset the database with DROP SCHEMA public CASCADE, causing the suite to hang. With this PR, instead only the minimum needed functionality - no background task loops - will be started.

===

With postgres running, I run this `MINT_BACKEND_BOLT11_SAT=FakeWallet WALLET_NAME=test_wallet MINT_HOST=localhost MINT_PORT=3337 MINT_TEST_DATABASE=postgres://cashu:cashu@localhost:5432/cashu DEBUG_MINT_ONLY_DEPRECATED=false TOR=false poetry run pytest tests/mint/test_mint.py -vv -s`

Without this fix, it always hangs - usually on `tests/mint/test_mint.py::test_keysets`. With this fix, it never hangs