### PR TITLE
feat(core): add method name to mint and melt settings

### DIFF
--- a/cashu/core/models/info.py
+++ b/cashu/core/models/info.py
@@ -10,6 +10,7 @@ class MintMethodBolt11OptionSetting(BaseModel):
 class MintMethodSetting(BaseModel):
     method: str
     unit: str
+    method_name: Optional[str] = None
     min_amount: Optional[int] = None
     max_amount: Optional[int] = None
     options: Optional[MintMethodBolt11OptionSetting] = None
@@ -18,6 +19,7 @@ class MintMethodSetting(BaseModel):
 class MeltMethodSetting(BaseModel):
     method: str
     unit: str
+    method_name: Optional[str] = None
     min_amount: Optional[int] = None
     max_amount: Optional[int] = None
 

--- a/cashu/mint/features.py
+++ b/cashu/mint/features.py
@@ -84,7 +84,9 @@ class LedgerFeatures(SupportsBackends, SupportsPubkey):
         mint_method_settings: List[MintMethodSetting] = []
         for method, unit_dict in self.backends.items():
             for unit in unit_dict.keys():
-                mint_setting = MintMethodSetting(method=method.name, unit=unit.name)
+                mint_setting = MintMethodSetting(
+                    method=method.name, unit=unit.name, method_name=method.name
+                )
                 if settings.mint_max_mint_bolt11_sat:
                     mint_setting.max_amount = settings.mint_max_mint_bolt11_sat
                     mint_setting.min_amount = 0
@@ -95,7 +97,9 @@ class LedgerFeatures(SupportsBackends, SupportsPubkey):
         melt_method_settings: List[MeltMethodSetting] = []
         for method, unit_dict in self.backends.items():
             for unit in unit_dict.keys():
-                melt_setting = MeltMethodSetting(method=method.name, unit=unit.name)
+                melt_setting = MeltMethodSetting(
+                    method=method.name, unit=unit.name, method_name=method.name
+                )
                 if settings.mint_max_melt_bolt11_sat:
                     melt_setting.max_amount = settings.mint_max_melt_bolt11_sat
                     melt_setting.min_amount = 0

--- a/tests/mint/test_mint_api.py
+++ b/tests/mint/test_mint_api.py
@@ -51,6 +51,7 @@ async def test_info(ledger: Ledger):
     assert info.nuts[MINT_NUT]["disabled"] is False
     setting = MintMethodSetting.model_validate(info.nuts[MINT_NUT]["methods"][0])
     assert setting.method == "bolt11"
+    assert setting.method_name == "bolt11"
     assert setting.unit == "sat"
     assert setting.options
     assert setting.options.description is True


### PR DESCRIPTION
## Summary
Implements https://github.com/cashubtc/nuts/pull/374 to keep Nutshell compliant in adding `method_name` to mint and melt settings.