### PR TITLE
fix: use UUIDv7 for quote and subscription IDs

### DIFF
--- a/cashu/core/crypto/keys.py
+++ b/cashu/core/crypto/keys.py
@@ -1,6 +1,5 @@
 import base64
 import hashlib
-import os
 import secrets
 import time
 import uuid
@@ -188,8 +187,8 @@ def derive_keyset_id_deprecated(keys: Dict[int, PublicKey]):
     ).decode()[:12]
 
 
-def random_quote_id() -> str:
-    """Returns a random UUIDv7 quote ID."""
+def generate_uuid_v7() -> str:
+    """Returns a random UUIDv7 string."""
     timestamp_ms = time.time_ns() // 1_000_000
     rand_a = secrets.randbits(12)
     rand_b = secrets.randbits(62)
@@ -197,8 +196,3 @@ def random_quote_id() -> str:
         (timestamp_ms << 80) | (0x7 << 76) | (rand_a << 64) | (0b10 << 62) | rand_b
     )
     return str(uuid.UUID(int=uuid_int))
-
-
-def random_hash() -> str:
-    """Returns a base64-urlsafe encoded random hash."""
-    return base64.urlsafe_b64encode(os.urandom(30)).decode()

--- a/cashu/core/crypto/keys.py
+++ b/cashu/core/crypto/keys.py
@@ -1,6 +1,9 @@
 import base64
 import hashlib
 import os
+import secrets
+import time
+import uuid
 from typing import Dict, List, Optional
 
 from bip32 import BIP32
@@ -59,42 +62,44 @@ def derive_keyset_id(keys: Dict[int, PublicKey]):
 
 
 def derive_keyset_id_v2(
-    keys: Dict[int, PublicKey], 
-    unit: str, 
+    keys: Dict[int, PublicKey],
+    unit: str,
     final_expiry: Optional[int] = None,
     input_fee_ppk: int = 0,
 ) -> str:
     """
     Deterministic derivation keyset_id v2 from set of public keys (version 01).
-    
+
     Args:
         keys: Dictionary mapping amounts to public keys
         unit: The unit of the keyset
         final_expiry: Optional unix epoch timestamp for keyset expiration
-        
+
     Returns:
         Full 33-byte keyset ID (version byte + 32-byte hash) as hex string
     """
     # sort public keys by amount in ascending order
     sorted_keys = dict(sorted(keys.items()))
-    
+
     # concatenate all public keys to one byte array with fixed separator between keys
-    keyset_id_bytes = b",".join([f"{a}:{p.format().hex()}".encode("utf-8") for (a, p) in sorted_keys.items()])
-    
+    keyset_id_bytes = b",".join(
+        [f"{a}:{p.format().hex()}".encode("utf-8") for (a, p) in sorted_keys.items()]
+    )
+
     # add the lowercase unit string to the byte array (no separator necessary since we hash)
     keyset_id_bytes += f"|unit:{unit}".encode("utf-8")
 
     # add the input_fee_ppk if > 0
     if input_fee_ppk > 0:
         keyset_id_bytes += f"|input_fee_ppk:{input_fee_ppk}".encode("utf-8")
-    
+
     # only include final_expiry if provided (per spec discussion)
     if final_expiry is not None:
         keyset_id_bytes += f"|final_expiry:{final_expiry}".encode("utf-8")
-    
+
     # SHA256 hash the concatenated byte array
     hash_digest = hashlib.sha256(keyset_id_bytes).hexdigest()
-    
+
     # prefix with version byte 01
     return f"01{hash_digest}"
 
@@ -102,43 +107,43 @@ def derive_keyset_id_v2(
 def derive_keyset_short_id(keyset_id: str) -> str:
     """
     Derive the short keyset ID (8 bytes) from a full keyset ID.
-    
+
     Args:
         keyset_id: Full keyset ID (either version 00 or 01)
-        
+
     Returns:
         Short keyset ID (version byte + first 7 bytes of hash)
     """
     # For version 00, keep existing behavior (already short)
     if is_base64_keyset_id(keyset_id) or keyset_id.startswith("00"):
         return keyset_id
-    
+
     # For version 01, return first 16 chars (8 bytes in hex)
     if keyset_id.startswith("01"):
         return keyset_id[:16]
-    
+
     raise ValueError(f"Unsupported keyset version in ID: {keyset_id}")
 
 
 def is_base64_keyset_id(keyset_id: str) -> bool:
     """
     Check if a keyset ID is a legacy base64 format (pre-0.15.0).
-    
+
     Base64 keyset IDs:
     - Don't start with "00" or "01" version prefix
     - Are typically 12 characters long
     - Are valid base64 strings
-    
+
     Args:
         keyset_id: The keyset ID to check
-        
+
     Returns:
         True if the keyset ID is base64 format, False otherwise
     """
     # If it starts with a known version prefix, it's not base64
     if keyset_id.startswith("00") or keyset_id.startswith("01"):
         return False
-    
+
     # Try to decode as base64 to confirm
     try:
         base64.b64decode(keyset_id, validate=True)
@@ -150,7 +155,7 @@ def is_base64_keyset_id(keyset_id: str) -> bool:
 def get_keyset_id_version(keyset_id: str) -> str:
     """
     Extract the version from a keyset ID.
-    
+
     Returns:
         - "00" for version 0 (hex keyset IDs with 00 prefix)
         - "01" for version 1 (v2 keyset IDs with 01 prefix)
@@ -158,17 +163,17 @@ def get_keyset_id_version(keyset_id: str) -> str:
     """
     if len(keyset_id) < 2:
         raise ValueError("Invalid keyset ID: too short")
-    
+
     # Check if it's a legacy base64 keyset ID
     if is_base64_keyset_id(keyset_id):
         return "base64"
-    
+
     return keyset_id[:2]
 
 
 def is_keyset_id_v2(keyset_id: str) -> bool:
     """Check if a keyset ID is version 2 (starts with '01')."""
-    return get_keyset_id_version(keyset_id) == '01'
+    return get_keyset_id_version(keyset_id) == "01"
 
 
 def derive_keyset_id_deprecated(keys: Dict[int, PublicKey]):
@@ -181,6 +186,17 @@ def derive_keyset_id_deprecated(keys: Dict[int, PublicKey]):
     return base64.b64encode(
         hashlib.sha256((pubkeys_concat).encode("utf-8")).digest()
     ).decode()[:12]
+
+
+def random_quote_id() -> str:
+    """Returns a random UUIDv7 quote ID."""
+    timestamp_ms = time.time_ns() // 1_000_000
+    rand_a = secrets.randbits(12)
+    rand_b = secrets.randbits(62)
+    uuid_int = (
+        (timestamp_ms << 80) | (0x7 << 76) | (rand_a << 64) | (0b10 << 62) | rand_b
+    )
+    return str(uuid.UUID(int=uuid_int))
 
 
 def random_hash() -> str:

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -23,7 +23,7 @@ from ..core.crypto import b_dhke
 from ..core.crypto.aes import AESCipher
 from ..core.crypto.keys import (
     derive_pubkey,
-    random_hash,
+    random_quote_id,
 )
 from ..core.crypto.secp import PrivateKey, PublicKey
 from ..core.db import Connection, Database
@@ -360,7 +360,7 @@ class Ledger(
             expiry = invoice_obj.date + invoice_obj.expiry
 
         quote = MintQuote(
-            quote=random_hash(),
+            quote=random_quote_id(),
             method=method.name,
             request=request,
             checking_id=invoice_response.checking_id,
@@ -787,7 +787,7 @@ class Ledger(
             expiry = invoice_obj.date + invoice_obj.expiry
 
         quote = MeltQuote(
-            quote=random_hash(),
+            quote=random_quote_id(),
             method=method.name,
             request=request,
             checking_id=payment_quote.checking_id,

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -23,7 +23,7 @@ from ..core.crypto import b_dhke
 from ..core.crypto.aes import AESCipher
 from ..core.crypto.keys import (
     derive_pubkey,
-    random_quote_id,
+    generate_uuid_v7,
 )
 from ..core.crypto.secp import PrivateKey, PublicKey
 from ..core.db import Connection, Database
@@ -360,7 +360,7 @@ class Ledger(
             expiry = invoice_obj.date + invoice_obj.expiry
 
         quote = MintQuote(
-            quote=random_quote_id(),
+            quote=generate_uuid_v7(),
             method=method.name,
             request=request,
             checking_id=invoice_response.checking_id,
@@ -787,7 +787,7 @@ class Ledger(
             expiry = invoice_obj.date + invoice_obj.expiry
 
         quote = MeltQuote(
-            quote=random_quote_id(),
+            quote=generate_uuid_v7(),
             method=method.name,
             request=request,
             checking_id=payment_quote.checking_id,

--- a/cashu/wallet/subscriptions.py
+++ b/cashu/wallet/subscriptions.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 from loguru import logger
 from websocket._app import WebSocketApp
 
-from ..core.crypto.keys import random_hash
+from ..core.crypto.keys import generate_uuid_v7
 from ..core.json_rpc.base import (
     JSONRPCMethods,
     JSONRPCNotficationParams,
@@ -87,7 +87,7 @@ class SubscriptionManager:
         self, kind: JSONRPCSubscriptionKinds, filters: List[str], callback: Callable
     ):
         self.wait_until_connected()
-        subId = random_hash()
+        subId = generate_uuid_v7()
         req = JSONRPCRequest(
             method=JSONRPCMethods.SUBSCRIBE.value,
             params=JSONRPCSubscribeParams(

--- a/tests/wallet/test_wallet_auth.py
+++ b/tests/wallet/test_wallet_auth.py
@@ -7,7 +7,7 @@ import pytest
 import pytest_asyncio
 
 from cashu.core.base import Unit
-from cashu.core.crypto.keys import random_hash
+from cashu.core.crypto.keys import generate_uuid_v7
 from cashu.core.crypto.secp import PrivateKey
 from cashu.core.errors import (
     BlindAuthFailedError,
@@ -138,7 +138,7 @@ async def test_wallet_auth_mint_manually_invalid_cat(wallet: Wallet):
     assert len(auth_wallet.proofs) == 0
 
     # invalidate CAT in the database
-    auth_wallet.oidc_client.access_token = random_hash()
+    auth_wallet.oidc_client.access_token = generate_uuid_v7()
 
     # this is the code executed in auth_wallet.mint_blind_auth():
     clear_auth_token = auth_wallet.oidc_client.access_token
@@ -209,7 +209,7 @@ async def test_wallet_auth_invoice_invalid_bat(wallet: Wallet):
     # invalidate blind auth proofs
     for p in auth_wallet.proofs:
         await auth_wallet.db.execute(
-            f"UPDATE proofs SET secret = '{random_hash()}' WHERE secret = '{p.secret}'"
+            f"UPDATE proofs SET secret = '{generate_uuid_v7()}' WHERE secret = '{p.secret}'"
         )
 
     wallet.auth_db = auth_wallet.db

--- a/tests/wallet/test_wallet_subscription_unit.py
+++ b/tests/wallet/test_wallet_subscription_unit.py
@@ -42,7 +42,10 @@ def test_subscription_manager_builds_websocket_url(monkeypatch):
 
 def test_subscription_manager_subscribe_and_close(monkeypatch):
     monkeypatch.setattr("cashu.wallet.subscriptions.WebSocketApp", FakeWebSocketApp)
-    monkeypatch.setattr("cashu.wallet.subscriptions.random_hash", lambda: "sub-1")
+    monkeypatch.setattr(
+        "cashu.wallet.subscriptions.generate_uuid_v7",
+        lambda: "018f0f61-8c4d-7cc2-8f21-4a6b5f0b6a11",
+    )
     manager = SubscriptionManager("https://mint.test")
     monkeypatch.setattr(manager, "wait_until_connected", lambda: None)
 
@@ -53,11 +56,11 @@ def test_subscription_manager_subscribe_and_close(monkeypatch):
 
     manager.subscribe(JSONRPCSubscriptionKinds.BOLT11_MINT_QUOTE, ["quote-1"], callback)
     assert manager.id_counter == 1
-    assert "sub-1" in manager.callback_map
+    assert "018f0f61-8c4d-7cc2-8f21-4a6b5f0b6a11" in manager.callback_map
 
     sent = json.loads(cast(Any, manager).websocket.sent[0])
     assert sent["method"] == JSONRPCMethods.SUBSCRIBE.value
-    assert sent["params"]["subId"] == "sub-1"
+    assert sent["params"]["subId"] == "018f0f61-8c4d-7cc2-8f21-4a6b5f0b6a11"
 
     manager.close()
     unsubscribe_messages = [
@@ -65,7 +68,10 @@ def test_subscription_manager_subscribe_and_close(monkeypatch):
         for message in cast(Any, manager).websocket.sent[1:]
         if json.loads(message)["method"] == JSONRPCMethods.UNSUBSCRIBE.value
     ]
-    assert any(msg["params"]["subId"] == "sub-1" for msg in unsubscribe_messages)
+    assert any(
+        msg["params"]["subId"] == "018f0f61-8c4d-7cc2-8f21-4a6b5f0b6a11"
+        for msg in unsubscribe_messages
+    )
     assert cast(Any, manager).websocket.closed is True
 
 


### PR DESCRIPTION
Implements https://github.com/cashubtc/nuts/pull/383

## Summary
- use a shared `generate_uuid_v7()` helper for UUIDv7 generation
- switch mint quote IDs and melt quote IDs to UUIDv7
- switch websocket subscription IDs to UUIDv7
- remove the old quote-specific/random hash helper usage

## Testing
- poetry run pytest -q tests/test_quote_ids.py tests/wallet/test_wallet_subscription_unit.py tests/wallet/test_wallet.py::test_request_mint tests/wallet/test_wallet.py::test_mint tests/wallet/test_wallet.py::test_melt tests/wallet/test_wallet.py::test_get_melt_quote_state tests/test_mint_rpc_cli.py::test_get_mint_quote tests/test_mint_rpc_cli.py::test_get_melt_quote tests/test_mint_rpc_cli.py::test_get_quote_ttl_mint_quote tests/test_mint_rpc_cli.py::test_get_quote_ttl_melt_quote