### PR TITLE
fix(lnbits): tolerate missing preimage in payment status response

### DIFF
--- a/cashu/lightning/lnbits.py
+++ b/cashu/lightning/lnbits.py
@@ -173,7 +173,7 @@ class LNbitsWallet(LightningBackend):
         return PaymentStatus(
             result=result,
             fee=Amount(unit=Unit.msat, amount=abs(data["details"]["fee"])),
-            preimage=data["preimage"],
+            preimage=data.get("preimage"),
         )
 
     async def get_payment_status(self, checking_id: str) -> PaymentStatus:


### PR DESCRIPTION
LNbits doesn't always include `preimage` in the payment status payload — notably for pending or failed payments, and for some backend configurations even on settled ones. Direct subscript access raises `KeyError` and breaks status polling. Use `.get()` so `preimage` falls through as `None`, which `PaymentStatus` already accepts.