### PR TITLE
fix(mint): use unit-aware conversion for melt fee_limit_msat

### DIFF
--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -1106,7 +1106,7 @@ class Ledger(
             logger.debug(f"Lightning: pay invoice {melt_quote.request}")
             try:
                 payment = await self.backends[method][unit].pay_invoice(
-                    melt_quote, melt_quote.fee_reserve * 1000
+                    melt_quote, Amount(unit, melt_quote.fee_reserve).to(Unit.msat).amount
                 )
                 logger.debug(
                     f"Melt – Result: {payment.result.name}: preimage: {payment.preimage},"

--- a/tests/mint/test_mint_melt.py
+++ b/tests/mint/test_mint_melt.py
@@ -858,3 +858,89 @@ async def test_melt_with_wrong_unit_proofs(ledger: Ledger, wallet: Wallet):
         ),
         "proof unit usd does not match quote unit sat"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not is_fake, reason="fake wallet only")
+async def test_melt_fee_limit_msat_off_by_thousand_for_msat_unit(
+    ledger: Ledger, wallet: Wallet
+):
+    """Regression for ledger.py:944-946 - the call
+    `self.backends[method][unit].pay_invoice(melt_quote, melt_quote.fee_reserve * 1000)`
+    hardcodes a sat -> msat conversion. For a melt quote with unit=msat
+    (a supported configuration via `mint_backend_bolt11_msat`)
+    `melt_quote.fee_reserve` is already in msat, so the `* 1000` makes
+    fee_limit_msat 1000x too high. The lightning backend will then
+    accept up to 1000x the lightning fees that the user actually
+    deposited into the mint as proofs.
+    """
+    import time
+    from typing import List
+    from unittest.mock import MagicMock
+
+    from cashu.core.base import (
+        Amount,
+        MeltQuote,
+        MeltQuoteState,
+        Method,
+        Unit,
+    )
+    from cashu.lightning.base import PaymentResponse, PaymentResult
+
+    # Mint sat ecash via the existing default sat backend / keyset.
+    mint_quote = await wallet.request_mint(64)
+    await ledger.get_mint_quote(mint_quote.quote)  # fakewallet marks paid
+    await wallet.mint(64, quote_id=mint_quote.quote)
+
+    # Stand up an msat backend that records the fee_limit_msat arg.
+    captured_fee_limit_msat: List[int] = []
+
+    async def mock_pay_invoice(quote, fee_limit_msat):
+        captured_fee_limit_msat.append(fee_limit_msat)
+        return PaymentResponse(
+            result=PaymentResult.SETTLED,
+            checking_id=quote.checking_id,
+            fee=Amount(Unit.msat, 5),
+            preimage="0" * 64,
+        )
+
+    msat_backend = MagicMock()
+    msat_backend.pay_invoice = mock_pay_invoice
+    msat_backend.supports_mpp = False
+    ledger.backends[Method.bolt11][Unit.msat] = msat_backend
+
+    # Repurpose the existing keysets as msat (private keys are unchanged so
+    # BDHKE verification of the proofs minted above still succeeds).
+    for keyset in ledger.keysets.values():
+        keyset.unit = Unit.msat
+
+    # Manually insert a melt quote in msat with a small msat fee_reserve.
+    msat_quote = MeltQuote(
+        quote="test_msat_melt_quote_regression",
+        method="bolt11",
+        request=(
+            "lnbcrt620n1pn0r3vepp5zljn7g09fsyeahl4rnhuy0xax2puhua5r3gspt7ttlfrley6va"
+            "lqdqqcqzzsxqyz5vqsp577h763sel3q06tfnfe75kvwn5pxn344sd5vnays65f9wfgx4fpz"
+            "q9qxpqysgqg3re9afz9rwwalytec04pdhf9mvh3e2k4r877tw7dr4g0fvzf9sny5nlfggdy"
+            "6nduy2dytn06w50ls34qfldgsj37x0ymxam0a687mspp0ytr8"
+        ),
+        checking_id="msat-ck-regression",
+        unit="msat",
+        amount=10,
+        fee_reserve=5,
+        state=MeltQuoteState.unpaid,
+        created_time=int(time.time()),
+    )
+    await ledger.crud.store_melt_quote(quote=msat_quote, db=ledger.db)
+
+    # Trigger the buggy call path.
+    await ledger.melt(proofs=wallet.proofs, quote=msat_quote.quote)
+
+    assert len(captured_fee_limit_msat) == 1
+    expected = Amount(Unit.msat, msat_quote.fee_reserve).to(Unit.msat).amount
+    assert captured_fee_limit_msat[0] == expected, (
+        f"ledger passes fee_limit_msat={captured_fee_limit_msat[0]} to pay_invoice "
+        f"but for unit=msat the correct value is {expected} "
+        f"(fee_reserve={msat_quote.fee_reserve} msat); the hardcoded "
+        f"`* 1000` at ledger.py:944-946 is wrong for non-sat units."
+    )

--- a/tests/mint/test_mint_melt.py
+++ b/tests/mint/test_mint_melt.py
@@ -1,9 +1,19 @@
+import time
 from typing import List, Tuple
+from unittest.mock import MagicMock
 
 import pytest
 import pytest_asyncio
 
-from cashu.core.base import MeltQuote, MeltQuoteState, MintQuoteState, Proof
+from cashu.core.base import (
+    Amount,
+    MeltQuote,
+    MeltQuoteState,
+    Method,
+    MintQuoteState,
+    Proof,
+    Unit,
+)
 from cashu.core.errors import (
     LightningPaymentFailedError,
     OutputsAlreadySignedError,
@@ -11,7 +21,7 @@ from cashu.core.errors import (
 )
 from cashu.core.models import PostMeltQuoteRequest, PostMintQuoteRequest
 from cashu.core.settings import settings
-from cashu.lightning.base import PaymentResult
+from cashu.lightning.base import PaymentResponse, PaymentResult
 from cashu.mint.ledger import Ledger
 from cashu.wallet.wallet import Wallet
 from tests.conftest import SERVER_ENDPOINT
@@ -874,18 +884,6 @@ async def test_melt_fee_limit_msat_off_by_thousand_for_msat_unit(
     accept up to 1000x the lightning fees that the user actually
     deposited into the mint as proofs.
     """
-    import time
-    from typing import List
-    from unittest.mock import MagicMock
-
-    from cashu.core.base import (
-        Amount,
-        MeltQuote,
-        MeltQuoteState,
-        Method,
-        Unit,
-    )
-    from cashu.lightning.base import PaymentResponse, PaymentResult
 
     # Mint sat ecash via the existing default sat backend / keyset.
     mint_quote = await wallet.request_mint(64)


### PR DESCRIPTION
Fixes https://github.com/project-loupe/audit-nutshell/issues/26

**Description**
In `Ledger.melt`, the lightning backend `pay_invoice` was previously called with `melt_quote.fee_reserve * 1000` as `fee_limit_msat`. This hardcoded `* 1000` multiplication incorrectly assumes that the `fee_reserve` is always in `sat`.

When the mint supports `unit == Unit.msat` (e.g., via `mint_backend_bolt11_msat`), `fee_reserve` is already in `msat`. In this case, `fee_reserve * 1000` produces a fee limit that is 1000x the value the wallet actually deposited as proofs. Backends that honor `fee_limit_msat` would then accept lightning routes whose fees are up to 1000x the user-provided reserve, potentially allowing an adversary to drain the mint by repeatedly routing self-payments through high-fee channels.

This PR replaces the hardcoded conversion with a unit-aware conversion: `Amount(unit, melt_quote.fee_reserve).to(Unit.msat).amount`.

**Testing**
A regression test (`test_melt_fee_limit_msat_off_by_thousand_for_msat_unit`) has been added. It stands up a mocked `msat` backend, monkey-patches existing keysets to declare `Unit.msat`, and asserts that the captured `fee_limit_msat` matches the expected unit-aware value rather than a 1000x inflated value.