### PR TITLE
fix(mint): handle websocket disconnect frames cleanly

### DIFF
--- a/cashu/mint/events/client.py
+++ b/cashu/mint/events/client.py
@@ -51,6 +51,8 @@ class LedgerEventClientManager:
                 self.websocket.receive(),
                 timeout=settings.mint_websocket_read_timeout,
             )
+            if message.get("type") == "websocket.disconnect":
+                raise WebSocketDisconnect(code=message.get("code", 1000))
             message_text = message.get("text")
 
             # Check the rate limit

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -212,7 +212,7 @@ async def get_mint_quote(request: Request, quote: str) -> PostMintQuoteResponse:
 @router.websocket("/v1/ws", name="Websocket endpoint for subscriptions")
 async def websocket_endpoint(websocket: WebSocket):
     limit_websocket(websocket)
-    disconnected = False
+    client = None
     try:
         client = ledger.events.add_client(websocket, ledger.db, ledger.crud)
     except Exception as e:
@@ -225,13 +225,12 @@ async def websocket_endpoint(websocket: WebSocket):
         await client.start()
     except WebSocketDisconnect as e:
         logger.debug(f"Websocket disconnected: {e}")
-        disconnected = True
-        return
     except Exception as e:
         logger.debug(f"Exception: {e}")
-        ledger.events.remove_client(client)
     finally:
-        if not disconnected:
+        if client and client in ledger.events.clients:
+            ledger.events.remove_client(client)
+        if websocket.client_state.name != "DISCONNECTED":
             await asyncio.wait_for(websocket.close(), timeout=1)
 
 

--- a/tests/mint/test_mint_websocket_protocol.py
+++ b/tests/mint/test_mint_websocket_protocol.py
@@ -93,6 +93,18 @@ async def test_websocket_start_returns_jsonrpc_errors(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_websocket_start_exits_on_disconnect_message(monkeypatch):
+    websocket = FakeWebSocket([{"type": "websocket.disconnect", "code": 1012}])
+    manager = _client_manager(websocket)
+    monkeypatch.setattr("cashu.mint.events.client.limit_websocket", lambda ws: None)
+
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        await manager.start()
+
+    assert exc_info.value.code == 1012
+
+
+@pytest.mark.asyncio
 async def test_handle_request_subscribe_and_unsubscribe_roundtrip(monkeypatch):
     manager = _client_manager(FakeWebSocket())
     monkeypatch.setattr(


### PR DESCRIPTION
While reviewing and testing [`fix(websocket): support generic quote kinds`](https://github.com/cashubtc/nutshell/pull/1013), websocket integration tests passed but produced noisy teardown errors in the mint logs. This PR fixes the underlying disconnect handling 

**Root cause:** `LedgerEventClientManager.start()` treated a `websocket.disconnect` frame as “no text, keep looping” instead of exiting. On server shutdown (ASGI `1012`), the loop called `receive()` again, which raised `RuntimeError`, triggered a double-close, and logged `ERROR | Exception in ASGI application`.

 Motivation

While running websocket subscription tests for the generic quote kinds PR:

```bash
poetry run pytest tests/wallet/test_wallet_subscription.py -q
```

All tests passed (`3 passed`), but pytest teardown produced alarming mint logs:

Before (broken teardown)

```
TRACE | 127.0.0.1:45068 - ASGI [14] Receive {'type': 'websocket.disconnect', 'code': 1012}
DEBUG | cashu.mint.router:websocket_endpoint:231 | Exception: Cannot call "receive" once a disconnect message has been received.
TRACE | 127.0.0.1:45068 - ASGI [14] Send {'type': 'websocket.close', 'code': 1000, 'reason': ''}
TRACE | 127.0.0.1:45068 - ASGI [14] Raised exception
ERROR | Exception in ASGI application
INFO  | connection closed
```

The disconnect frame was received, but the receive loop ignored it and called `receive()` again.

After (clean teardown)

```
TRACE | 127.0.0.1:50118 - ASGI [8] Receive {'type': 'websocket.disconnect', 'code': 1012}
DEBUG | cashu.mint.router:websocket_endpoint:227 | Websocket disconnected:
TRACE | 127.0.0.1:50118 - ASGI [8] Completed
INFO  | connection closed
```

No exception, no double-close, no ASGI error.

 Changes

- **`cashu/mint/events/client.py`** — exit the receive loop when a `websocket.disconnect` frame is received (raise `WebSocketDisconnect` with the frame's code).
- **`cashu/mint/router.py`** — unify websocket endpoint cleanup:
  - always remove the client from the event manager in `finally`
  - only call `websocket.close()` if the socket is not already disconnected
- **`tests/mint/test_mint_websocket_protocol.py`** — add regression test for disconnect frame handling

