### PR TITLE
fix(mint): async melt pending race

### DIFF
--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -1023,7 +1023,9 @@ class Ledger(
             PostMeltQuoteResponse: Melt quote response with pending state.
         """
         # validate and set the quote to pending before responding
-        melt_quote = await self._prepare_melt(proofs=proofs, quote=quote, outputs=outputs)
+        melt_quote = await self._prepare_melt(
+            proofs=proofs, quote=quote, outputs=outputs
+        )
 
         # run the payment in the background
         async def melt_task():
@@ -1058,7 +1060,9 @@ class Ledger(
         Returns:
             PostMeltQuoteResponse: Melt quote response.
         """
-        melt_quote = await self._prepare_melt(proofs=proofs, quote=quote, outputs=outputs)
+        melt_quote = await self._prepare_melt(
+            proofs=proofs, quote=quote, outputs=outputs
+        )
         return await self._execute_melt_payment(melt_quote, proofs, outputs)
 
     async def _prepare_melt(

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -1022,24 +1022,21 @@ class Ledger(
         Returns:
             PostMeltQuoteResponse: Melt quote response with pending state.
         """
-        # get melt quote
-        melt_quote = await self.get_melt_quote(quote_id=quote)
-        if not melt_quote:
-            raise TransactionError("melt quote not found")
-        if not melt_quote.unpaid:
-            raise TransactionError(f"melt quote is not unpaid: {melt_quote.state}")
+        # validate and set the quote to pending before responding
+        melt_quote = await self._prepare_melt(proofs=proofs, quote=quote, outputs=outputs)
 
-        # Launch actual melt task
+        # run the payment in the background
         async def melt_task():
             try:
-                await self.melt(proofs=proofs, quote=quote, outputs=outputs)
+                await self._execute_melt_payment(melt_quote, proofs, outputs)
             except Exception as e:
                 logger.error(f"Error in background melt task: {e}")
 
         asyncio.create_task(melt_task())
 
-        melt_quote.state = MeltQuoteState.pending
-        return PostMeltQuoteResponse.from_melt_quote(melt_quote)
+        # respond pending now that it is durably committed
+        pending_quote = melt_quote.model_copy(update={"state": MeltQuoteState.pending})
+        return PostMeltQuoteResponse.from_melt_quote(pending_quote)
 
     async def melt(
         self,
@@ -1061,6 +1058,17 @@ class Ledger(
         Returns:
             PostMeltQuoteResponse: Melt quote response.
         """
+        melt_quote = await self._prepare_melt(proofs=proofs, quote=quote, outputs=outputs)
+        return await self._execute_melt_payment(melt_quote, proofs, outputs)
+
+    async def _prepare_melt(
+        self,
+        *,
+        proofs: List[Proof],
+        quote: str,
+        outputs: Optional[List[BlindedMessage]] = None,
+    ) -> MeltQuote:
+        """Validates a melt request and sets the quote and its proofs to pending."""
         # make sure we're allowed to melt
         if self.disable_melt and settings.mint_disable_melt_on_error:
             raise NotAllowedError("Melt is disabled. Please contact the operator.")
@@ -1070,9 +1078,7 @@ class Ledger(
         if not melt_quote.unpaid:
             raise TransactionError(f"melt quote is not unpaid: {melt_quote.state}")
 
-        unit, method = self._verify_and_get_unit_method(
-            melt_quote.unit, melt_quote.method
-        )
+        unit, _ = self._verify_and_get_unit_method(melt_quote.unit, melt_quote.method)
 
         # make sure that the proofs are in the same unit as the quote
         self._verify_proofs_unit(proofs, expected_unit=unit)
@@ -1131,6 +1137,21 @@ class Ledger(
                 state=MeltQuoteState.unpaid,
             )
             raise e
+
+        return melt_quote
+
+    async def _execute_melt_payment(
+        self,
+        melt_quote: MeltQuote,
+        proofs: List[Proof],
+        outputs: Optional[List[BlindedMessage]],
+    ) -> PostMeltQuoteResponse:
+        """Pays the Lightning invoice for a pending melt quote and finalizes it."""
+        unit, method = self._verify_and_get_unit_method(
+            melt_quote.unit, melt_quote.method
+        )
+        input_fees = self.get_fees_for_proofs(proofs)
+        fee_reserve_provided = sum_proofs(proofs) - melt_quote.amount - input_fees
 
         # quote not paid yet (not internal), pay it with the backend
         if not melt_quote.paid:

--- a/tests/mint/test_async_melt.py
+++ b/tests/mint/test_async_melt.py
@@ -11,13 +11,17 @@ from tests.helpers import is_fake, pay_if_regtest
 
 BASE_URL = "http://localhost:3337"
 
+
 @pytest.mark.asyncio
 @pytest.mark.skipif(not is_fake, reason="only on fakewallet")
 async def test_async_melt(ledger):
     # This test uses direct API calls because the wallet fixture issue
     # for async melt is complex in this setup.
     from cashu.wallet.wallet import Wallet
-    wallet = await Wallet.with_db(url=SERVER_ENDPOINT, db="test_data/wallet_async_melt", name="wallet_async_melt")
+
+    wallet = await Wallet.with_db(
+        url=SERVER_ENDPOINT, db="test_data/wallet_async_melt", name="wallet_async_melt"
+    )
     await wallet.load_mint()
 
     # Setup: get some funds
@@ -47,15 +51,16 @@ async def test_async_melt(ledger):
     assert response.status_code == 200
     result = response.json()
     assert result["state"] == MeltQuoteState.pending.value
-    
+
     # Wait a bit for the background task to complete
     await asyncio.sleep(2)
-    
+
     # Verify it became paid
     response = httpx.get(f"{BASE_URL}/v1/melt/quote/bolt11/{quote.quote}")
     assert response.status_code == 200
     result = response.json()
     assert result["state"] == MeltQuoteState.paid.value
+
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not is_fake, reason="only on fakewallet")
@@ -110,7 +115,9 @@ async def test_async_melt_commits_pending_before_returning(ledger):
     finally:
         settings.fakewallet_delay_outgoing_payment = original_delay
 
-    persisted = await ledger.crud.get_melt_quote(quote_id=melt_quote.quote, db=ledger.db)
+    persisted = await ledger.crud.get_melt_quote(
+        quote_id=melt_quote.quote, db=ledger.db
+    )
     assert persisted is not None
     assert persisted.state == MeltQuoteState.paid
 

--- a/tests/mint/test_async_melt.py
+++ b/tests/mint/test_async_melt.py
@@ -3,7 +3,9 @@ import asyncio
 import httpx
 import pytest
 
-from cashu.core.base import MeltQuoteState
+from cashu.core.base import Amount, MeltQuoteState, Method, Unit
+from cashu.core.models import PostMeltQuoteRequest
+from cashu.core.settings import settings
 from tests.conftest import SERVER_ENDPOINT
 from tests.helpers import is_fake, pay_if_regtest
 
@@ -54,6 +56,68 @@ async def test_async_melt(ledger):
     assert response.status_code == 200
     result = response.json()
     assert result["state"] == MeltQuoteState.paid.value
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not is_fake, reason="only on fakewallet")
+async def test_async_melt_commits_pending_before_returning(ledger):
+    """Regression: async_melt must durably persist PENDING *before* it returns
+    PENDING. If the commit is deferred into the detached task (the old behavior),
+    a NUT-17 subscriber or a poller reading right after the response sees the
+    stale UNPAID, which NUT-05 clients treat as a terminal payment failure."""
+    from cashu.wallet.wallet import Wallet
+
+    wallet = await Wallet.with_db(
+        url=SERVER_ENDPOINT,
+        db="test_data/wallet_async_melt_race",
+        name="wallet_async_melt_race",
+    )
+    await wallet.load_mint()
+    mint_quote = await wallet.request_mint(64)
+    await pay_if_regtest(mint_quote.request)
+    await wallet.mint(64, quote_id=mint_quote.quote)
+
+    # External invoice: payable by the backend but with no matching mint quote,
+    # so the melt takes the Lightning path (where the race window exists) instead
+    # of settling internally and synchronously.
+    invoice = await ledger.backends[Method.bolt11][Unit.sat].create_invoice(
+        Amount(Unit.sat, 32)
+    )
+    melt_quote = await ledger.melt_quote(
+        PostMeltQuoteRequest(request=invoice.payment_request, unit="sat")
+    )
+    _, send_proofs = await wallet.swap_to_send(
+        wallet.proofs, melt_quote.amount + melt_quote.fee_reserve
+    )
+
+    # Hold the background Lightning payment in-flight so the committed PENDING
+    # state is observable instead of racing straight to PAID.
+    original_delay = settings.fakewallet_delay_outgoing_payment
+    settings.fakewallet_delay_outgoing_payment = 1.0
+    try:
+        resp = await ledger.async_melt(proofs=send_proofs, quote=melt_quote.quote)
+        assert resp.state == MeltQuoteState.pending.value
+
+        # Read the RAW committed state (as the NUT-17 snapshot does); the public
+        # ledger.get_melt_quote() would itself poll the backend and settle it.
+        persisted = await ledger.crud.get_melt_quote(
+            quote_id=melt_quote.quote, db=ledger.db
+        )
+        assert persisted is not None
+        assert persisted.state == MeltQuoteState.pending
+
+        for _ in range(30):
+            persisted = await ledger.crud.get_melt_quote(
+                quote_id=melt_quote.quote, db=ledger.db
+            )
+            assert persisted is not None
+            if persisted.state == MeltQuoteState.paid:
+                break
+            await asyncio.sleep(0.1)
+        else:
+            pytest.fail("background async melt did not settle before test exit")
+    finally:
+        settings.fakewallet_delay_outgoing_payment = original_delay
+
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not is_fake, reason="only on fakewallet")

--- a/tests/mint/test_async_melt.py
+++ b/tests/mint/test_async_melt.py
@@ -105,18 +105,14 @@ async def test_async_melt_commits_pending_before_returning(ledger):
         assert persisted is not None
         assert persisted.state == MeltQuoteState.pending
 
-        for _ in range(30):
-            persisted = await ledger.crud.get_melt_quote(
-                quote_id=melt_quote.quote, db=ledger.db
-            )
-            assert persisted is not None
-            if persisted.state == MeltQuoteState.paid:
-                break
-            await asyncio.sleep(0.1)
-        else:
-            pytest.fail("background async melt did not settle before test exit")
+        # Wait for the background payment to complete
+        await asyncio.sleep(settings.fakewallet_delay_outgoing_payment + 1)
     finally:
         settings.fakewallet_delay_outgoing_payment = original_delay
+
+    persisted = await ledger.crud.get_melt_quote(quote_id=melt_quote.quote, db=ledger.db)
+    assert persisted is not None
+    assert persisted.state == MeltQuoteState.paid
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Bug Fixes

- `async_melt` now runs part of the process synchronously to update the melt quote record to PENDING before returning the PENDING response. 

This prevents a race condition where a wallet receives a `PENDING` response on the melt quote `POST`, then reads a stale `UNPAID` state on a subsequent poll or subscription. This can cause wallets to revert proofs the mint later spends.

## Changes

- **Melt refactor** — split the monolithic `melt()` into `_prepare_melt()` (validation + set-pending + internal settle) and `_execute_melt_payment()` (Lightning payment + finalize); synchronous melt path behavior is unchanged.

## Testing

- **Pending-commit regression test** — asserts the persisted melt-quote state is already PENDING the moment `async_melt` returns, holding the fake backend payment in-flight to expose the window.