### PR TITLE
chore(docker): restrict redis port binding to localhost

### DIFF
--- a/docker/redis/docker-compose.yml
+++ b/docker/redis/docker-compose.yml
@@ -5,5 +5,5 @@ services:
     image: redis:latest
     container_name: redis
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     restart: always


### PR DESCRIPTION
This PR restricts the Redis port binding in docker-compose to `127.0.0.1` instead of `0.0.0.0` (all interfaces). 

This fixes a security vulnerability where unauthenticated Redis cache servers running in Docker were exposed to public internet probes, while still keeping them fully accessible to local/host-based processes and other Docker containers on the same network.