### PR TITLE
fix(mint): round up fee_paid on pending melt quote resolution

### DIFF
--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -859,10 +859,6 @@ class Ledger(
                 logger.debug(f"Setting quote {quote_id} as paid")
                 melt_quote.state = MeltQuoteState.paid
                 if status.fee:
-                    # Round up so that the fee paid is never under-counted.
-                    # This must match the direct melt() path (round="up"); otherwise
-                    # the change returned to the wallet would exceed the fee actually
-                    # overpaid, leaking value from the mint.
                     melt_quote.fee_paid = status.fee.to(unit, round="up").amount
                 if status.preimage:
                     melt_quote.payment_preimage = status.preimage

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -859,7 +859,11 @@ class Ledger(
                 logger.debug(f"Setting quote {quote_id} as paid")
                 melt_quote.state = MeltQuoteState.paid
                 if status.fee:
-                    melt_quote.fee_paid = status.fee.to(unit).amount
+                    # Round up so that the fee paid is never under-counted.
+                    # This must match the direct melt() path (round="up"); otherwise
+                    # the change returned to the wallet would exceed the fee actually
+                    # overpaid, leaking value from the mint.
+                    melt_quote.fee_paid = status.fee.to(unit, round="up").amount
                 if status.preimage:
                     melt_quote.payment_preimage = status.preimage
                 melt_quote.paid_time = int(time.time())


### PR DESCRIPTION
This PR fixes a slow value leakage vulnerability where the pending-resolution path for melt quotes floored the paid Lightning fee. Under-counting the actual external spend when sizing the NUT-08 change meant the mint over-refunded up to ~1 sat in change. This aligns the pending-resolution path with the direct melt path, which correctly uses ceiling rounding (`round="up"`).