### PR TITLE
fix(mint): resolve auth ledger schema, audience validation, and rate limit issues

### DIFF
--- a/cashu/mint/auth/migrations.py
+++ b/cashu/mint/auth/migrations.py
@@ -119,12 +119,6 @@ async def m002_add_balance_to_keysets_and_log_table(db: Database):
 async def m003_add_final_expiry_to_keysets(db: Database):
     """
     Add the final_expiry column to the auth keysets table for keysets v2 support.
-
-    The mint ledger migrations add this column in m031, and store_keyset() always
-    inserts it. The auth ledger uses its own database and migration set, so without
-    this migration storing the auth keyset fails at startup with
-    "table keysets has no column named final_expiry" and the mint aborts whenever
-    MINT_REQUIRE_AUTH is enabled.
     """
     async with db.connect() as conn:
         await conn.execute(

--- a/cashu/mint/auth/migrations.py
+++ b/cashu/mint/auth/migrations.py
@@ -114,3 +114,22 @@ async def m002_add_balance_to_keysets_and_log_table(db: Database):
                 ADD COLUMN fees_paid INTEGER NOT NULL DEFAULT 0
             """
         )
+
+
+async def m003_add_final_expiry_to_keysets(db: Database):
+    """
+    Add the final_expiry column to the auth keysets table for keysets v2 support.
+
+    The mint ledger migrations add this column in m031, and store_keyset() always
+    inserts it. The auth ledger uses its own database and migration set, so without
+    this migration storing the auth keyset fails at startup with
+    "table keysets has no column named final_expiry" and the mint aborts whenever
+    MINT_REQUIRE_AUTH is enabled.
+    """
+    async with db.connect() as conn:
+        await conn.execute(
+            f"""
+                ALTER TABLE {db.table_with_schema('keysets')}
+                ADD COLUMN final_expiry INTEGER NULL
+            """
+        )

--- a/cashu/mint/auth/server.py
+++ b/cashu/mint/auth/server.py
@@ -109,10 +109,19 @@ class AuthLedger(Ledger):
                 clear_auth_token,
                 signing_key.key,
                 algorithms=["RS256", "ES256"],
-                options={"verify_aud": False},
+                audience=settings.mint_auth_oicd_client_id,
                 issuer=self.issuer,
             )
             logger.trace(f"Decoded JWT: {decoded}")
+            # Bind the token to this mint's OIDC client. Keycloak puts the client
+            # id in `azp` (authorized party) for access tokens; reject tokens
+            # issued to a different client in the same realm.
+            azp = decoded.get("azp")
+            if azp is not None and azp != settings.mint_auth_oicd_client_id:
+                raise jwt.InvalidTokenError(
+                    f"token azp '{azp}' does not match mint client"
+                    f" '{settings.mint_auth_oicd_client_id}'"
+                )
         except jwt.ExpiredSignatureError as e:
             logger.error("Token has expired")
             raise e
@@ -167,7 +176,7 @@ class AuthLedger(Ledger):
 
         logger.info(f"User authenticated: {user.id}")
         try:
-            assert_limit(user.id)
+            assert_limit(user.id, settings.mint_auth_rate_limit_per_minute)
         except Exception:
             raise BlindAuthRateLimitExceededError()
 

--- a/tests/mint/test_mint_auth_server_unit.py
+++ b/tests/mint/test_mint_auth_server_unit.py
@@ -111,7 +111,7 @@ async def test_verify_clear_auth_maps_rate_limit_errors(monkeypatch):
 
     monkeypatch.setattr(ledger, "_get_user", get_user)
 
-    def fail_limit(identifier):
+    def fail_limit(identifier, *args, **kwargs):
         raise Exception("too many requests")
 
     monkeypatch.setattr("cashu.mint.auth.server.assert_limit", fail_limit)
@@ -131,7 +131,7 @@ async def test_verify_clear_auth_returns_user_on_success(monkeypatch):
         return expected_user
 
     monkeypatch.setattr(ledger, "_get_user", get_user)
-    monkeypatch.setattr("cashu.mint.auth.server.assert_limit", lambda identifier: None)
+    monkeypatch.setattr("cashu.mint.auth.server.assert_limit", lambda identifier, *args, **kwargs: None)
 
     user = await ledger.verify_clear_auth("token")
     assert user is expected_user

--- a/tests/mint/test_mint_auth_server_unit.py
+++ b/tests/mint/test_mint_auth_server_unit.py
@@ -131,7 +131,9 @@ async def test_verify_clear_auth_returns_user_on_success(monkeypatch):
         return expected_user
 
     monkeypatch.setattr(ledger, "_get_user", get_user)
-    monkeypatch.setattr("cashu.mint.auth.server.assert_limit", lambda identifier, *args, **kwargs: None)
+    monkeypatch.setattr(
+        "cashu.mint.auth.server.assert_limit", lambda identifier, *args, **kwargs: None
+    )
 
     user = await ledger.verify_clear_auth("token")
     assert user is expected_user
@@ -243,3 +245,151 @@ async def test_verify_blind_auth_wraps_inner_failure_and_still_unsets_pending():
 
     assert calls["invalidated"] is False
     assert calls["unset"] is True
+
+
+def test_verify_decode_jwt_success(monkeypatch):
+    import jwt
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    from cashu.core.settings import settings
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+
+    ledger = _ledger()
+    ledger.issuer = "https://issuer.test"
+
+    class MockJWKSClient:
+        def get_signing_key_from_jwt(self, token):
+            class MockSigningKey:
+                def __init__(self, key):
+                    self.key = key
+
+            return MockSigningKey(public_key)
+
+    ledger.jwks_client = cast(Any, MockJWKSClient())
+
+    # Token with matching audience and matching azp
+    token = jwt.encode(
+        {
+            "iss": "https://issuer.test",
+            "aud": settings.mint_auth_oicd_client_id,
+            "azp": settings.mint_auth_oicd_client_id,
+            "sub": "alice",
+        },
+        private_key,
+        algorithm="RS256",
+    )
+
+    decoded = ledger._verify_decode_jwt(token)
+    assert decoded["sub"] == "alice"
+
+    # Token with matching audience and no azp
+    token_no_azp = jwt.encode(
+        {
+            "iss": "https://issuer.test",
+            "aud": settings.mint_auth_oicd_client_id,
+            "sub": "bob",
+        },
+        private_key,
+        algorithm="RS256",
+    )
+    decoded_no_azp = ledger._verify_decode_jwt(token_no_azp)
+    assert decoded_no_azp["sub"] == "bob"
+
+
+def test_verify_decode_jwt_rejects_mismatched_audience(monkeypatch):
+    import jwt
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+
+    ledger = _ledger()
+    ledger.issuer = "https://issuer.test"
+
+    class MockJWKSClient:
+        def get_signing_key_from_jwt(self, token):
+            class MockSigningKey:
+                def __init__(self, key):
+                    self.key = key
+
+            return MockSigningKey(public_key)
+
+    ledger.jwks_client = cast(Any, MockJWKSClient())
+
+    # Token with mismatched audience
+    token = jwt.encode(
+        {
+            "iss": "https://issuer.test",
+            "aud": "wrong-client",
+            "sub": "alice",
+        },
+        private_key,
+        algorithm="RS256",
+    )
+
+    with pytest.raises(jwt.InvalidTokenError):
+        ledger._verify_decode_jwt(token)
+
+
+def test_verify_decode_jwt_rejects_mismatched_azp(monkeypatch):
+    import jwt
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    from cashu.core.settings import settings
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+
+    ledger = _ledger()
+    ledger.issuer = "https://issuer.test"
+
+    class MockJWKSClient:
+        def get_signing_key_from_jwt(self, token):
+            class MockSigningKey:
+                def __init__(self, key):
+                    self.key = key
+
+            return MockSigningKey(public_key)
+
+    ledger.jwks_client = cast(Any, MockJWKSClient())
+
+    # Token with matching audience but mismatched azp
+    token = jwt.encode(
+        {
+            "iss": "https://issuer.test",
+            "aud": settings.mint_auth_oicd_client_id,
+            "azp": "wrong-client",
+            "sub": "alice",
+        },
+        private_key,
+        algorithm="RS256",
+    )
+
+    with pytest.raises(jwt.InvalidTokenError, match="does not match mint client"):
+        ledger._verify_decode_jwt(token)
+
+
+@pytest.mark.asyncio
+async def test_verify_clear_auth_uses_correct_rate_limit(monkeypatch):
+    ledger = _ledger()
+    monkeypatch.setattr(ledger, "_verify_oicd_issuer", lambda token: None)
+    monkeypatch.setattr(ledger, "_verify_decode_jwt", lambda token: {"sub": "alice"})
+
+    async def get_user(decoded):
+        return User(id="alice")
+
+    monkeypatch.setattr(ledger, "_get_user", get_user)
+
+    captured_limit = []
+
+    def mock_assert_limit(identifier, limit=None):
+        captured_limit.append(limit)
+
+    monkeypatch.setattr("cashu.mint.auth.server.assert_limit", mock_assert_limit)
+    monkeypatch.setattr(settings, "mint_auth_rate_limit_per_minute", 42)
+
+    await ledger.verify_clear_auth("token")
+    assert len(captured_limit) == 1
+    assert captured_limit[0] == 42

--- a/tests/mint/test_mint_migrations.py
+++ b/tests/mint/test_mint_migrations.py
@@ -72,3 +72,47 @@ async def test_m029_witness_cleanup():
             f"SELECT witness FROM {db.table_with_schema('proofs_pending')} WHERE secret = 's_pend_short'"
         )
         assert row["witness"] == short_witness
+
+
+@pytest.mark.asyncio
+async def test_auth_m003_migration():
+    import os
+    import shutil
+
+    from cashu.core.base import MintKeyset
+    from cashu.mint.auth import migrations as auth_migrations
+    from cashu.mint.crud import LedgerCrudSqlite
+
+    db_path = "./test_data/mig_auth"
+    if os.path.exists(db_path):
+        shutil.rmtree(db_path)
+    db = Database("auth", db_path)
+
+    # Migrate auth database to latest
+    await migrate_databases(db, auth_migrations)
+
+    # Verify that keysets table now has the final_expiry column
+    async with db.connect() as conn:
+        columns = await conn.fetchall(
+            f"PRAGMA table_info({db.table_with_schema('keysets')})"
+        )
+        assert any(col["name"] == "final_expiry" for col in columns)
+
+    # Verify that we can successfully store a keyset (which uses the final_expiry column)
+    crud = LedgerCrudSqlite()
+    keyset = MintKeyset(
+        seed="test_seed",
+        derivation_path="m/0'/0'/0'",
+        version="0.15.0",
+        final_expiry=123456789,
+    )
+    await crud.store_keyset(db=db, keyset=keyset)
+
+    # Verify that the keyset was stored and final_expiry value is set correctly
+    retrieved = await crud.get_keyset(db=db, id=keyset.id)
+    assert len(retrieved) == 1
+    assert retrieved[0].final_expiry == 123456789
+
+    # Clean up
+    if os.path.exists(db_path):
+        shutil.rmtree(db_path)


### PR DESCRIPTION
This PR addresses multiple auth ledger security issues and schema bugs identified in security audits:

1. **Missing `final_expiry` Migration**: Added migration `m003_add_final_expiry_to_keysets` in `cashu/mint/auth/migrations.py` to prevent auth-enabled mints from failing at startup when attempting to persist the auth keyset into the database.
2. **Audience/Client Binding Not Verified**: Updated `verify_clear_auth` in `cashu/mint/auth/server.py` to enforce the configured client ID scope (`mint_auth_oicd_client_id`) on the `aud` and `azp` JWT claims, resolving potential cross-client authorization bypasses.
3. **Ignored Auth Rate Limit**: Configured the per-user auth throttle check to correctly consume `settings.mint_auth_rate_limit_per_minute` instead of defaulting to the transaction rate limit.