### PR TITLE
fix(wallet): handle unpaid invoices in the CLI invoice command

### DIFF
--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -600,7 +600,8 @@ async def invoice(
                 flush=True,
             )
         if mint_supports_websockets:
-            while not paid:
+            ws_deadline = mint_quote.expiry or (time.time() + 5 * 60)  # wait for five minutes
+            while not paid and time.time() < ws_deadline:
                 await asyncio.sleep(0.1)
 
         # we still check manually every 10 seconds
@@ -648,10 +649,13 @@ async def invoice(
         subscription.close()
     except Exception:
         pass
-    print(" Invoice paid.")
 
-    print("")
-    await print_balance(ctx)
+    if paid:
+        print(" Invoice paid.")
+
+        print("")
+        await print_balance(ctx)
+
     return
 
 


### PR DESCRIPTION
## Fixes #1021

## Summary
- Added timeout to websocket wait loop using mint quote expiry, preventing indefinite hang when invoice is never paid
- Put "Invoice paid" output behind paid state check so it only prints when minting actually succeeded

## Testing
Tested by setting `fakewallet_brr=False` to disable auto invoice payment, then running `cashu invoice 99` and waiting ~10 minutes.
Console correctly output "Invoice is not paid yet, stopping check..." with no misleading "Invoice paid" message.