### PR TITLE
chore(release): bump version to 0.20.2

### DIFF
--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -9,7 +9,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 env = Env()
 
-VERSION = "0.20.1"
+VERSION = "0.20.2"
 
 
 def find_env_file():
@@ -57,7 +57,9 @@ class MintSettings(CashuSettings):
     mint_listen_port: int = Field(default=3338)
 
     mint_database: str = Field(default="data/mint")
-    mint_database_lock_timeout: int = Field(default=30000) # Postgres lock timeout in milliseconds
+    mint_database_lock_timeout: int = Field(
+        default=30000
+    )  # Postgres lock timeout in milliseconds
     mint_test_database: str = Field(default="test_data/test_mint")
     mint_max_secret_length: int = Field(default=1024)
     mint_max_witness_length: int = Field(default=1024)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cashu"
-version = "0.20.1"
+version = "0.20.2"
 description = "Ecash wallet and mint"
 authors = ["calle <callebtc@protonmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump Poetry package version to 0.20.2
- bump runtime VERSION/settings.version to 0.20.2

## Verification
- pre-commit hooks from git commit passed, including ruff, ruff format, and mypy