### PR TITLE
fix(wallet): gracefully handle and filter out unsupported keyset versions

### DIFF
--- a/cashu/core/crypto/keys.py
+++ b/cashu/core/crypto/keys.py
@@ -170,6 +170,27 @@ def get_keyset_id_version(keyset_id: str) -> str:
     return keyset_id[:2]
 
 
+def is_supported_keyset_version(keyset_id: str) -> bool:
+    """
+    Check if the keyset ID's version is supported by this wallet.
+    Supported versions:
+    - "base64" (pre-0.15.0 legacy keysets)
+    - "00" (legacy keysets)
+    - "01" (v2 keysets)
+    """
+    try:
+        version = get_keyset_id_version(keyset_id)
+        if version == "base64":
+            return True
+        # If the version prefix is not a 2-hex-digit string, it represents a legacy keyset ID.
+        is_hex_version = len(version) == 2 and all(c in "0123456789abcdefABCDEF" for c in version)
+        if not is_hex_version:
+            return True
+        return version in ("00", "01")
+    except Exception:
+        return False
+
+
 def is_keyset_id_v2(keyset_id: str) -> bool:
     """Check if a keyset ID is version 2 (starts with '01')."""
     return get_keyset_id_version(keyset_id) == "01"

--- a/cashu/wallet/v1_api.py
+++ b/cashu/wallet/v1_api.py
@@ -19,6 +19,7 @@ from ..core.base import (
     Unit,
     WalletKeyset,
 )
+from ..core.crypto.keys import is_supported_keyset_version
 from ..core.crypto.secp import PublicKey
 from ..core.db import Database
 from ..core.models import (
@@ -244,18 +245,24 @@ class LedgerAPI(SupportsAuth):
         keys = KeysResponse.model_validate(keys_dict)
         keysets_str = " ".join([f"{k.id} ({k.unit})" for k in keys.keysets])
         logger.debug(f"Received {len(keys.keysets)} keysets from mint: {keysets_str}.")
-        ret = [
-            WalletKeyset(
-                id=keyset.id,
-                unit=keyset.unit,
-                public_keys={
-                    int(amt): PublicKey(bytes.fromhex(val))
-                    for amt, val in keyset.keys.items()
-                },
-                mint_url=self.url,
-            )
-            for keyset in keys.keysets
-        ]
+        ret = []
+        for keyset in keys.keysets:
+            if not is_supported_keyset_version(keyset.id):
+                logger.warning(f"Skipping unsupported keyset version in _get_keys: {keyset.id}")
+                continue
+            try:
+                ret.append(WalletKeyset(
+                    id=keyset.id,
+                    unit=keyset.unit,
+                    public_keys={
+                        int(amt): PublicKey(bytes.fromhex(val))
+                        for amt, val in keyset.keys.items()
+                    },
+                    mint_url=self.url,
+                ))
+            except Exception as exc:
+                logger.error(f"Failed to parse keyset {keyset.id}: {exc}")
+                continue
         return ret
 
     @async_set_httpx_client
@@ -272,6 +279,9 @@ class LedgerAPI(SupportsAuth):
         Raises:
             Exception: If no keys are received from the mint
         """
+        if not is_supported_keyset_version(keyset_id):
+            raise ValueError(f"Unsupported keyset version: {keyset_id}")
+
         keyset_id_urlsafe = keyset_id.replace("+", "-").replace("/", "_")
         resp = await self._request(GET, f"keys/{keyset_id_urlsafe}")
 
@@ -311,7 +321,15 @@ class LedgerAPI(SupportsAuth):
         keysets = KeysetsResponse.model_validate(keysets_dict).keysets
         if not keysets:
             raise Exception("did not receive any keysets")
-        return keysets
+
+        # Gracefully filter out unsupported keyset versions
+        supported_keysets = []
+        for keyset in keysets:
+            if is_supported_keyset_version(keyset.id):
+                supported_keysets.append(keyset)
+            else:
+                logger.warning(f"Ignoring unsupported keyset version: {keyset.id}")
+        return supported_keysets
 
     @async_set_httpx_client
     async def _get_info(self) -> GetInfoResponse:

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -22,6 +22,7 @@ from ..core.base import (
     WalletMint,
 )
 from ..core.crypto import b_dhke
+from ..core.crypto.keys import is_supported_keyset_version
 from ..core.crypto.secp import PrivateKey, PublicKey
 from ..core.db import Database
 from ..core.errors import KeysetNotFoundError
@@ -313,6 +314,8 @@ class Wallet(
 
         # get all new keysets that are not in memory yet and store them in the database
         for mint_keyset in mint_keysets_dict.values():
+            if not is_supported_keyset_version(mint_keyset.id):
+                continue
             if mint_keyset.id not in keysets_in_db_dict:
                 logger.debug(
                     f"Storing new mint keyset: {mint_keyset.id} ({mint_keyset.unit})"
@@ -323,6 +326,8 @@ class Wallet(
                 await store_keyset(keyset=wallet_keyset, db=self.db)
 
         for mint_keyset in mint_keysets_dict.values():
+            if not is_supported_keyset_version(mint_keyset.id):
+                continue
             # if the active flag changes from active to inactive
             # or the fee attributes have changed, update them in the database
             if mint_keyset.id in keysets_in_db_dict:

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -479,6 +479,12 @@ class Wallet(
         Returns:
             MintQuote: Mint Quote
         """
+        active_keysets = [k for k in self.keysets.values() if k.active]
+        if not active_keysets:
+            raise KeysetNotFoundError(
+                f"Cannot request mint quote: no active keysets found for unit {self.unit.name} (or they are unsupported by this wallet)."
+            )
+
         # generate a key for signing the quote request
         privkey_hex, pubkey_hex = nut20.generate_keypair()
         mint_quote = await super().mint_quote(amount, self.unit, memo, pubkey_hex)
@@ -515,6 +521,12 @@ class Wallet(
         Returns:
             MintQuote: Mint Quote
         """
+        active_keysets = [k for k in self.keysets.values() if k.active]
+        if not active_keysets:
+            raise KeysetNotFoundError(
+                f"Cannot request mint quote: no active keysets found for unit {self.unit.name} (or they are unsupported by this wallet)."
+            )
+
         # generate a key for signing the quote request
         privkey_hex, pubkey_hex = nut20.generate_keypair()
 

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -481,6 +481,13 @@ class Wallet(
         """
         active_keysets = [k for k in self.keysets.values() if k.active]
         if not active_keysets:
+            try:
+                await self.load_mint()
+                active_keysets = [k for k in self.keysets.values() if k.active]
+            except Exception as e:
+                logger.error(f"Could not load mint keysets: {e}")
+
+        if not active_keysets:
             raise KeysetNotFoundError(
                 f"Cannot request mint quote: no active keysets found for unit {self.unit.name} (or they are unsupported by this wallet)."
             )
@@ -522,6 +529,13 @@ class Wallet(
             MintQuote: Mint Quote
         """
         active_keysets = [k for k in self.keysets.values() if k.active]
+        if not active_keysets:
+            try:
+                await self.load_mint()
+                active_keysets = [k for k in self.keysets.values() if k.active]
+            except Exception as e:
+                logger.error(f"Could not load mint keysets: {e}")
+
         if not active_keysets:
             raise KeysetNotFoundError(
                 f"Cannot request mint quote: no active keysets found for unit {self.unit.name} (or they are unsupported by this wallet)."

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -599,3 +599,11 @@ async def test_raise_on_unsupported_version_non_404(wallet1: Wallet):
 
     # should not raise
     wallet1.raise_on_unsupported_version(resp, "GET /v1/keys")
+
+
+@pytest.mark.asyncio
+async def test_request_mint_raises_no_active_keysets(wallet1: Wallet):
+    wallet1.keysets = {}
+    with pytest.raises(KeysetNotFoundError) as excinfo:
+        await wallet1.request_mint(64)
+    assert "no active keysets found" in str(excinfo.value)

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -610,6 +610,7 @@ async def test_request_mint_raises_no_active_keysets(wallet1: Wallet):
 
     wallet1.load_mint = mock_load_mint  # type: ignore
 
+    # Verify KeysetNotFoundError is raised when no active keysets are available
     with pytest.raises(KeysetNotFoundError) as excinfo:
         await wallet1.request_mint(64)
     assert "no active keysets found" in str(excinfo.value)

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -604,6 +604,12 @@ async def test_raise_on_unsupported_version_non_404(wallet1: Wallet):
 @pytest.mark.asyncio
 async def test_request_mint_raises_no_active_keysets(wallet1: Wallet):
     wallet1.keysets = {}
+
+    async def mock_load_mint(*args, **kwargs):
+        pass
+
+    wallet1.load_mint = mock_load_mint  # type: ignore
+
     with pytest.raises(KeysetNotFoundError) as excinfo:
         await wallet1.request_mint(64)
     assert "no active keysets found" in str(excinfo.value)

--- a/tests/wallet/test_wallet_v1_api.py
+++ b/tests/wallet/test_wallet_v1_api.py
@@ -561,3 +561,53 @@ async def test_melt_quote_get_melt_quote_and_melt(monkeypatch, api: LedgerAPI):
         "C",
         "witness",
     }
+
+
+@pytest.mark.asyncio
+async def test_get_keysets_and_get_keys_filters_unsupported_versions(monkeypatch, api: LedgerAPI):
+    async def fake_request(self, method, path, **kwargs):
+        if path == "keysets":
+            return _response(
+                200,
+                {
+                    "keysets": [
+                        {"id": "01abcd", "unit": "sat", "active": True},
+                        {"id": "02efgh", "unit": "sat", "active": True},  # Unsupported
+                        {"id": "00ijkl", "unit": "sat", "active": True},
+                    ]
+                },
+            )
+        if path == "keys":
+            pubkey_hex = PrivateKey().public_key.format().hex()
+            return _response(
+                200,
+                {
+                    "keysets": [
+                        {
+                            "id": "01abcd",
+                            "unit": "sat",
+                            "active": True,
+                            "keys": {"1": pubkey_hex},
+                        },
+                        {
+                            "id": "02efgh",  # Unsupported
+                            "unit": "sat",
+                            "active": True,
+                            "keys": {"1": "invalid-hex-unsupported"},
+                        },
+                    ]
+                },
+            )
+        raise AssertionError(f"Unexpected path {path}")
+
+    monkeypatch.setattr(api, "_request", MethodType(fake_request, api))
+
+    # Test _get_keysets filters out 02efgh
+    keysets = await api._get_keysets()
+    assert len(keysets) == 2
+    assert [k.id for k in keysets] == ["01abcd", "00ijkl"]
+
+    # Test _get_keys filters out 02efgh
+    wallet_keysets = await api._get_keys()
+    assert len(wallet_keysets) == 1
+    assert wallet_keysets[0].id == "01abcd"


### PR DESCRIPTION
### Summary
This PR enhances the wallet to gracefully handle, filter out, and reject unsupported keyset versions during keyset synchronization instead of crashing.

### Changes
1. **Centralized Keyset Version Check ()**: Added to  to identify supported versions (`base64`, `00`, `01`).
2. **Graceful Keyset Synchronization Filtering**:
   -  and  in  skip/filter out any unsupported keysets.
   -  in  skips storing and updating unsupported keysets.
3. **Mint Quote Keyset Safety Check**: Added active keyset verification checks to  and  in . If there are no active supported keysets found for the selected mint and unit, the wallet throws .
4. **Unit Tests**: Added robust coverage for all new checks inside  and .