### PR TITLE
fix(mint): handle background melt exceptions

### DIFF
--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -1018,7 +1018,13 @@ class Ledger(
             raise TransactionError(f"melt quote is not unpaid: {melt_quote.state}")
 
         # Launch actual melt task
-        asyncio.create_task(self.melt(proofs=proofs, quote=quote, outputs=outputs))
+        async def melt_task():
+            try:
+                await self.melt(proofs=proofs, quote=quote, outputs=outputs)
+            except Exception as e:
+                logger.error(f"Error in background melt task: {e}")
+
+        asyncio.create_task(melt_task())
 
         melt_quote.state = MeltQuoteState.pending
         return PostMeltQuoteResponse.from_melt_quote(melt_quote)


### PR DESCRIPTION
This PR handles exceptions within the background melt task in async_melt to avoid unhandled exception logs.

Closes #1045