### PR TITLE
fix: complete remaining Pydantic v1 to v2 migration

### DIFF
--- a/cashu/mint/management_rpc/management_rpc.py
+++ b/cashu/mint/management_rpc/management_rpc.py
@@ -140,7 +140,7 @@ class MintManagementRPC(management_pb2_grpc.MintServicer):
     async def GetNut04Quote(self, request, _):
         logger.debug("gRPC GetNut04Quote has been called")
         mint_quote = await self.ledger.get_mint_quote(request.quote_id)
-        mint_quote_dict = mint_quote.dict()
+        mint_quote_dict = mint_quote.model_dump()
         mint_quote_dict['state'] = str(mint_quote.state)
         mint_quote_dict.pop('state_val', None)
         del mint_quote_dict['mint'] # unused
@@ -162,7 +162,7 @@ class MintManagementRPC(management_pb2_grpc.MintServicer):
     async def GetNut05Quote(self, request, _):
         logger.debug("gRPC GetNut05Quote has been called")
         melt_quote = await self.ledger.get_melt_quote(request.quote_id)
-        melt_quote_dict = melt_quote.dict()
+        melt_quote_dict = melt_quote.model_dump()
         melt_quote_dict['state'] = str(melt_quote_dict['state'])
         del melt_quote_dict['mint']
         return management_pb2.GetNut05QuoteResponse(

--- a/cashu/mint/startup.py
+++ b/cashu/mint/startup.py
@@ -27,7 +27,7 @@ if not __debug__:
     raise Exception("Nutshell cannot run in non-debug mode.")
 
 logger.debug("Enviroment Settings:")
-for key, value in settings.dict().items():
+for key, value in settings.model_dump().items():
     if key in [
         "mint_private_key",
         "mint_seed_decryption_key",


### PR DESCRIPTION
**Summary:** This is a follow-up PR that was raised from #850 and addressed by #866

**Motivation:** The initial Pydantic v1 to v2 migration left a few deprecated v1 methods in the codebase, resulting in deprecation warnings. This follow-up completes the [migration](https://pydantic.dev/docs/validation/latest/get-started/migration/#migration-guide) by replacing pydantic's **_dict()_** with its equivalent **_model_dump_**

**Testing:** 

```sh
pytest tests/mint/test_mint_management_rpc.py::test_nut04_quote tests/mint/test_mint_management_rpc_server.py::test_get_and_update_quote_rpcs
```