### PR TITLE
fix: await ledger.melt() call in test_melt_quote_reuse_same_outputs

### DIFF
--- a/tests/mint/test_mint_melt.py
+++ b/tests/mint/test_mint_melt.py
@@ -253,7 +253,7 @@ async def test_melt_quote_reuse_same_outputs(wallet, ledger: Ledger):
     change_outputs, change_rs = wallet._construct_outputs(
         n_change_outputs * [1], change_secrets, change_rs
     )
-    (ledger.melt(proofs=proofs1, quote=melt_quote1.quote, outputs=change_outputs),)
+    await ledger.melt(proofs=proofs1, quote=melt_quote1.quote, outputs=change_outputs)
 
     await assert_err(
         ledger.melt(


### PR DESCRIPTION
**Description:** The [melt() ](https://github.com/cashubtc/nutshell/blob/main/tests/mint/test_mint_melt.py#L256) call was wrapped in a trailing-comma tuple, which created the coroutine but never awaited it. This led to a silent no-op, meaning the test wasn't actually exercising the output-reuse scenario it claims to test.

Fixes: coroutine 'Ledger.melt' was never awaited (RuntimeWarning)

**Change:**

```diff
@@ -253,7 +253,7 @@ async def test_melt_quote_reuse_same_outputs(wallet, ledger: Ledger):
     change_outputs, change_rs = wallet._construct_outputs(
         n_change_outputs * [1], change_secrets, change_rs
     )
-    (ledger.melt(proofs=proofs1, quote=melt_quote1.quote, outputs=change_outputs),)
+    await ledger.melt(proofs=proofs1, quote=melt_quote1.quote, outputs=change_outputs)
```

**Testing:**

```sh
pytest tests/mint/test_mint_melt.py::test_melt_quote_reuse_same_outputs
```
