### PR TITLE
fix(mint): enforce validation and length limits on NUT-29 batch requests

### DIFF
--- a/cashu/core/models/mint.py
+++ b/cashu/core/models/mint.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Annotated, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -22,7 +22,7 @@ class PostMintResponse(BaseModel):
 
 
 class PostMintBatchRequest(BaseModel):
-    quotes: List[str] = Field(..., max_length=settings.mint_max_request_length)
+    quotes: List[Annotated[str, Field(max_length=MAX_QUOTE_ID_LEN)]] = Field(..., max_length=settings.mint_max_request_length)
     quote_amounts: Optional[List[int]] = Field(default=None, max_length=settings.mint_max_request_length)
     outputs: List[BlindedMessage] = Field(
         ..., max_length=settings.mint_max_request_length

--- a/cashu/core/models/mint_quote.py
+++ b/cashu/core/models/mint_quote.py
@@ -1,9 +1,15 @@
-from typing import Optional
+from typing import Annotated, List, Optional
 
 from pydantic import BaseModel, Field
 
 from cashu.core.base import MintQuote
-from cashu.core.constants import MAX_INVOICE_DESC_LEN, MAX_PUBKEY_LEN, MAX_UNIT_LEN
+from cashu.core.constants import (
+    MAX_INVOICE_DESC_LEN,
+    MAX_PUBKEY_LEN,
+    MAX_QUOTE_ID_LEN,
+    MAX_UNIT_LEN,
+)
+from cashu.core.settings import settings
 
 
 class PostMintQuoteRequest(BaseModel):
@@ -18,7 +24,9 @@ class PostMintQuoteRequest(BaseModel):
 
 
 class PostMintQuoteCheckRequest(BaseModel):
-    quotes: list[str]
+    quotes: List[Annotated[str, Field(max_length=MAX_QUOTE_ID_LEN)]] = Field(
+        ..., max_length=settings.mint_max_request_length
+    )
 
 
 class PostMintQuoteResponse(BaseModel):

--- a/tests/mint/test_mint_batch.py
+++ b/tests/mint/test_mint_batch.py
@@ -253,3 +253,41 @@ async def test_ledger_mint_batch_and_normal_mint_race(ledger: Ledger, wallet: Wa
 
     assert len(successes) == 1, f"Expected 1 success, got {len(successes)}"
     assert len(exceptions) == 1, f"Expected 1 exception, got {len(exceptions)}"
+
+
+def test_mint_batch_and_check_validation():
+    from pydantic import ValidationError
+
+    from cashu.core.constants import MAX_QUOTE_ID_LEN
+
+    # 1. Check PostMintBatchRequest with too long quote ID
+    long_quote = "a" * (MAX_QUOTE_ID_LEN + 1)
+    with pytest.raises(ValidationError) as excinfo:
+        PostMintBatchRequest(
+            quotes=[long_quote],
+            outputs=[],
+        )
+    assert "at most" in str(excinfo.value) or "max_length" in str(excinfo.value)
+
+    # 2. Check PostMintBatchRequest with too many quotes
+    too_many_quotes = ["a"] * (settings.mint_max_request_length + 1)
+    with pytest.raises(ValidationError) as excinfo:
+        PostMintBatchRequest(
+            quotes=too_many_quotes,
+            outputs=[],
+        )
+    assert "at most" in str(excinfo.value) or "max_length" in str(excinfo.value)
+
+    # 3. Check PostMintQuoteCheckRequest with too long quote ID
+    with pytest.raises(ValidationError) as excinfo:
+        PostMintQuoteCheckRequest(
+            quotes=[long_quote],
+        )
+    assert "at most" in str(excinfo.value) or "max_length" in str(excinfo.value)
+
+    # 4. Check PostMintQuoteCheckRequest with too many quotes
+    with pytest.raises(ValidationError) as excinfo:
+        PostMintQuoteCheckRequest(
+            quotes=too_many_quotes,
+        )
+    assert "at most" in str(excinfo.value) or "max_length" in str(excinfo.value)


### PR DESCRIPTION
Enforces length and size constraints for the list of quotes inside the NUT-29 payload, as well as validating individual quote string ID length bounds.