### PR TITLE
fix(wallet): persist mint quote accounting

### DIFF
--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -423,6 +423,9 @@ class MintQuote(LedgerEvent):
     unit: str
     amount: int
     state: MintQuoteState
+    amount_paid: int = 0
+    amount_issued: int = 0
+    updated_at: Optional[int] = None
     created_time: Union[int, None] = None
     paid_time: Union[int, None] = None
     issued_time: Union[int, None] = None
@@ -438,8 +441,16 @@ class MintQuote(LedgerEvent):
             #  SQLITE: row is timestamp (string)
             created_time = int(row["created_time"]) if row["created_time"] else None
             paid_time = int(row["paid_time"]) if row["paid_time"] else None
-            issued_time = int(row["issued_time"]) if "issued_time" in row.keys() and row["issued_time"] else None
-            last_checked = int(row["last_checked"]) if "last_checked" in row.keys() and row["last_checked"] else None
+            issued_time = (
+                int(row["issued_time"])
+                if "issued_time" in row.keys() and row["issued_time"]
+                else None
+            )
+            last_checked = (
+                int(row["last_checked"])
+                if "last_checked" in row.keys() and row["last_checked"]
+                else None
+            )
         except Exception:
             # POSTGRES: row is datetime.datetime
             created_time = (
@@ -447,11 +458,27 @@ class MintQuote(LedgerEvent):
             )
             paid_time = int(row["paid_time"].timestamp()) if row["paid_time"] else None
             issued_time = (
-                int(row["issued_time"].timestamp()) if "issued_time" in row.keys() and row["issued_time"] else None
+                int(row["issued_time"].timestamp())
+                if "issued_time" in row.keys() and row["issued_time"]
+                else None
             )
             last_checked = (
-                int(row["last_checked"].timestamp()) if "last_checked" in row.keys() and row["last_checked"] else None
+                int(row["last_checked"].timestamp())
+                if "last_checked" in row.keys() and row["last_checked"]
+                else None
             )
+        state = MintQuoteState(row["state"])
+        amount_paid = (
+            row["amount_paid"]
+            if "amount_paid" in row.keys()
+            else cls.amount_paid_from_state(state, row["amount"])
+        )
+        amount_issued = (
+            row["amount_issued"]
+            if "amount_issued" in row.keys()
+            else cls.amount_issued_from_state(state, row["amount"])
+        )
+        updated_at = row["updated_at"] if "updated_at" in row.keys() else None
         return cls(
             quote=row["quote"],
             method=row["method"],
@@ -459,7 +486,10 @@ class MintQuote(LedgerEvent):
             checking_id=row["checking_id"],
             unit=row["unit"],
             amount=row["amount"],
-            state=MintQuoteState(row["state"]),
+            state=state,
+            amount_paid=amount_paid,
+            amount_issued=amount_issued,
+            updated_at=updated_at,
             created_time=created_time,
             paid_time=paid_time,
             issued_time=issued_time,
@@ -467,6 +497,58 @@ class MintQuote(LedgerEvent):
             pubkey=row["pubkey"] if "pubkey" in row.keys() else None,
             privkey=row["privkey"] if "privkey" in row.keys() else None,
         )
+
+    @staticmethod
+    def amount_paid_from_state(state: MintQuoteState, amount: int) -> int:
+        if state in [MintQuoteState.paid, MintQuoteState.issued]:
+            return amount
+        return 0
+
+    @staticmethod
+    def amount_issued_from_state(state: MintQuoteState, amount: int) -> int:
+        if state == MintQuoteState.issued:
+            return amount
+        return 0
+
+    @property
+    def accounting_updated_at(self) -> int:
+        if self.updated_at is not None:
+            return self.updated_at
+        if self.issued_time is not None:
+            return self.issued_time
+        if self.paid_time is not None:
+            return self.paid_time
+        if self.created_time is not None:
+            return self.created_time
+        return 0
+
+    @staticmethod
+    def state_from_accounting(amount_paid: int, amount_issued: int) -> MintQuoteState:
+        if amount_issued > amount_paid:
+            raise ValueError("amount_issued must not exceed amount_paid")
+        if amount_paid == 0 and amount_issued == 0:
+            return MintQuoteState.unpaid
+        if amount_paid > amount_issued:
+            return MintQuoteState.paid
+        return MintQuoteState.issued
+
+    @classmethod
+    def accounting_from_response(cls, mint_quote_resp, amount: int):
+        amount_paid = mint_quote_resp.amount_paid
+        amount_issued = mint_quote_resp.amount_issued
+
+        if amount_paid is None and amount_issued is None:
+            state = MintQuoteState(mint_quote_resp.state or MintQuoteState.unpaid.value)
+            return (
+                cls.amount_paid_from_state(state, amount),
+                cls.amount_issued_from_state(state, amount),
+                mint_quote_resp.updated_at,
+            )
+        if amount_paid is None or amount_issued is None:
+            raise ValueError("amount_paid and amount_issued must be provided together")
+        if amount_issued > amount_paid:
+            raise ValueError("amount_issued must not exceed amount_paid")
+        return amount_paid, amount_issued, mint_quote_resp.updated_at
 
     @classmethod
     def from_resp_wallet(
@@ -478,43 +560,32 @@ class MintQuote(LedgerEvent):
         paid_time: Optional[int] = None,
         issued_time: Optional[int] = None,
     ):
-        # Prefer amount_paid/amount_issued if present
-        amount_paid = mint_quote_resp.amount_paid
-        amount_issued = mint_quote_resp.amount_issued
+        amount_paid, amount_issued, updated_at = cls.accounting_from_response(
+            mint_quote_resp, amount
+        )
+        state = cls.state_from_accounting(amount_paid, amount_issued)
 
-        if amount_paid is not None and amount_issued is not None:
-            if amount_paid == 0 and amount_issued == 0:
-                if mint_quote_resp.state == "PENDING":
-                    state = MintQuoteState.pending
-                else:
-                    state = MintQuoteState.unpaid
-            elif amount_paid > amount_issued:
-                state = MintQuoteState.paid
-            elif amount_paid == amount_issued and amount_issued > 0:
-                state = MintQuoteState.issued
-            else:
-                state = MintQuoteState.unpaid
-        elif mint_quote_resp.state:
-            state = MintQuoteState(mint_quote_resp.state)
-        else:
-            state = MintQuoteState.unpaid
-
-        if paid_time is None and mint_quote_resp.updated_at is not None:
+        if paid_time is None and updated_at is not None:
             if state in [MintQuoteState.paid, MintQuoteState.issued]:
-                paid_time = mint_quote_resp.updated_at
+                paid_time = updated_at
 
-        if issued_time is None and mint_quote_resp.updated_at is not None:
+        if issued_time is None and updated_at is not None:
             if state == MintQuoteState.issued:
-                issued_time = mint_quote_resp.updated_at
+                issued_time = updated_at
 
         return cls(
             quote=mint_quote_resp.quote,
             method="bolt11",
             request=mint_quote_resp.request,
             checking_id="",
-            unit=mint_quote_resp.unit or unit,  # BACKWARDS COMPATIBILITY mint response < 0.17.0
-            amount=mint_quote_resp.amount or amount,  # BACKWARDS COMPATIBILITY mint response < 0.17.0
+            unit=mint_quote_resp.unit
+            or unit,  # BACKWARDS COMPATIBILITY mint response < 0.17.0
+            amount=mint_quote_resp.amount
+            or amount,  # BACKWARDS COMPATIBILITY mint response < 0.17.0
             state=state,
+            amount_paid=amount_paid,
+            amount_issued=amount_issued,
+            updated_at=updated_at,
             mint=mint,
             expiry=mint_quote_resp.expiry,
             created_time=int(time.time()),
@@ -532,26 +603,6 @@ class MintQuote(LedgerEvent):
         default_amount: int = 0,
         default_unit: str = "sat",
     ) -> "MintQuote":
-        # Check if the response is stale according to the spec
-        is_stale = False
-        if mint_quote_local:
-            resp_updated_at = mint_quote_resp.updated_at
-            resp_amount_paid = mint_quote_resp.amount_paid
-            resp_amount_issued = mint_quote_resp.amount_issued
-            local_updated_at = (
-                mint_quote_local.issued_time or mint_quote_local.paid_time
-            )
-
-            if (
-                (resp_updated_at is not None and local_updated_at is not None and resp_updated_at < local_updated_at)
-                or (resp_amount_paid is not None and resp_amount_paid < mint_quote_local.amount_paid)
-                or (resp_amount_issued is not None and resp_amount_issued < mint_quote_local.amount_issued)
-            ):
-                is_stale = True
-
-        if is_stale and mint_quote_local:
-            return mint_quote_local
-
         amount = (
             (mint_quote_resp.amount or mint_quote_local.amount)
             if mint_quote_local
@@ -566,7 +617,7 @@ class MintQuote(LedgerEvent):
         paid_time = mint_quote_local.paid_time if mint_quote_local else None
         issued_time = mint_quote_local.issued_time if mint_quote_local else None
 
-        return cls.from_resp_wallet(
+        quote = cls.from_resp_wallet(
             mint_quote_resp,
             mint=mint,
             amount=amount,
@@ -575,27 +626,21 @@ class MintQuote(LedgerEvent):
             issued_time=issued_time,
         )
 
-    @property
-    def amount_paid(self) -> int:
-        if self.state in [MintQuoteState.paid, MintQuoteState.issued]:
-            return self.amount
-        return 0
+        if not mint_quote_local:
+            return quote
 
-    @property
-    def amount_issued(self) -> int:
-        if self.state == MintQuoteState.issued:
-            return self.amount
-        return 0
+        if (
+            quote.updated_at is not None
+            and mint_quote_local.updated_at is not None
+            and quote.updated_at < mint_quote_local.updated_at
+        ):
+            return mint_quote_local
+        if quote.amount_paid < mint_quote_local.amount_paid:
+            return mint_quote_local
+        if quote.amount_issued < mint_quote_local.amount_issued:
+            return mint_quote_local
 
-    @property
-    def updated_at(self) -> int:
-        if self.issued_time is not None:
-            return self.issued_time
-        if self.paid_time is not None:
-            return self.paid_time
-        if self.created_time is not None:
-            return self.created_time
-        return 0
+        return quote
 
     @property
     def identifier(self) -> str:
@@ -623,6 +668,7 @@ class MintQuote(LedgerEvent):
         return self.state == MintQuoteState.issued
 
     def __setattr__(self, name, value):
+        old_state = getattr(self, "state", None) if name == "state" else None
         # un unpaid quote can only be set to paid
         if name == "state" and self.unpaid:
             if value != MintQuoteState.paid:
@@ -646,6 +692,13 @@ class MintQuote(LedgerEvent):
                 "MintQuote does not support `paid` anymore! Use `state` instead."
             )
         super().__setattr__(name, value)
+        if name == "state" and old_state != value:
+            super().__setattr__(
+                "amount_paid", self.amount_paid_from_state(value, self.amount)
+            )
+            super().__setattr__(
+                "amount_issued", self.amount_issued_from_state(value, self.amount)
+            )
 
 
 # ------- KEYSETS -------
@@ -675,11 +728,11 @@ class Unit(Enum):
         elif self == Unit.msat:
             return f"{amount} msat"
         elif self == Unit.usd:
-            return f"${amount/100:.2f} USD"
+            return f"${amount / 100:.2f} USD"
         elif self == Unit.eur:
-            return f"{amount/100:.2f} EUR"
+            return f"{amount / 100:.2f} EUR"
         elif self == Unit.btc:
-            return f"{amount/1e8:.8f} BTC"
+            return f"{amount / 1e8:.8f} BTC"
         elif self == Unit.auth:
             return f"{amount} AUTH"
         else:
@@ -744,18 +797,18 @@ class Amount:
     def sat_to_btc(self) -> str:
         if self.unit != Unit.sat:
             raise Exception("Amount must be in satoshis")
-        return f"{self.amount/1e8:.8f}"
+        return f"{self.amount / 1e8:.8f}"
 
     def msat_to_btc(self) -> str:
         if self.unit != Unit.msat:
             raise Exception("Amount must be in msat")
         sat_amount = Amount(Unit.msat, self.amount).to(Unit.sat, round="up")
-        return f"{sat_amount.amount/1e8:.8f}"
+        return f"{sat_amount.amount / 1e8:.8f}"
 
     def cents_to_usd(self) -> str:
         if self.unit != Unit.usd and self.unit != Unit.eur:
             raise Exception("Amount must be in cents")
-        return f"{self.amount/100:.2f}"
+        return f"{self.amount / 100:.2f}"
 
     def str(self) -> str:
         return self.unit.str(self.amount)
@@ -1045,8 +1098,7 @@ class MintKeyset:
     def public_keys_hex(self) -> Dict[int, str]:
         assert self.public_keys, "public keys not set"
         return {
-            int(amount): key.format().hex()
-            for amount, key in self.public_keys.items()
+            int(amount): key.format().hex() for amount, key in self.public_keys.items()
         }
 
     def generate_keys(self):
@@ -1087,7 +1139,7 @@ class MintKeyset:
                 self.seed, self.derivation_path, self.amounts
             )
             self.public_keys = derive_pubkeys(self.private_keys, self.amounts)  # type: ignore
-            
+
             if id_in_db:
                 # If loading from DB, preserve existing ID
                 self.id = id_in_db
@@ -1100,14 +1152,19 @@ class MintKeyset:
                 self.seed, self.derivation_path, self.amounts
             )
             self.public_keys = derive_pubkeys(self.private_keys, self.amounts)  # type: ignore
-            
+
             # KEYSETS V2: Use new keyset ID derivation
             if id_in_db:
                 # If loading from DB, preserve existing ID
                 self.id = id_in_db
             else:
                 assert self.public_keys is not None
-                self.id = derive_keyset_id_v2(self.public_keys, self.unit.name, self.final_expiry, self.input_fee_ppk)
+                self.id = derive_keyset_id_v2(
+                    self.public_keys,
+                    self.unit.name,
+                    self.final_expiry,
+                    self.input_fee_ppk,
+                )
                 logger.info(f"Generated keyset v2 ID: {self.id}")
 
 
@@ -1538,9 +1595,9 @@ class AuthProof(BaseModel):
     def to_base64(self):
         serialize_dict = self.model_dump()
         serialize_dict.pop("amount", None)
-        return (
-            self.prefix + base64.urlsafe_b64encode(json.dumps(serialize_dict).encode()).decode().rstrip("=")
-        )
+        return self.prefix + base64.urlsafe_b64encode(
+            json.dumps(serialize_dict).encode()
+        ).decode().rstrip("=")
 
     @classmethod
     def from_base64(cls, base64_str: str):

--- a/cashu/core/models/mint_quote.py
+++ b/cashu/core/models/mint_quote.py
@@ -52,5 +52,5 @@ class PostMintQuoteResponse(BaseModel):
         to_dict["state"] = mint_quote.state.value
         to_dict["amount_paid"] = mint_quote.amount_paid
         to_dict["amount_issued"] = mint_quote.amount_issued
-        to_dict["updated_at"] = mint_quote.updated_at
+        to_dict["updated_at"] = mint_quote.accounting_updated_at
         return cls.model_validate(to_dict)

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -183,7 +183,8 @@ async def mint_quote(
         pubkey=quote.pubkey,
         amount_paid=quote.amount_paid,
         amount_issued=quote.amount_issued,
-        updated_at=quote.updated_at,
+        updated_at=getattr(quote, "accounting_updated_at", None)
+        or getattr(quote, "updated_at", None),
     )
     logger.trace(f"< POST /v1/mint/quote/bolt11: {resp}")
     return resp
@@ -212,7 +213,8 @@ async def get_mint_quote(request: Request, quote: str) -> PostMintQuoteResponse:
         pubkey=mint_quote.pubkey,
         amount_paid=mint_quote.amount_paid,
         amount_issued=mint_quote.amount_issued,
-        updated_at=mint_quote.updated_at,
+        updated_at=getattr(mint_quote, "accounting_updated_at", None)
+        or getattr(mint_quote, "updated_at", None),
     )
     logger.trace(f"< GET /v1/mint/quote/bolt11/{quote}")
     return resp
@@ -242,7 +244,8 @@ async def mint_quote_check(
             pubkey=quote.pubkey,
             amount_paid=quote.amount_paid,
             amount_issued=quote.amount_issued,
-            updated_at=quote.updated_at,
+            updated_at=getattr(quote, "accounting_updated_at", None)
+            or getattr(quote, "updated_at", None),
         )
         for quote in quotes
     ]

--- a/cashu/wallet/crud.py
+++ b/cashu/wallet/crud.py
@@ -262,8 +262,8 @@ async def store_bolt11_mint_quote(
     await (conn or db).execute(
         """
         INSERT INTO bolt11_mint_quotes
-            (quote, mint, method, request, checking_id, unit, amount, state, created_time, paid_time, expiry, privkey)
-        VALUES (:quote, :mint, :method, :request, :checking_id, :unit, :amount, :state, :created_time, :paid_time, :expiry, :privkey)
+            (quote, mint, method, request, checking_id, unit, amount, state, created_time, paid_time, expiry, privkey, amount_paid, amount_issued, updated_at)
+        VALUES (:quote, :mint, :method, :request, :checking_id, :unit, :amount, :state, :created_time, :paid_time, :expiry, :privkey, :amount_paid, :amount_issued, :updated_at)
         """,
         {
             "quote": quote.quote,
@@ -278,6 +278,9 @@ async def store_bolt11_mint_quote(
             "paid_time": quote.paid_time,
             "expiry": quote.expiry,
             "privkey": quote.privkey or "",
+            "amount_paid": quote.amount_paid,
+            "amount_issued": quote.amount_issued,
+            "updated_at": quote.updated_at,
         },
     )
 
@@ -344,21 +347,27 @@ async def get_bolt11_mint_quotes(
 
 async def update_bolt11_mint_quote(
     db: Database,
-    quote: str,
-    state: MintQuoteState,
-    paid_time: int,
+    quote: MintQuote,
     conn: Optional[Connection] = None,
 ) -> None:
     await (conn or db).execute(
         """
         UPDATE bolt11_mint_quotes
-        SET state = :state, paid_time = :paid_time
+        SET
+            state = :state,
+            paid_time = :paid_time,
+            amount_paid = :amount_paid,
+            amount_issued = :amount_issued,
+            updated_at = :updated_at
         WHERE quote = :quote
         """,
         {
-            "state": state.value,
-            "paid_time": paid_time,
-            "quote": quote,
+            "state": quote.state.value,
+            "paid_time": quote.paid_time,
+            "amount_paid": quote.amount_paid,
+            "amount_issued": quote.amount_issued,
+            "updated_at": quote.updated_at,
+            "quote": quote.quote,
         },
     )
 
@@ -390,7 +399,9 @@ async def store_bolt11_melt_quote(
             "payment_preimage": quote.payment_preimage,
             "expiry": quote.expiry,
             "change": (
-                json.dumps([c.model_dump() for c in quote.change]) if quote.change else ""
+                json.dumps([c.model_dump() for c in quote.change])
+                if quote.change
+                else ""
             ),
         },
     )

--- a/cashu/wallet/migrations.py
+++ b/cashu/wallet/migrations.py
@@ -334,3 +334,53 @@ async def m016_remove_nostr_table(db: Database):
             DROP TABLE IF EXISTS nostr;
             """
         )
+
+
+async def m017_add_mint_quote_accounting(db: Database):
+    """
+    Store canonical NUT-04 quote accounting fields in wallet mint quotes.
+    """
+    async with db.connect() as conn:
+        columns = await conn.fetchall(
+            """
+                SELECT name FROM pragma_table_info('bolt11_mint_quotes');
+            """
+        )
+        column_names = {col["name"] for col in columns}
+        if "amount_paid" not in column_names:
+            await conn.execute(
+                """
+                    ALTER TABLE bolt11_mint_quotes
+                    ADD COLUMN amount_paid INTEGER NOT NULL DEFAULT 0;
+                """
+            )
+        if "amount_issued" not in column_names:
+            await conn.execute(
+                """
+                    ALTER TABLE bolt11_mint_quotes
+                    ADD COLUMN amount_issued INTEGER NOT NULL DEFAULT 0;
+                """
+            )
+        if "updated_at" not in column_names:
+            await conn.execute(
+                """
+                    ALTER TABLE bolt11_mint_quotes
+                    ADD COLUMN updated_at INTEGER DEFAULT NULL;
+                """
+            )
+
+        await conn.execute(
+            """
+                UPDATE bolt11_mint_quotes
+                SET
+                    amount_paid = CASE
+                        WHEN state IN ('PAID', 'ISSUED') THEN amount
+                        ELSE 0
+                    END,
+                    amount_issued = CASE
+                        WHEN state = 'ISSUED' THEN amount
+                        ELSE 0
+                    END
+                WHERE amount_paid = 0 AND amount_issued = 0;
+            """
+        )

--- a/cashu/wallet/npc.py
+++ b/cashu/wallet/npc.py
@@ -13,9 +13,10 @@ from cashu.wallet.wallet import Wallet
 # Constant holding the npub cash hostname
 NPUB_CASH = settings.npub_cash_hostname
 
+
 class NpubCash:
     """Client for npub.cash API"""
-    
+
     API_URL = f"https://{NPUB_CASH}/api/v2"
     LNURL_BASE = f"https://{NPUB_CASH}/.well-known/lnurlp"
 
@@ -30,23 +31,27 @@ class NpubCash:
     def _derive_keys(self):
         """Derives Nostr keys from wallet seed."""
         if not self.wallet.seed:
-             raise ValueError("Wallet seed not initialized")
+            raise ValueError("Wallet seed not initialized")
         self.privkey_hex, self.pubkey_hex = derive_nostr_keypair(self.wallet.seed)
         assert self.pubkey_hex
         self.npub = get_npub(self.pubkey_hex)
 
-    async def _request(self, method: str, path: str, body: Optional[Dict] = None, auth: bool = True) -> Any:
+    async def _request(
+        self, method: str, path: str, body: Optional[Dict] = None, auth: bool = True
+    ) -> Any:
         """Executes an HTTP request with optional NIP-98 authentication."""
         url = f"{self.API_URL}{path}"
         headers: Dict[str, str] = {}
-        
+
         if auth:
             if not self.privkey_hex:
-                 self._derive_keys()
+                self._derive_keys()
             if not self.privkey_hex:
-                 raise ValueError("Private key not initialized. Cannot authenticate.")
-            headers["Authorization"] = create_nip98_header(url, method, self.privkey_hex, body)
-            
+                raise ValueError("Private key not initialized. Cannot authenticate.")
+            headers["Authorization"] = create_nip98_header(
+                url, method, self.privkey_hex, body
+            )
+
         async with httpx.AsyncClient() as client:
             try:
                 if method == "GET":
@@ -57,13 +62,13 @@ class NpubCash:
                     resp = await client.patch(url, headers=headers, json=body)
                 else:
                     raise ValueError(f"Unsupported method: {method}")
-                
+
                 resp.raise_for_status()
                 data = resp.json()
-                
+
                 if data.get("error"):
                     raise Exception(data.get("message", "Unknown error"))
-                    
+
                 return data.get("data", {})
             except httpx.HTTPStatusError as e:
                 try:
@@ -94,7 +99,7 @@ class NpubCash:
             data = await self._request("GET", "/user/info")
             user = data.get("user", {})
             if user.get("mintUrl"):
-                 raise Exception(f"LNURL already created: {self.npub}@{NPUB_CASH}")
+                raise Exception(f"LNURL already created: {self.npub}@{NPUB_CASH}")
         except Exception as e:
             if "LNURL already created" in str(e):
                 raise e
@@ -104,21 +109,21 @@ class NpubCash:
 
         mint_to_use = mint_url or self.wallet.url
         if not mint_to_use:
-             raise ValueError("No mint URL provided or found in wallet")
+            raise ValueError("No mint URL provided or found in wallet")
 
         # Use PATCH /api/v2/user/mint with mint_url body
         await self._request("PATCH", "/user/mint", body={"mint_url": mint_to_use})
-        
+
         return await self.get_lnurl()
 
     async def update_mint_url(self, mint_url: Optional[str] = None) -> str:
         """Updates the mint URL for the LNURL."""
         if not self.npub:
             self._derive_keys()
-            
+
         mint_to_use = mint_url or self.wallet.url
         if not mint_to_use:
-             raise ValueError("No mint URL provided or found in wallet")
+            raise ValueError("No mint URL provided or found in wallet")
 
         await self._request("PATCH", "/user/mint", body={"mint_url": mint_to_use})
         return await self.get_lnurl()
@@ -127,7 +132,7 @@ class NpubCash:
         """Fetches all paid quotes from the API."""
         if not self.privkey_hex:
             self._derive_keys()
-        
+
         try:
             data = await self._request("GET", "/wallet/quotes")
             # API v2 returns data object containing 'quotes' list
@@ -147,11 +152,11 @@ class NpubCash:
         Returns a list of minted proofs.
         """
         if not self.wallet.url:
-             raise ValueError("Wallet mint URL not set")
-             
+            raise ValueError("Wallet mint URL not set")
+
         quotes = await self.check_quotes()
         minted_proofs = []
-        
+
         for quote_dict in quotes:
             # quote['mintUrl'] contains the mint URL used for this quote
             quote_mint = quote_dict.get("mintUrl") or quote_dict.get("mint")
@@ -159,15 +164,17 @@ class NpubCash:
                 continue
 
             if quote_mint.rstrip("/") != self.wallet.url.rstrip("/"):
-                print(f"Skipping quote {quote_dict.get('id', 'unknown')} from different mint: {quote_mint} (Wallet: {self.wallet.url})")
+                print(
+                    f"Skipping quote {quote_dict.get('id', 'unknown')} from different mint: {quote_mint} (Wallet: {self.wallet.url})"
+                )
                 continue
-            
+
             quote_id = quote_dict.get("quoteId") or quote_dict.get("id")
             amount = quote_dict.get("amount")
-            
+
             if not quote_id or not amount:
                 continue
-                
+
             try:
                 # Mint tokens
                 # For v2, we are minting the quote ID that NPC created.
@@ -188,16 +195,21 @@ class NpubCash:
                 minted_proofs.extend(proofs)
             except Exception as e:
                 # If the mint returns an error that the quote is already issued, we assume it is issued
-                if "Code: 11000" in str(e) or (isinstance(e, CashuError) and e.code == 11000):
-                    print(f"Quote {quote_id} already issued (mint). Updating local state.")
-                    await update_bolt11_mint_quote(
-                        db=self.wallet.db,
-                        quote=quote_id,
-                        state=MintQuoteState.issued,
-                        paid_time=int(time.time()),
+                if "Code: 11000" in str(e) or (
+                    isinstance(e, CashuError) and e.code == 11000
+                ):
+                    print(
+                        f"Quote {quote_id} already issued (mint). Updating local state."
                     )
+                    quote = await get_bolt11_mint_quote(
+                        db=self.wallet.db, quote=quote_id
+                    )
+                    if quote:
+                        quote.state = MintQuoteState.issued
+                        quote.paid_time = int(time.time())
+                        await update_bolt11_mint_quote(db=self.wallet.db, quote=quote)
                     continue
                 print(f"Failed to mint quote {quote_id}: {e}")
                 pass
-                
+
         return minted_proofs

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -282,7 +282,9 @@ class Wallet(
             logger.debug("Updating mint info in db.")
             await update_mint(
                 db=self.db,
-                mint=WalletMint(url=self.url, info=json.dumps(self.mint_info.model_dump())),
+                mint=WalletMint(
+                    url=self.url, info=json.dumps(self.mint_info.model_dump())
+                ),
             )
             return self.mint_info
         else:
@@ -583,13 +585,18 @@ class Wallet(
 
         if not mint_quote_local:
             await store_bolt11_mint_quote(db=self.db, quote=mint_quote)
-        elif mint_quote_local.state != mint_quote.state:
-            await update_bolt11_mint_quote(
-                db=self.db,
-                quote=mint_quote.quote,
-                state=mint_quote.state,
-                paid_time=mint_quote.paid_time or int(time.time()),
-            )
+        elif (
+            mint_quote_local.state != mint_quote.state
+            or mint_quote_local.amount_paid != mint_quote.amount_paid
+            or mint_quote_local.amount_issued != mint_quote.amount_issued
+            or mint_quote_local.updated_at != mint_quote.updated_at
+        ):
+            if mint_quote.paid_time is None and mint_quote.state in [
+                MintQuoteState.paid,
+                MintQuoteState.issued,
+            ]:
+                mint_quote.paid_time = int(time.time())
+            await update_bolt11_mint_quote(db=self.db, quote=mint_quote)
 
         return mint_quote
 
@@ -654,12 +661,9 @@ class Wallet(
         )
         proofs = await self._construct_proofs(promises, secrets, rs, derivation_paths)
 
-        await update_bolt11_mint_quote(
-            db=self.db,
-            quote=quote_id,
-            state=MintQuoteState.issued,
-            paid_time=int(time.time()),
-        )
+        quote.state = MintQuoteState.issued
+        quote.paid_time = int(time.time())
+        await update_bolt11_mint_quote(db=self.db, quote=quote)
         # store the mint_id in proofs
         async with self.db.connect() as conn:
             for p in proofs:
@@ -733,9 +737,9 @@ class Wallet(
                 send_outputs, keep_outputs, secret_lock
             )
 
-        assert len(secrets) == len(
-            amounts
-        ), "number of secrets does not match number of outputs"
+        assert len(secrets) == len(amounts), (
+            "number of secrets does not match number of outputs"
+        )
         # verify that we didn't accidentally reuse a secret
         await self._check_used_secrets(secrets)
 
@@ -980,9 +984,9 @@ class Wallet(
                 return
             logger.trace("Verifying DLEQ proof.")
             assert proof.id
-            assert (
-                proof.id in self.keysets
-            ), f"Keyset {proof.id} not known, can not verify DLEQ."
+            assert proof.id in self.keysets, (
+                f"Keyset {proof.id} not known, can not verify DLEQ."
+            )
             if not b_dhke.carol_verify_dleq(
                 secret_msg=proof.secret,
                 C=PublicKey(bytes.fromhex(proof.C)),
@@ -1093,9 +1097,9 @@ class Wallet(
         Raises:
             AssertionError: if len(amounts) != len(secrets)
         """
-        assert len(amounts) == len(
-            secrets
-        ), f"len(amounts)={len(amounts)} not equal to len(secrets)={len(secrets)}"
+        assert len(amounts) == len(secrets), (
+            f"len(amounts)={len(amounts)} not equal to len(secrets)={len(secrets)}"
+        )
         keyset_id = keyset_id or self.keyset_id
         outputs: List[BlindedMessage] = []
         rs_ = [None] * len(amounts) if not rs else rs
@@ -1110,9 +1114,7 @@ class Wallet(
 
             assert r
             rs_return.append(r)
-            output = BlindedMessage(
-                amount=amount, B_=B_.format().hex(), id=keyset_id
-            )
+            output = BlindedMessage(amount=amount, B_=B_.format().hex(), id=keyset_id)
             outputs.append(output)
             logger.trace(f"Constructing output: {output}, r: {r.to_hex()}")
 

--- a/tests/wallet/test_wallet_crud_unit.py
+++ b/tests/wallet/test_wallet_crud_unit.py
@@ -1,4 +1,5 @@
 import time
+from types import SimpleNamespace
 
 import pytest
 import pytest_asyncio
@@ -218,19 +219,67 @@ async def test_mint_quote_crud_lifecycle(wallet_db: Database):
     assert len(pending) == 1
     assert pending[0].quote == "quote-2"
 
-    await update_bolt11_mint_quote(
-        db=wallet_db,
-        quote="quote-1",
-        state=MintQuoteState.paid,
-        paid_time=123,
-    )
+    assert by_quote is not None
+    by_quote.state = MintQuoteState.paid
+    by_quote.paid_time = 123
+    await update_bolt11_mint_quote(db=wallet_db, quote=by_quote)
     updated = await get_bolt11_mint_quote(db=wallet_db, quote="quote-1")
     assert updated is not None
     assert updated.state == MintQuoteState.paid
     assert updated.paid_time == 123
+    assert updated.amount_paid == 21
+    assert updated.amount_issued == 0
+    assert updated.updated_at is None
 
     with pytest.raises(ValueError, match="quote or request must be provided"):
         await get_bolt11_mint_quote(db=wallet_db)
+
+
+def test_mint_quote_stale_check_ignores_local_paid_time():
+    local = _mint_quote("quote-local", MintQuoteState.unpaid)
+    local.state = MintQuoteState.paid
+    local.paid_time = 5000
+
+    resp = SimpleNamespace(
+        quote="quote-local",
+        request=local.request,
+        amount=21,
+        unit="sat",
+        amount_paid=21,
+        amount_issued=21,
+        updated_at=10,
+        state="PAID",
+        expiry=local.expiry,
+        pubkey=None,
+    )
+
+    quote = MintQuote.check_stale_and_from_resp_wallet(
+        resp, mint="https://mint.test", mint_quote_local=local
+    )
+
+    assert quote.state == MintQuoteState.issued
+    assert quote.updated_at == 10
+
+
+def test_mint_quote_state_is_derived_from_accounting_when_present():
+    resp = SimpleNamespace(
+        quote="quote-accounting",
+        request="req-quote-accounting",
+        amount=21,
+        unit="sat",
+        amount_paid=0,
+        amount_issued=0,
+        updated_at=10,
+        state="PENDING",
+        expiry=None,
+        pubkey=None,
+    )
+
+    quote = MintQuote.from_resp_wallet(
+        resp, mint="https://mint.test", amount=21, unit="sat"
+    )
+
+    assert quote.state == MintQuoteState.unpaid
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- persist mint quote amount_paid, amount_issued, and server updated_at in the wallet DB
- derive wallet quote state from accounting fields when present, with legacy fallback for old mints
- keep server updated_at separate from local wallet timestamps for stale-response checks

## Tests
- poetry run pytest tests/wallet/test_wallet_crud_unit.py tests/mint/test_mint_api.py::test_mint_quote tests/mint/test_mint_app_router.py