### PR TITLE
fix(docker): restrict redis access to localhost in compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,5 +21,5 @@ services:
     image: redis:latest
     container_name: redis
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     restart: always


### PR DESCRIPTION
This PR binds the Redis port to localhost (127.0.0.1) in the root docker-compose.yaml file to prevent exposing the Redis instance publicly to the internet, resolving potential security scans and attack attempts.