### PR TITLE
fix(mint): remove all subscription filters upon unsubscribe

### DIFF
--- a/cashu/mint/events/client.py
+++ b/cashu/mint/events/client.py
@@ -194,16 +194,17 @@ class LedgerEventClientManager:
         asyncio.create_task(self._init_subscriptions(subId, filters, kind))
 
     def remove_subscription(self, subId: str) -> None:
+        removed = False
         for kind, sub_filters in self.subscriptions.items():
             for filter, subs in sub_filters.items():
-                for sub in subs:
-                    if sub == subId:
-                        logger.debug(
-                            f"Removing subscription {subId} for filter {filter}"
-                        )
-                        self.subscriptions[kind][filter].remove(sub)
-                        return
-        raise ValueError(f"Subscription not found: {subId}")
+                while subId in subs:
+                    logger.debug(
+                        f"Removing subscription {subId} for filter {filter}"
+                    )
+                    subs.remove(subId)
+                    removed = True
+        if not removed:
+            raise ValueError(f"Subscription not found: {subId}")
 
     def serialize_event(self, event: LedgerEvent) -> dict:
         if isinstance(event, MintQuote):

--- a/tests/mint/test_mint_websocket_protocol.py
+++ b/tests/mint/test_mint_websocket_protocol.py
@@ -282,3 +282,33 @@ async def test_event_manager_rejects_unsupported_events():
     manager = LedgerEventManager()
     with pytest.raises(ValueError, match="Unsupported event object type"):
         await manager.submit(cast(Any, object()))
+
+
+def test_remove_subscription_removes_all_filter_entries_for_subid(monkeypatch):
+    """Regression test for `remove_subscription` early-return bug.
+
+    NUT-17 lets a wallet subscribe to multiple filters in one subscribe
+    request, with a single `subId`. The unsubscribe command carries
+    only that `subId`, so `remove_subscription` must remove the
+    `subId` from every filter list it was registered against. The
+    current implementation returns after the first match, leaving
+    stranded `subId` entries for every other filter -- the client
+    keeps receiving notifications it already unsubscribed from, and
+    the server accumulates one stranded subscription per filter per
+    subscribe/unsubscribe cycle.
+    """
+    manager = _client_manager(FakeWebSocket())
+    monkeypatch.setattr(
+        "cashu.mint.events.client.asyncio.create_task",
+        lambda coro: (coro.close(), None)[1],
+    )
+    manager.add_subscription(
+        JSONRPCSubscriptionKinds.BOLT11_MINT_QUOTE,
+        ["quote-1", "quote-2", "quote-3"],
+        "sub-X",
+    )
+    manager.remove_subscription("sub-X")
+    kind_map = manager.subscriptions[JSONRPCSubscriptionKinds.BOLT11_MINT_QUOTE]
+    assert kind_map["quote-1"] == []
+    assert kind_map["quote-2"] == []
+    assert kind_map["quote-3"] == []


### PR DESCRIPTION
Unsubscribe command carries only a subId, so remove_subscription must remove the subId from every filter list it was registered against instead of returning after the first match.