### PR TITLE
fix(auth): allow OIDC tokens with non-client audience

### DIFF
--- a/cashu/mint/auth/server.py
+++ b/cashu/mint/auth/server.py
@@ -109,8 +109,8 @@ class AuthLedger(Ledger):
                 clear_auth_token,
                 signing_key.key,
                 algorithms=["RS256", "ES256"],
-                audience=settings.mint_auth_oicd_client_id,
                 issuer=self.issuer,
+                options={"verify_aud": False},
             )
             logger.trace(f"Decoded JWT: {decoded}")
             # Bind the token to this mint's OIDC client. Keycloak puts the client

--- a/tests/mint/test_mint_auth_server_unit.py
+++ b/tests/mint/test_mint_auth_server_unit.py
@@ -298,9 +298,11 @@ def test_verify_decode_jwt_success(monkeypatch):
     assert decoded_no_azp["sub"] == "bob"
 
 
-def test_verify_decode_jwt_rejects_mismatched_audience(monkeypatch):
+def test_verify_decode_jwt_accepts_non_client_audience(monkeypatch):
     import jwt
     from cryptography.hazmat.primitives.asymmetric import rsa
+
+    from cashu.core.settings import settings
 
     private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     public_key = private_key.public_key()
@@ -318,19 +320,20 @@ def test_verify_decode_jwt_rejects_mismatched_audience(monkeypatch):
 
     ledger.jwks_client = cast(Any, MockJWKSClient())
 
-    # Token with mismatched audience
+    # NUT-21 does not require access token audience to match the OIDC client id.
     token = jwt.encode(
         {
             "iss": "https://issuer.test",
-            "aud": "wrong-client",
+            "aud": "account",
+            "azp": settings.mint_auth_oicd_client_id,
             "sub": "alice",
         },
         private_key,
         algorithm="RS256",
     )
 
-    with pytest.raises(jwt.InvalidTokenError):
-        ledger._verify_decode_jwt(token)
+    decoded = ledger._verify_decode_jwt(token)
+    assert decoded["sub"] == "alice"
 
 
 def test_verify_decode_jwt_rejects_mismatched_azp(monkeypatch):


### PR DESCRIPTION
## Summary
- stop requiring OIDC access token aud to equal the OIDC client id
- keep issuer/signature/expiry validation and the existing optional azp mismatch rejection
- update auth unit coverage for Keycloak-style aud=account, azp=cashu-client tokens

## Tests
- pytest tests/mint/test_mint_auth_server_unit.py
- ruff check cashu/mint/auth/server.py tests/mint/test_mint_auth_server_unit.py
- ruff format --check cashu/mint/auth/server.py tests/mint/test_mint_auth_server_unit.py