### PR TITLE
fix(mint): enforce auth for NUT-29 batch minting endpoint

### DIFF
--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -348,6 +348,7 @@ class AuthSettings(MintSettings):
         ["POST", "/v1/swap"],
         ["POST", "/v1/mint/quote/bolt11"],
         ["POST", "/v1/mint/bolt11"],
+        ["POST", "/v1/mint/bolt11/batch"],
         ["POST", "/v1/melt/bolt11"],
     ]
 

--- a/tests/mint/test_mint_auth_middleware.py
+++ b/tests/mint/test_mint_auth_middleware.py
@@ -178,3 +178,34 @@ async def test_blind_auth_middleware_wraps_protected_paths(monkeypatch):
     )
     assert entered["value"] is True
     assert response.status_code == 200
+
+
+def test_mint_require_blind_auth_paths_includes_batch_mint():
+    from cashu.core.mint_info import MintInfo
+    from cashu.core.nuts.nuts import BLIND_AUTH_NUT
+
+    # Create dummy nuts configuration referencing the settings list
+    nuts = {
+        BLIND_AUTH_NUT: {
+            "protected_endpoints": [
+                {"method": e[0], "path": e[1]}
+                for e in settings.mint_require_blind_auth_paths
+            ]
+        }
+    }
+    mint_info = MintInfo(
+        name="test",
+        pubkey="pubkey",
+        version="version",
+        description="description",
+        description_long="description_long",
+        contact=[],
+        nuts=nuts,
+        icon_url=None,
+        urls=None,
+        tos_url=None,
+        motd=None,
+        time=None,
+    )
+
+    assert mint_info.requires_blind_auth_path("POST", "/v1/mint/bolt11/batch")


### PR DESCRIPTION
Enforce blind authentication for the NUT-29 batch minting endpoint (`/v1/mint/bolt11/batch`) when `settings.mint_require_auth` is enabled.