### PR TITLE
feat(crypto): align NUT-20/29 signatures with spec change

### DIFF
--- a/cashu/core/nuts/nut20.py
+++ b/cashu/core/nuts/nut20.py
@@ -14,10 +14,22 @@ def generate_keypair() -> tuple[str, str]:
     return privkey.to_hex(), pubkey.format().hex()
 
 
+def int_to_minimal_bytes(val: int) -> bytes:
+    if val == 0:
+        return b""
+    return val.to_bytes((val.bit_length() + 7) // 8, "big")
+
+
 def construct_message(quote_id: str, outputs: List[BlindedMessage]) -> bytes:
-    serialized_outputs = b"".join([o.B_.encode("utf-8") for o in outputs])
-    msgbytes = sha256(quote_id.encode("utf-8") + serialized_outputs).digest()
-    return msgbytes
+    dst = b"Cashu_MintQuoteSig_v1"
+    quote_bytes = quote_id.encode("utf-8")
+    msg = dst + len(quote_bytes).to_bytes(4, "big") + quote_bytes
+    for o in outputs:
+        amount_bytes = int_to_minimal_bytes(o.amount)
+        b_bytes = bytes.fromhex(o.B_)
+        msg += len(amount_bytes).to_bytes(4, "big") + amount_bytes
+        msg += len(b_bytes).to_bytes(4, "big") + b_bytes
+    return sha256(msg).digest()
 
 
 def sign_mint_quote(
@@ -25,11 +37,16 @@ def sign_mint_quote(
     outputs: List[BlindedMessage],
     private_key: str,
 ) -> str:
-
     privkey = PrivateKey(bytes.fromhex(private_key))
     msgbytes = construct_message(quote_id, outputs)
     sig = privkey.sign_schnorr(msgbytes)
     return sig.hex()
+
+
+def construct_message_legacy(quote_id: str, outputs: List[BlindedMessage]) -> bytes:
+    serialized_outputs = b"".join([o.B_.encode("utf-8") for o in outputs])
+    msgbytes = sha256(quote_id.encode("utf-8") + serialized_outputs).digest()
+    return msgbytes
 
 
 def verify_mint_quote(
@@ -39,6 +56,19 @@ def verify_mint_quote(
     signature: str,
 ) -> bool:
     pubkey = PublicKeyXOnly(bytes.fromhex(public_key)[1:])
-    msgbytes = construct_message(quote_id, outputs)
     sig = bytes.fromhex(signature)
-    return pubkey.verify(sig, msgbytes)
+
+    # Try verifying with the new spec method first
+    msgbytes = construct_message(quote_id, outputs)
+    try:
+        if pubkey.verify(sig, msgbytes):
+            return True
+    except Exception:
+        pass
+
+    # Fallback to the legacy method for backward compatibility
+    msgbytes_legacy = construct_message_legacy(quote_id, outputs)
+    try:
+        return pubkey.verify(sig, msgbytes_legacy)
+    except Exception:
+        return False

--- a/tests/mint/test_mint_verification.py
+++ b/tests/mint/test_mint_verification.py
@@ -379,6 +379,20 @@ def test_verify_mint_quote_witness_rejects_bad_signature(ledger: Ledger):
     assert ledger._verify_mint_quote_witness(quote, outs, signature=wrong_sig) is False
 
 
+def test_verify_mint_quote_witness_legacy_fallback(ledger: Ledger):
+    priv, pub = nut20.generate_keypair()
+    quote = _mint_quote_with_pubkey(pub)
+    outs = [_blinded_output(ledger, label="nut20_legacy")]
+
+    from cashu.core.crypto.secp import PrivateKey
+
+    privkey = PrivateKey(bytes.fromhex(priv))
+    msgbytes_legacy = nut20.construct_message_legacy(quote.quote, outs)
+    sig_legacy = privkey.sign_schnorr(msgbytes_legacy).hex()
+
+    assert ledger._verify_mint_quote_witness(quote, outs, signature=sig_legacy) is True
+
+
 # ---------------------------------------------------------------------------
 # _verify_proof_bdhke
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Aligns NUT-20/29 batch minting signatures to the spec changes in cashubtc/nuts pull request 375, while retaining fallback legacy signature verification for older wallets.