### PR TITLE
fix(lightning): enforce max fee reserve on blink payment quotes

### DIFF
--- a/cashu/lightning/blink.py
+++ b/cashu/lightning/blink.py
@@ -592,11 +592,24 @@ class BlinkWallet(LightningBackend):
             math.ceil(amount_msat / 100 * BLINK_MAX_FEE_PERCENT / 1000) * 1000
         )
 
+        # The absolute maximum fee we are willing to accept from the probe.
+        # We must respect Blink's hardcoded minimums (10 sats or 0.5%) for small payments,
+        # but otherwise bound it by the mint's global fee_reserve.
         expected_reserve = fee_reserve(amount_msat)
-        capped_fees_response_msat = min(fees_response_msat, expected_reserve)
+        max_allowed_fee_msat = max(
+            expected_reserve,
+            fees_amount_msat,
+            MINIMUM_FEE_MSAT,
+        )
+
+        if fees_response_msat > max_allowed_fee_msat:
+            raise Exception(
+                f"Fee quote from Blink is unexpectedly high: "
+                f"{fees_response_msat} msat > allowed {max_allowed_fee_msat} msat"
+            )
 
         fees_msat: int = max(
-            capped_fees_response_msat,
+            fees_response_msat,
             max(
                 fees_amount_msat,
                 MINIMUM_FEE_MSAT,

--- a/cashu/lightning/blink.py
+++ b/cashu/lightning/blink.py
@@ -10,6 +10,7 @@ from bolt11 import (
 from loguru import logger
 
 from ..core.base import Amount, MeltQuote, Unit
+from ..core.helpers import fee_reserve
 from ..core.models import PostMeltQuoteRequest
 from ..core.settings import settings
 from .base import (
@@ -301,9 +302,7 @@ class BlinkWallet(LightningBackend):
             )
 
         transaction = (
-            resp.get("data", {})
-            .get("lnInvoicePaymentSend", {})
-            .get("transaction", {})
+            resp.get("data", {}).get("lnInvoicePaymentSend", {}).get("transaction", {})
         )
 
         checking_id = quote.request
@@ -480,10 +479,7 @@ class BlinkWallet(LightningBackend):
                 }
             }
             """,
-            "variables": {
-                "amount": 1,
-                "currency": "USD"
-            },
+            "variables": {"amount": 1, "currency": "USD"},
         }
         try:
             r = await self.client.post(
@@ -505,7 +501,9 @@ class BlinkWallet(LightningBackend):
         sats_per_usd = conversion.get("btcSatAmount")
 
         if not sats_per_usd or sats_per_usd == 0:
-            logger.error(f"Invalid conversion data from Blink: btcSatAmount={sats_per_usd}")
+            logger.error(
+                f"Invalid conversion data from Blink: btcSatAmount={sats_per_usd}"
+            )
             raise Exception("Invalid conversion data: btcSatAmount is missing or zero")
 
         return int(sats_per_usd)
@@ -582,8 +580,7 @@ class BlinkWallet(LightningBackend):
                 )
             else:
                 fees_response_msat = (
-                    int(resp.get("data", {}).get(response_key, {}).get("amount"))
-                    * 1000
+                    int(resp.get("data", {}).get(response_key, {}).get("amount")) * 1000
                 )
         except httpx.ReadTimeout:
             pass
@@ -595,8 +592,11 @@ class BlinkWallet(LightningBackend):
             math.ceil(amount_msat / 100 * BLINK_MAX_FEE_PERCENT / 1000) * 1000
         )
 
+        expected_reserve = fee_reserve(amount_msat)
+        capped_fees_response_msat = min(fees_response_msat, expected_reserve)
+
         fees_msat: int = max(
-            fees_response_msat,
+            capped_fees_response_msat,
             max(
                 fees_amount_msat,
                 MINIMUM_FEE_MSAT,


### PR DESCRIPTION
## Description

This PR fixes a potential vulnerability in the Blink lightning backend where the returned routing fee from the Blink API was blindly trusted without any maximum bounds. An attacker could exploit this by posing as a malicious node in the routing path and returning an extremely high fee during the probe. 

The fix enforces a max fee reserve by capping the backend's API fee probe with the mint's global `fee_reserve`. It ensures the backend never proposes a fee unbounded beyond the system limits or Blink's defined default minimums (`0.5%` or `10 sats`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified by successfully running `make check` and the Blink-specific test suite `pytest tests/mint/test_mint_lightning_blink.py`.