### PR TITLE
fix(sparkl2): prevent description_hash from being used as payment_hash

### DIFF
--- a/cashu/lightning/sparkl2.py
+++ b/cashu/lightning/sparkl2.py
@@ -157,7 +157,7 @@ class SparkL2Wallet(LightningBackend):
                     description=(memo or "") if not description_hash else "",
                     amount_sats=amount_sats,
                     expiry_secs=None,
-                    payment_hash=description_hash.hex() if description_hash else None
+                    payment_hash=None
                 )
             )
             


### PR DESCRIPTION
Fixes the critical vulnerability described in [PR 300 on security-audits](https://github.com/cashubtc/security-audits/pull/300) where `SparkL2Wallet` mistakenly uses `description_hash` as `payment_hash` in Lightning Invoices.