### PR TITLE
fix(lightning): migrate LND backends to SendPaymentV2 (SendPaymentSync removed in lnd 0.21)

### DIFF
--- a/cashu/lightning/lnd_grpc/lnd_grpc.py
+++ b/cashu/lightning/lnd_grpc/lnd_grpc.py
@@ -211,9 +211,12 @@ class LndRPCWallet(LightningBackend):
                         ),
                     )
         except AioRpcError as e:
+            # transport/RPC error: we don't know whether the payment was
+            # attempted, so report UNKNOWN (never FAILED) and let the ledger
+            # re-check the real state with TrackPaymentV2.
             error_message = f"SendPaymentV2 failed: {e}"
             return PaymentResponse(
-                result=PaymentResult.FAILED,
+                result=PaymentResult.UNKNOWN,
                 error_message=error_message,
             )
 

--- a/cashu/lightning/lnd_grpc/lnd_grpc.py
+++ b/cashu/lightning/lnd_grpc/lnd_grpc.py
@@ -47,6 +47,7 @@ INVOICE_RESULT_MAP = {
 }
 
 MAX_ROUTE_RETRIES = 50
+PAYMENT_TIMEOUT_SECONDS = 60
 
 
 class LndRPCWallet(LightningBackend):
@@ -168,42 +169,59 @@ class LndRPCWallet(LightningBackend):
                     quote, quote_amount, fee_limit_msat
                 )
 
-        # set the fee limit for the payment
-        feelimit = lnrpc.FeeLimit(fixed_msat=fee_limit_msat)
-        r = None
+        # pay the invoice with routerrpc.SendPaymentV2, a streaming RPC that
+        # sends payment updates until a terminal status is reached. The
+        # previously used lnrpc.SendPaymentSync was removed in lnd v0.21.0.
+        request = routerrpc.SendPaymentRequest(
+            payment_request=quote.request,
+            fee_limit_msat=fee_limit_msat,
+            timeout_seconds=PAYMENT_TIMEOUT_SECONDS,
+            no_inflight_updates=True,
+        )
         try:
             async with grpc.aio.secure_channel(
                 self.endpoint, self.combined_creds
             ) as channel:
-                lnstub = lightningstub.LightningStub(channel)
-                r = await lnstub.SendPaymentSync(
-                    lnrpc.SendRequest(
-                        payment_request=quote.request,
-                        fee_limit=feelimit,
+                router_stub = routerstub.RouterStub(channel)
+                async for payment in router_stub.SendPaymentV2(request):
+                    result = PAYMENT_RESULT_MAP.get(
+                        payment.status, PaymentResult.UNKNOWN
                     )
-                )
+                    if result == PaymentResult.PENDING:
+                        # non-terminal in-flight update, wait for the next one
+                        continue
+
+                    if result == PaymentResult.SETTLED:
+                        return PaymentResponse(
+                            result=PaymentResult.SETTLED,
+                            checking_id=payment.payment_hash,
+                            fee=(
+                                Amount(unit=Unit.msat, amount=payment.fee_msat)
+                                if payment.fee_msat
+                                else None
+                            ),
+                            preimage=payment.payment_preimage,
+                            error_message=None,
+                        )
+
+                    return PaymentResponse(
+                        result=result,
+                        error_message=lnrpc.PaymentFailureReason.Name(
+                            payment.failure_reason
+                        ),
+                    )
         except AioRpcError as e:
-            error_message = f"SendPaymentSync failed: {e}"
+            error_message = f"SendPaymentV2 failed: {e}"
             return PaymentResponse(
                 result=PaymentResult.FAILED,
                 error_message=error_message,
             )
 
-        if r.payment_error:
-            return PaymentResponse(
-                result=PaymentResult.FAILED,
-                error_message=r.payment_error,
-            )
-
-        checking_id = r.payment_hash.hex()
-        fee_msat = r.payment_route.total_fees_msat
-        preimage = r.payment_preimage.hex()
+        # stream ended without a terminal status, get_payment_status will
+        # check the payment state with TrackPaymentV2
         return PaymentResponse(
-            result=PaymentResult.SETTLED,
-            checking_id=checking_id,
-            fee=Amount(unit=Unit.msat, amount=fee_msat) if fee_msat else None,
-            preimage=preimage,
-            error_message=None,
+            result=PaymentResult.UNKNOWN,
+            error_message="SendPaymentV2 stream ended without a terminal payment status",
         )
 
     async def pay_partial_invoice(

--- a/cashu/lightning/lndrest.py
+++ b/cashu/lightning/lndrest.py
@@ -221,18 +221,25 @@ class LndRestWallet(LightningBackend):
                 except json.JSONDecodeError:
                     continue
 
-                # streaming errors from the REST proxy
+                # streaming errors from the REST proxy: the stream errored
+                # after the request was accepted (e.g. gRPC AlreadyExists when
+                # the payment is already in flight). We don't know whether the
+                # payment is live, so report UNKNOWN (never FAILED) and let the
+                # ledger re-check the real state with TrackPaymentV2.
                 if line.get("error"):
                     error = line["error"]
                     message = (
                         error["message"] if "message" in error else str(error)
                     )
                     return PaymentResponse(
-                        result=PaymentResult.FAILED, error_message=message
+                        result=PaymentResult.UNKNOWN, error_message=message
                     )
 
-                # immediate (non-streaming) errors from the REST proxy,
-                # e.g. {"code": 5, "message": "Not Found", "details": []}
+                # immediate (non-streaming) errors from the REST proxy reject
+                # the request before any payment is initiated, e.g.
+                # {"code": 5, "message": "Not Found", "details": []} when the
+                # route is unavailable. No payment was created, so this is an
+                # explicit FAILED.
                 if line.get("message") and "result" not in line:
                     return PaymentResponse(
                         result=PaymentResult.FAILED, error_message=line["message"]

--- a/cashu/lightning/lndrest.py
+++ b/cashu/lightning/lndrest.py
@@ -43,6 +43,7 @@ INVOICE_RESULT_MAP = {
 
 MAX_ROUTE_RETRIES = 50
 TEMPORARY_CHANNEL_FAILURE_ERROR = "TEMPORARY_CHANNEL_FAILURE"
+PAYMENT_TIMEOUT_SECONDS = 60
 
 
 class LndRestWallet(LightningBackend):
@@ -200,31 +201,75 @@ class LndRestWallet(LightningBackend):
                     quote, quote_amount, fee_limit_msat
                 )
 
-        # set the fee limit for the payment
-        lnrpcFeeLimit = dict()
-        lnrpcFeeLimit["fixed_msat"] = f"{fee_limit_msat}"
+        # pay the invoice with routerrpc.SendPaymentV2 (POST /v2/router/send),
+        # a streaming endpoint that sends payment updates until a terminal
+        # status is reached. The previously used lnrpc.SendPaymentSync
+        # (POST /v1/channels/transactions) was removed in lnd v0.21.0.
+        data = {
+            "payment_request": quote.request,
+            "fee_limit_msat": str(fee_limit_msat),
+            "timeout_seconds": PAYMENT_TIMEOUT_SECONDS,
+            "no_inflight_updates": True,
+        }
 
-        r = await self.client.post(
-            url="/v1/channels/transactions",
-            json={"payment_request": quote.request, "fee_limit": lnrpcFeeLimit},
-            timeout=None,
-        )
+        async with self.client.stream(
+            "POST", "/v2/router/send", json=data, timeout=None
+        ) as r:
+            async for json_line in r.aiter_lines():
+                try:
+                    line = json.loads(json_line)
+                except json.JSONDecodeError:
+                    continue
 
-        if r.is_error or r.json().get("payment_error"):
-            error_message = r.json().get("payment_error") or r.text
-            return PaymentResponse(
-                result=PaymentResult.FAILED, error_message=error_message
-            )
+                # streaming errors from the REST proxy
+                if line.get("error"):
+                    error = line["error"]
+                    message = (
+                        error["message"] if "message" in error else str(error)
+                    )
+                    return PaymentResponse(
+                        result=PaymentResult.FAILED, error_message=message
+                    )
 
-        data = r.json()
-        checking_id = base64.b64decode(data["payment_hash"]).hex()
-        fee_msat = int(data["payment_route"]["total_fees_msat"])
-        preimage = base64.b64decode(data["payment_preimage"]).hex()
+                # immediate (non-streaming) errors from the REST proxy,
+                # e.g. {"code": 5, "message": "Not Found", "details": []}
+                if line.get("message") and "result" not in line:
+                    return PaymentResponse(
+                        result=PaymentResult.FAILED, error_message=line["message"]
+                    )
+
+                payment = line.get("result")
+                if payment is None or not payment.get("status"):
+                    continue
+
+                result = PAYMENT_RESULT_MAP.get(
+                    payment["status"], PaymentResult.UNKNOWN
+                )
+                if result == PaymentResult.PENDING:
+                    # non-terminal in-flight update, wait for the next one
+                    continue
+
+                if result == PaymentResult.SETTLED:
+                    fee_msat = int(payment.get("fee_msat") or 0)
+                    return PaymentResponse(
+                        result=PaymentResult.SETTLED,
+                        checking_id=payment.get("payment_hash"),
+                        fee=Amount(unit=Unit.msat, amount=fee_msat)
+                        if fee_msat
+                        else None,
+                        preimage=payment.get("payment_preimage"),
+                    )
+
+                return PaymentResponse(
+                    result=result,
+                    error_message=payment.get("failure_reason"),
+                )
+
+        # stream ended without a terminal status, get_payment_status will
+        # check the payment state with TrackPaymentV2
         return PaymentResponse(
-            result=PaymentResult.SETTLED,
-            checking_id=checking_id,
-            fee=Amount(unit=Unit.msat, amount=fee_msat) if fee_msat else None,
-            preimage=preimage,
+            result=PaymentResult.UNKNOWN,
+            error_message="SendPaymentV2 stream ended without a terminal payment status",
         )
 
     async def pay_partial_invoice(

--- a/tests/lightning/test_lightning_backends_mocked.py
+++ b/tests/lightning/test_lightning_backends_mocked.py
@@ -481,6 +481,37 @@ async def test_lndrest_pay_invoice_returns_failed_on_rest_proxy_error(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_lndrest_pay_invoice_unknown_on_stream_error(monkeypatch):
+    # a streaming error envelope (e.g. payment already in flight) arrives after
+    # the request was accepted, so the payment may be live: must be UNKNOWN, not
+    # FAILED, so the ledger re-checks the real state with TrackPaymentV2.
+    wallet = object.__new__(LndRestWallet)
+    wallet.unit = Unit.sat
+    wallet.supports_mpp = False
+
+    lines = [
+        json.dumps(
+            {"error": {"code": 6, "message": "invoice is already paid"}}
+        )
+    ]
+
+    class Client:
+        def stream(self, method, url, json=None, timeout=None):
+            return _StreamResponse(lines)
+
+    cast(Any, wallet).client = Client()
+    monkeypatch.setattr(
+        "cashu.lightning.lndrest.bolt11.decode",
+        lambda request: SimpleNamespace(amount_msat=1000),
+    )
+    result = await wallet.pay_invoice(
+        _quote("lnbc1fake", amount=1), fee_limit_msat=1000
+    )
+    assert result.result == PaymentResult.UNKNOWN
+    assert result.error_message == "invoice is already paid"
+
+
+@pytest.mark.asyncio
 async def test_lndrest_pay_invoice_unknown_on_empty_stream(monkeypatch):
     wallet = object.__new__(LndRestWallet)
     wallet.unit = Unit.sat

--- a/tests/lightning/test_lightning_backends_mocked.py
+++ b/tests/lightning/test_lightning_backends_mocked.py
@@ -383,14 +383,66 @@ async def test_lndrest_create_invoice_decodes_r_hash():
 
 
 @pytest.mark.asyncio
-async def test_lndrest_pay_invoice_returns_failed_on_payment_error(monkeypatch):
+async def test_lndrest_pay_invoice_settled_reads_stream_result(monkeypatch):
     wallet = object.__new__(LndRestWallet)
     wallet.unit = Unit.sat
     wallet.supports_mpp = False
 
+    lines = [
+        json.dumps(
+            {
+                "result": {
+                    "status": "SUCCEEDED",
+                    "payment_hash": "11" * 32,
+                    "fee_msat": "7",
+                    "payment_preimage": "ab" * 32,
+                }
+            }
+        )
+    ]
+
     class Client:
-        async def post(self, *args, **kwargs):
-            return _response(200, {"payment_error": "denied"})
+        def stream(self, method, url, json=None, timeout=None):
+            assert method == "POST"
+            assert url == "/v2/router/send"
+            assert json["payment_request"] == "lnbc1fake"
+            assert json["fee_limit_msat"] == "1000"
+            return _StreamResponse(lines)
+
+    cast(Any, wallet).client = Client()
+    monkeypatch.setattr(
+        "cashu.lightning.lndrest.bolt11.decode",
+        lambda request: SimpleNamespace(amount_msat=1000),
+    )
+    result = await wallet.pay_invoice(
+        _quote("lnbc1fake", amount=1), fee_limit_msat=1000
+    )
+    assert result.result == PaymentResult.SETTLED
+    assert result.checking_id == "11" * 32
+    assert result.fee == Amount(Unit.msat, 7)
+    assert result.preimage == "ab" * 32
+
+
+@pytest.mark.asyncio
+async def test_lndrest_pay_invoice_returns_failed_on_payment_failure(monkeypatch):
+    wallet = object.__new__(LndRestWallet)
+    wallet.unit = Unit.sat
+    wallet.supports_mpp = False
+
+    lines = [
+        json.dumps(
+            {
+                "result": {
+                    "status": "FAILED",
+                    "failure_reason": "FAILURE_REASON_NO_ROUTE",
+                }
+            }
+        )
+    ]
+
+    class Client:
+        def stream(self, method, url, json=None, timeout=None):
+            return _StreamResponse(lines)
 
     cast(Any, wallet).client = Client()
     monkeypatch.setattr(
@@ -401,7 +453,52 @@ async def test_lndrest_pay_invoice_returns_failed_on_payment_error(monkeypatch):
         _quote("lnbc1fake", amount=1), fee_limit_msat=1000
     )
     assert result.result == PaymentResult.FAILED
-    assert result.error_message == "denied"
+    assert result.error_message == "FAILURE_REASON_NO_ROUTE"
+
+
+@pytest.mark.asyncio
+async def test_lndrest_pay_invoice_returns_failed_on_rest_proxy_error(monkeypatch):
+    wallet = object.__new__(LndRestWallet)
+    wallet.unit = Unit.sat
+    wallet.supports_mpp = False
+
+    lines = [json.dumps({"code": 5, "message": "Not Found", "details": []})]
+
+    class Client:
+        def stream(self, method, url, json=None, timeout=None):
+            return _StreamResponse(lines)
+
+    cast(Any, wallet).client = Client()
+    monkeypatch.setattr(
+        "cashu.lightning.lndrest.bolt11.decode",
+        lambda request: SimpleNamespace(amount_msat=1000),
+    )
+    result = await wallet.pay_invoice(
+        _quote("lnbc1fake", amount=1), fee_limit_msat=1000
+    )
+    assert result.result == PaymentResult.FAILED
+    assert result.error_message == "Not Found"
+
+
+@pytest.mark.asyncio
+async def test_lndrest_pay_invoice_unknown_on_empty_stream(monkeypatch):
+    wallet = object.__new__(LndRestWallet)
+    wallet.unit = Unit.sat
+    wallet.supports_mpp = False
+
+    class Client:
+        def stream(self, method, url, json=None, timeout=None):
+            return _StreamResponse([])
+
+    cast(Any, wallet).client = Client()
+    monkeypatch.setattr(
+        "cashu.lightning.lndrest.bolt11.decode",
+        lambda request: SimpleNamespace(amount_msat=1000),
+    )
+    result = await wallet.pay_invoice(
+        _quote("lnbc1fake", amount=1), fee_limit_msat=1000
+    )
+    assert result.result == PaymentResult.UNKNOWN
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Fixes #1049

## Problem

LND **v0.21.0-beta** (released 2026-06-05) removed the long-deprecated payment RPCs, including `lnrpc.SendPaymentSync` and its REST route `POST /v1/channels/transactions` ([v0.21.0 release notes](https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.21.0.md)):

> Removed the deprecated payment RPCs [...] This also removes the corresponding REST routes `POST /v1/channels/transaction-stream`, `POST /v1/channels/transactions`, and `POST /v1/channels/transactions/route`.

Both Nutshell LND backends paid invoices via this removed RPC, so **every melt fails immediately** against an lnd 0.21 node. Reported by a mint operator (LND REST backend) whose node updated to lnd 0.21 — all melts fail in ~60 ms:

```
DEBUG | cashu.mint.ledger:melt:1111 | Melt – Result: FAILED: preimage: None, fee: None
DEBUG | cashu.mint.ledger:melt:1135 | Payment state is FAILED. Error: {"code":5,"message":"Not Found","details":[]}. Checking status for 3774be4f...
ERROR | cashu.lightning.lndrest:get_payment_status:384 | LND get_payment_status error: payment isn't initiated
ERROR | cashu.mint.app:catch_exceptions:99 | CashuError: Lightning payment failed: {"code":5,"message":"Not Found","details":[]}.
```

`{"code":5,"message":"Not Found"}` is the grpc-gateway body for a 404 on the now-unregistered route; the payment never reaches the payment engine, and the follow-up `TrackPaymentV2` status check correctly reports `payment isn't initiated`. Minting/receiving is unaffected (`POST /v1/invoices` still exists), which makes this look like a wallet-side or routing problem at first.

## Fix

Migrate `pay_invoice` in both backends to the streaming `routerrpc.SendPaymentV2` (available since lnd 0.10, so no minimum-version bump in practice):

- **lndrest**: `POST /v2/router/send` with `no_inflight_updates: true`, consuming the JSON-line stream until a terminal payment status, mirroring the existing `get_payment_status` (`TrackPaymentV2`) handling. Streaming `{"error": ...}` lines and immediate REST-proxy error bodies (`{"code": ..., "message": ...}`) map to `FAILED`; on `FAILED` the `failure_reason` (e.g. `FAILURE_REASON_NO_ROUTE`) is surfaced as the error message.
- **lnd_grpc**: `router_stub.SendPaymentV2(routerrpc.SendPaymentRequest(...))`, same terminal-status handling; `AioRpcError` maps to `FAILED` (matching the previous `SendPaymentSync` behavior).
- If the stream ends without a terminal status, `UNKNOWN` is returned so the ledger's existing status double-check (`get_payment_status` → `TrackPaymentV2`) resolves the payment state — the ledger already re-checks `FAILED`/`UNKNOWN` results before rolling back, so fund-safety semantics are unchanged.
- `timeout_seconds` is required by `SendPaymentV2`; set to 60s (same as the `lncli` default).

Not affected (already on non-removed endpoints): invoice creation (`AddInvoice`), `get_invoice_status`, `get_payment_status` (`TrackPaymentV2`), and the MPP path `pay_partial_invoice` (`SendToRouteV2`).

## Tests

- Updated the mocked lndrest `pay_invoice` test (previously mocked the removed `SendPaymentSync` response shape) and added cases for: settled stream result (fee/preimage/checking_id parsing), terminal `FAILED` with `failure_reason`, immediate REST-proxy error body (the exact lnd 0.21 failure mode), and an empty stream returning `UNKNOWN`.
- `pytest tests/lightning/` passes (31 tests), `ruff check` and `mypy --check-untyped-defs` clean on the changed files.

## Workaround for operators until release

Stay on LND v0.20.x. for now