### PR TITLE
refactor(mint): recalculate DLEQs on restore

### DIFF
--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -274,7 +274,6 @@ class BlindedSignature(BaseModel):
             id=row["id"],
             amount=row["amount"],
             C_=row["c_"],
-            dleq=DLEQ(e=row["dleq_e"], s=row["dleq_s"]),
         )
 
 

--- a/cashu/mint/auth/crud.py
+++ b/cashu/mint/auth/crud.py
@@ -124,8 +124,6 @@ class AuthLedgerCrud(ABC):
         b_: str,
         c_: str,
         id: str,
-        e: str = "",
-        s: str = "",
         conn: Optional[Connection] = None,
     ) -> None: ...
 
@@ -214,22 +212,18 @@ class AuthLedgerCrudSqlite(AuthLedgerCrud):
         b_: str,
         c_: str,
         id: str,
-        e: str = "",
-        s: str = "",
         conn: Optional[Connection] = None,
     ) -> None:
         await (conn or db).execute(
             f"""
             INSERT INTO {db.table_with_schema('promises')}
-            (amount, b_, c_, dleq_e, dleq_s, id, created)
-            VALUES (:amount, :b_, :c_, :dleq_e, :dleq_s, :id, :created)
+            (amount, b_, c_, id, created)
+            VALUES (:amount, :b_, :c_, :id, :created)
             """,
             {
                 "amount": amount,
                 "b_": b_,
                 "c_": c_,
-                "dleq_e": e,
-                "dleq_s": s,
                 "id": id,
                 "created": db.to_timestamp(db.timestamp_now_str()),
             },

--- a/cashu/mint/auth/migrations.py
+++ b/cashu/mint/auth/migrations.py
@@ -127,3 +127,14 @@ async def m003_add_final_expiry_to_keysets(db: Database):
                 ADD COLUMN final_expiry INTEGER NULL
             """
         )
+
+
+async def m004_remove_dleq_from_promises(db: Database):
+    """Remove deterministically generated DLEQ proofs from persisted promises."""
+    async with db.connect() as conn:
+        await conn.execute(
+            f"ALTER TABLE {db.table_with_schema('promises')} DROP COLUMN dleq_e"
+        )
+        await conn.execute(
+            f"ALTER TABLE {db.table_with_schema('promises')} DROP COLUMN dleq_s"
+        )

--- a/cashu/mint/crud.py
+++ b/cashu/mint/crud.py
@@ -183,8 +183,6 @@ class LedgerCrud(ABC):
         amount: int,
         b_: str,
         c_: str,
-        e: str = "",
-        s: str = "",
         conn: Optional[Connection] = None,
     ) -> None: ...
 
@@ -443,15 +441,13 @@ class LedgerCrudSqlite(LedgerCrud):
         await (conn or db).execute(
             f"""
             UPDATE {db.table_with_schema("promises")}
-            SET amount = :amount, c_ = :c_, dleq_e = :dleq_e, dleq_s = :dleq_s, signed_at = :signed_at
+            SET amount = :amount, c_ = :c_, signed_at = :signed_at
             WHERE b_ = :b_;
             """,
             {
                 "b_": b_,
                 "amount": amount,
                 "c_": c_,
-                "dleq_e": e,
-                "dleq_s": s,
                 "signed_at": db.to_timestamp(db.timestamp_now_str()),
             },
         )

--- a/cashu/mint/crud.py
+++ b/cashu/mint/crud.py
@@ -427,8 +427,6 @@ class LedgerCrudSqlite(LedgerCrud):
         amount: int,
         b_: str,
         c_: str,
-        e: str = "",
-        s: str = "",
         conn: Optional[Connection] = None,
     ) -> None:
         existing = await (conn or db).fetchone(

--- a/cashu/mint/crud.py
+++ b/cashu/mint/crud.py
@@ -192,6 +192,7 @@ class LedgerCrud(ABC):
         *,
         db: Database,
         melt_id: str,
+        signed: bool = False,
         conn: Optional[Connection] = None,
     ) -> List[BlindedMessage]: ...
 
@@ -370,12 +371,14 @@ class LedgerCrudSqlite(LedgerCrud):
         *,
         db: Database,
         melt_id: str,
+        signed: bool = False,
         conn: Optional[Connection] = None,
     ) -> List[BlindedMessage]:
         rows = await (conn or db).fetchall(
             f"""
             SELECT * from {db.table_with_schema("promises")}
-            WHERE melt_quote = :melt_id AND c_ IS NULL
+            WHERE melt_quote = :melt_id
+                AND c_ IS {'NOT NULL' if signed else 'NULL'}
             ORDER BY order_index ASC
             """,
             {"melt_id": melt_id},

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -1340,6 +1340,15 @@ class Ledger(
                     b_=output.B_, db=self.db, conn=conn
                 )
                 if promise is not None:
+                    B_ = PublicKey(bytes.fromhex(output.B_))
+                    keyset = self.keysets[promise.id]
+                    private_key_amount = keyset.private_keys[promise.amount]
+                    C_, e, s = b_dhke.step2_bob(B_, private_key_amount)
+                    if C_.format().hex() != promise.C_:
+                        raise TransactionError(
+                            "restored signature does not match promise"
+                        )
+                    promise.dleq = DLEQ(e=e.to_hex(), s=s.to_hex())
                     signatures.append(promise)
                     return_outputs.append(output)
                     logger.trace(f"promise found: {promise}")
@@ -1435,8 +1444,6 @@ class Ledger(
                     amount=amount,
                     b_=B_.format().hex(),
                     c_=C_.format().hex(),
-                    e=e.to_hex(),
-                    s=s.to_hex(),
                     db=self.db,
                     conn=conn,
                 )

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -1359,7 +1359,13 @@ class Ledger(
 
     def _generate_dleq(self, output: BlindedMessage, promise: BlindedSignature) -> DLEQ:
         B_ = PublicKey(bytes.fromhex(output.B_))
+        if promise.id not in self.keysets:
+            raise TransactionError(f"keyset {promise.id} not found")
         keyset = self.keysets[promise.id]
+        if promise.amount not in keyset.private_keys:
+            raise TransactionError(
+                f"keyset {promise.id} does not support amount {promise.amount}"
+            )
         private_key_amount = keyset.private_keys[promise.amount]
         C_, e, s = b_dhke.step2_bob(B_, private_key_amount)
         if C_.format().hex() != promise.C_:

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -855,6 +855,15 @@ class Ledger(
         if not melt_quote:
             raise Exception("quote not found")
 
+        if melt_quote.change:
+            change_outputs = await self.crud.get_blinded_messages_melt_id(
+                melt_id=quote_id, db=self.db, signed=True
+            )
+            if len(change_outputs) != len(melt_quote.change):
+                raise TransactionError("could not reconstruct melt change promises")
+            for output, promise in zip(change_outputs, melt_quote.change):
+                promise.dleq = self._generate_dleq(output, promise)
+
         unit, method = self._verify_and_get_unit_method(
             melt_quote.unit, melt_quote.method
         )

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -1340,21 +1340,22 @@ class Ledger(
                     b_=output.B_, db=self.db, conn=conn
                 )
                 if promise is not None:
-                    B_ = PublicKey(bytes.fromhex(output.B_))
-                    keyset = self.keysets[promise.id]
-                    private_key_amount = keyset.private_keys[promise.amount]
-                    C_, e, s = b_dhke.step2_bob(B_, private_key_amount)
-                    if C_.format().hex() != promise.C_:
-                        raise TransactionError(
-                            "restored signature does not match promise"
-                        )
-                    promise.dleq = DLEQ(e=e.to_hex(), s=s.to_hex())
+                    promise.dleq = self._generate_dleq(output, promise)
                     signatures.append(promise)
                     return_outputs.append(output)
                     logger.trace(f"promise found: {promise}")
         return return_outputs, signatures
 
     # ------- BLIND SIGNATURES -------
+
+    def _generate_dleq(self, output: BlindedMessage, promise: BlindedSignature) -> DLEQ:
+        B_ = PublicKey(bytes.fromhex(output.B_))
+        keyset = self.keysets[promise.id]
+        private_key_amount = keyset.private_keys[promise.amount]
+        C_, e, s = b_dhke.step2_bob(B_, private_key_amount)
+        if C_.format().hex() != promise.C_:
+            raise TransactionError("restored signature does not match promise")
+        return DLEQ(e=e.to_hex(), s=s.to_hex())
 
     async def _store_blinded_messages(
         self,

--- a/cashu/mint/migrations.py
+++ b/cashu/mint/migrations.py
@@ -1327,3 +1327,14 @@ async def m037_remove_paid_from_melt_quote(db: Database):
             await conn.execute(
                 f"ALTER TABLE {db.table_with_schema('melt_quotes')} DROP COLUMN IF EXISTS paid"
             )
+
+
+async def m038_remove_dleq_from_promises(db: Database):
+    """Remove deterministically generated DLEQ proofs from persisted promises."""
+    async with db.connect() as conn:
+        await conn.execute(
+            f"ALTER TABLE {db.table_with_schema('promises')} DROP COLUMN dleq_e"
+        )
+        await conn.execute(
+            f"ALTER TABLE {db.table_with_schema('promises')} DROP COLUMN dleq_s"
+        )

--- a/tests/mint/test_mint_api.py
+++ b/tests/mint/test_mint_api.py
@@ -572,6 +572,10 @@ async def test_api_restore(ledger: Ledger, wallet: Wallet):
         secret_counter - 1, secret_counter - 1
     )
     outputs, rs = wallet._construct_outputs([64], secrets, rs)
+    original_proof = next(
+        proof for proof in wallet.proofs if proof.secret == secrets[0]
+    )
+    assert original_proof.dleq
 
     payload = PostRestoreRequest(outputs=outputs)
     response = httpx.post(
@@ -587,6 +591,16 @@ async def test_api_restore(ledger: Ledger, wallet: Wallet):
     assert len(restore_response.signatures) == 1
     assert len(restore_response.outputs) == 1
     assert restore_response.outputs == outputs
+    assert restore_response.signatures[0].dleq
+    assert restore_response.signatures[0].dleq.e == original_proof.dleq.e
+    assert restore_response.signatures[0].dleq.s == original_proof.dleq.s
+
+    async with ledger.db.connect() as conn:
+        columns = await conn.fetchall(
+            f"PRAGMA table_info({ledger.db.table_with_schema('promises')})"
+        )
+    assert "dleq_e" not in {column["name"] for column in columns}
+    assert "dleq_s" not in {column["name"] for column in columns}
 
 
 @pytest.mark.asyncio

--- a/tests/mint/test_mint_api.py
+++ b/tests/mint/test_mint_api.py
@@ -595,13 +595,6 @@ async def test_api_restore(ledger: Ledger, wallet: Wallet):
     assert restore_response.signatures[0].dleq.e == original_proof.dleq.e
     assert restore_response.signatures[0].dleq.s == original_proof.dleq.s
 
-    async with ledger.db.connect() as conn:
-        columns = await conn.fetchall(
-            f"PRAGMA table_info({ledger.db.table_with_schema('promises')})"
-        )
-    assert "dleq_e" not in {column["name"] for column in columns}
-    assert "dleq_s" not in {column["name"] for column in columns}
-
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(

--- a/tests/mint/test_mint_db_operations.py
+++ b/tests/mint/test_mint_db_operations.py
@@ -2,7 +2,7 @@ import asyncio
 import datetime
 import os
 import time
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import pytest
 import pytest_asyncio
@@ -380,15 +380,13 @@ async def test_store_and_sign_blinded_message(ledger: Ledger):
     # Act: compute a valid blind signature for the stored row and persist it
     private_key_amount = ledger.keyset.private_keys[amount]
     B_point = PublicKey(bytes.fromhex(B_hex))
-    C_point, e, s = step2_bob(B_point, private_key_amount)
+    C_point, _, _ = step2_bob(B_point, private_key_amount)
 
     await ledger.crud.update_blinded_message_signature(
         db=ledger.db,
         amount=amount,
         b_=B_hex,
         c_=C_point.format().hex(),
-        e=e.to_hex(),
-        s=s.to_hex(),
     )
 
     # Assert: row is now a full promise and can be read back via get_blind_signature
@@ -397,6 +395,36 @@ async def test_store_and_sign_blinded_message(ledger: Ledger):
     assert promise.amount == amount
     assert promise.C_ == C_point.format().hex()
     assert promise.id == keyset_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("keyset_id", "amount", "error"),
+    [
+        ("unknown-keyset", 1, "keyset unknown-keyset not found"),
+        (None, 3, "does not support amount 3"),
+    ],
+)
+async def test_generate_dleq_rejects_unavailable_key(
+    ledger: Ledger, keyset_id: Optional[str], amount: int, error: str
+):
+    from cashu.core.base import BlindedMessage, BlindedSignature
+    from cashu.core.crypto.b_dhke import step1_alice, step2_bob
+    from cashu.core.errors import TransactionError
+
+    B_, _ = step1_alice("unavailable-key")
+    C_, _, _ = step2_bob(B_, ledger.keyset.private_keys[1])
+    output = BlindedMessage(
+        amount=amount, id=keyset_id or ledger.keyset.id, B_=B_.format().hex()
+    )
+    promise = BlindedSignature(
+        amount=amount,
+        id=keyset_id or ledger.keyset.id,
+        C_=C_.format().hex(),
+    )
+
+    with pytest.raises(TransactionError, match=error):
+        ledger._generate_dleq(output, promise)
 
 
 @pytest.mark.asyncio
@@ -509,14 +537,12 @@ async def test_get_blinded_messages_by_melt_id_filters_signed(
 
     # Sign one of them (it should no longer be returned by get_blinded_messages_melt_id which filters c_ IS NULL)
     priv = ledger.keyset.private_keys[amount]
-    C_point, e, s = step2_bob(PublicKey(bytes.fromhex(b1_hex)), priv)
+    C_point, _, _ = step2_bob(PublicKey(bytes.fromhex(b1_hex)), priv)
     await ledger.crud.update_blinded_message_signature(
         db=ledger.db,
         amount=amount,
         b_=b1_hex,
         c_=C_point.format().hex(),
-        e=e.to_hex(),
-        s=s.to_hex(),
     )
 
     # Act
@@ -570,7 +596,7 @@ async def test_update_blinded_message_signature_before_store_blinded_message_err
 
     # Create a valid signature tuple for that blinded message
     priv = ledger.keyset.private_keys[amount]
-    C_point, e, s = step2_bob(PublicKey(bytes.fromhex(b_hex)), priv)
+    C_point, _, _ = step2_bob(PublicKey(bytes.fromhex(b_hex)), priv)
 
     # Expect a DB-level error; on SQLite/Postgres this is typically a no-op update, so this test is xfail.
     await assert_err(
@@ -579,8 +605,6 @@ async def test_update_blinded_message_signature_before_store_blinded_message_err
             amount=amount,
             b_=b_hex,
             c_=C_point.format().hex(),
-            e=e.to_hex(),
-            s=s.to_hex(),
         ),
         "blinded message does not exist",
     )
@@ -632,14 +656,12 @@ async def test_get_blind_signatures_by_melt_id_returns_signed(
 
     # Sign only one of them -> should be returned by get_blind_signatures_melt_id
     priv = ledger.keyset.private_keys[amount]
-    C_point, e, s = step2_bob(PublicKey(bytes.fromhex(b1_hex)), priv)
+    C_point, _, _ = step2_bob(PublicKey(bytes.fromhex(b1_hex)), priv)
     await ledger.crud.update_blinded_message_signature(
         db=ledger.db,
         amount=amount,
         b_=b1_hex,
         c_=C_point.format().hex(),
-        e=e.to_hex(),
-        s=s.to_hex(),
     )
 
     # Act
@@ -657,7 +679,7 @@ async def test_get_blind_signatures_by_melt_id_returns_signed(
 async def test_get_melt_quote_preserves_change_signatures_order(
     wallet: Wallet, ledger: Ledger
 ):
-    from cashu.core.crypto.b_dhke import step1_alice, step2_bob
+    from cashu.core.crypto.b_dhke import step1_alice
     from cashu.core.crypto.secp import PublicKey
 
     amount = 8
@@ -689,8 +711,6 @@ async def test_get_melt_quote_preserves_change_signatures_order(
         )
 
         # Sign it right away so it is returned in change
-        priv = ledger.keyset.private_keys[amount]
-        _, e, s = step2_bob(PublicKey(bytes.fromhex(b_values[idx])), priv)
         await ledger.crud.update_blinded_message_signature(
             db=ledger.db,
             amount=amount,
@@ -698,8 +718,6 @@ async def test_get_melt_quote_preserves_change_signatures_order(
             c_=PublicKey(bytes.fromhex(b_values[idx]))
             .format()
             .hex(),  # Mock C_ just to not be NULL
-            e=e.to_hex(),
-            s=s.to_hex(),
         )
 
     # Act
@@ -758,8 +776,6 @@ async def test_get_melt_quote_includes_change_signatures(
         amount=amount,
         b_=b1_hex,
         c_=C_point.format().hex(),
-        e=e.to_hex(),
-        s=s.to_hex(),
     )
 
     # Act

--- a/tests/mint/test_mint_db_operations.py
+++ b/tests/mint/test_mint_db_operations.py
@@ -687,7 +687,7 @@ async def test_get_melt_quote_preserves_change_signatures_order(
             melt_id=melt_id,
             order_index=idx,
         )
-        
+
         # Sign it right away so it is returned in change
         priv = ledger.keyset.private_keys[amount]
         _, e, s = step2_bob(PublicKey(bytes.fromhex(b_values[idx])), priv)
@@ -695,9 +695,11 @@ async def test_get_melt_quote_preserves_change_signatures_order(
             db=ledger.db,
             amount=amount,
             b_=b_values[idx],
-            c_=PublicKey(bytes.fromhex(b_values[idx])).format().hex(), # Mock C_ just to not be NULL
+            c_=PublicKey(bytes.fromhex(b_values[idx]))
+            .format()
+            .hex(),  # Mock C_ just to not be NULL
             e=e.to_hex(),
-            s=s.to_hex()
+            s=s.to_hex(),
         )
 
     # Act
@@ -707,12 +709,15 @@ async def test_get_melt_quote_preserves_change_signatures_order(
     assert quote_db is not None
     assert quote_db.change is not None
     assert len(quote_db.change) == 5
-    
+
     # We check if we can reconstruct the original B_ mapping using the DB again (to verify test mock is valid)
     # However we can just verify that C_ values matches what we inserted
     # Since we mocked C_ to be the same as B_ in our test
     for i in range(5):
-        assert quote_db.change[i].C_ == b_values[i], f"Change signature at index {i} is out of order"
+        assert (
+            quote_db.change[i].C_ == b_values[i]
+        ), f"Change signature at index {i} is out of order"
+
 
 @pytest.mark.asyncio
 async def test_get_melt_quote_includes_change_signatures(
@@ -767,6 +772,13 @@ async def test_get_melt_quote_includes_change_signatures(
     assert len(quote_db.change) == 1
     assert quote_db.change[0].amount == amount
     assert quote_db.change[0].id == keyset_id
+
+    # The public retrieval path deterministically reconstructs the dropped DLEQ.
+    quote = await ledger.get_melt_quote(melt_id)
+    assert quote.change is not None
+    assert quote.change[0].dleq is not None
+    assert quote.change[0].dleq.e == e.to_hex()
+    assert quote.change[0].dleq.s == s.to_hex()
 
 
 @pytest.mark.asyncio
@@ -868,31 +880,39 @@ async def test_concurrent_set_melt_quote_pending_same_checking_id(ledger: Ledger
     error = next(r for r in results if isinstance(r, Exception))
     assert "Melt quote already paid or pending." in str(error)
 
+
 # === CONCURRENCY TESTS FOR PARAMETERIZED ROW LOCKS ===
+
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(
     is_github_actions,
     reason=("Fails on GitHub Actions for regtest + SQLite"),
 )
-async def test_concurrent_set_mint_quote_pending_same_quote(wallet: Wallet, ledger: Ledger):
+async def test_concurrent_set_mint_quote_pending_same_quote(
+    wallet: Wallet, ledger: Ledger
+):
     mint_quote = await wallet.request_mint(64)
     await pay_if_regtest(mint_quote.request)
     _ = await ledger.get_mint_quote(mint_quote.quote)
     # Get quote object
     quote = await ledger.crud.get_mint_quote(quote_id=mint_quote.quote, db=ledger.db)
-    
+
     results = await asyncio.gather(
         ledger.db_write._set_mint_quote_pending(quote.quote),
         ledger.db_write._set_mint_quote_pending(quote.quote),
-        return_exceptions=True
+        return_exceptions=True,
     )
     success = sum(1 for r in results if not isinstance(r, Exception))
     errors = [r for r in results if isinstance(r, Exception)]
     assert success == 1, f"Expected 1 success, got {success}. Errors: {errors}"
     assert len(errors) == 1, f"Expected 1 error, got {len(errors)}"
     err_str = str(errors[0])
-    assert "lock" in err_str.lower() or "pending" in err_str.lower() or "locked" in err_str.lower(), f"Unexpected error: {err_str}"
+    assert (
+        "lock" in err_str.lower()
+        or "pending" in err_str.lower()
+        or "locked" in err_str.lower()
+    ), f"Unexpected error: {err_str}"
 
 
 @pytest.mark.asyncio
@@ -900,18 +920,20 @@ async def test_concurrent_set_mint_quote_pending_same_quote(wallet: Wallet, ledg
     is_github_actions,
     reason=("Fails on GitHub Actions for regtest + SQLite"),
 )
-async def test_concurrent_set_mint_quote_pending_different_quotes(wallet: Wallet, ledger: Ledger):
+async def test_concurrent_set_mint_quote_pending_different_quotes(
+    wallet: Wallet, ledger: Ledger
+):
     mint_quote1 = await wallet.request_mint(64)
     mint_quote2 = await wallet.request_mint(64)
     await pay_if_regtest(mint_quote1.request)
     await pay_if_regtest(mint_quote2.request)
     _ = await ledger.get_mint_quote(mint_quote1.quote)
     _ = await ledger.get_mint_quote(mint_quote2.quote)
-    
+
     results = await asyncio.gather(
         ledger.db_write._set_mint_quote_pending(mint_quote1.quote),
         ledger.db_write._set_mint_quote_pending(mint_quote2.quote),
-        return_exceptions=True
+        return_exceptions=True,
     )
     errors = [r for r in results if isinstance(r, Exception)]
     assert len(errors) == 0, f"Expected 0 errors, got: {errors}"
@@ -922,24 +944,31 @@ async def test_concurrent_set_mint_quote_pending_different_quotes(wallet: Wallet
     is_github_actions,
     reason=("Fails on GitHub Actions for regtest + SQLite"),
 )
-async def test_concurrent_set_melt_quote_pending_same_quote(wallet: Wallet, ledger: Ledger):
+async def test_concurrent_set_melt_quote_pending_same_quote(
+    wallet: Wallet, ledger: Ledger
+):
     mint_quote = await wallet.request_mint(64)
     melt_quote = await ledger.melt_quote(
         PostMeltQuoteRequest(request=mint_quote.request, unit="sat")
     )
     quote_db = await ledger.crud.get_melt_quote(quote_id=melt_quote.quote, db=ledger.db)
-    
+
     results = await asyncio.gather(
         ledger.db_write._set_melt_quote_pending(quote_db),
         ledger.db_write._set_melt_quote_pending(quote_db),
-        return_exceptions=True
+        return_exceptions=True,
     )
     success = sum(1 for r in results if not isinstance(r, Exception))
     errors = [r for r in results if isinstance(r, Exception)]
     assert success == 1, f"Expected 1 success, got {success}. Errors: {errors}"
     assert len(errors) == 1, f"Expected 1 error, got {len(errors)}"
     err_str = str(errors[0])
-    assert "lock" in err_str.lower() or "pending" in err_str.lower() or "locked" in err_str.lower() or "paid" in err_str.lower(), f"Unexpected error: {err_str}"
+    assert (
+        "lock" in err_str.lower()
+        or "pending" in err_str.lower()
+        or "locked" in err_str.lower()
+        or "paid" in err_str.lower()
+    ), f"Unexpected error: {err_str}"
 
 
 @pytest.mark.asyncio
@@ -947,7 +976,9 @@ async def test_concurrent_set_melt_quote_pending_same_quote(wallet: Wallet, ledg
     is_github_actions,
     reason=("Fails on GitHub Actions for regtest + SQLite"),
 )
-async def test_concurrent_set_melt_quote_pending_different_quotes(wallet: Wallet, ledger: Ledger):
+async def test_concurrent_set_melt_quote_pending_different_quotes(
+    wallet: Wallet, ledger: Ledger
+):
     mint_quote1 = await wallet.request_mint(64)
     mint_quote2 = await wallet.request_mint(64)
     melt_quote1 = await ledger.melt_quote(
@@ -956,13 +987,17 @@ async def test_concurrent_set_melt_quote_pending_different_quotes(wallet: Wallet
     melt_quote2 = await ledger.melt_quote(
         PostMeltQuoteRequest(request=mint_quote2.request, unit="sat")
     )
-    quote_db1 = await ledger.crud.get_melt_quote(quote_id=melt_quote1.quote, db=ledger.db)
-    quote_db2 = await ledger.crud.get_melt_quote(quote_id=melt_quote2.quote, db=ledger.db)
-    
+    quote_db1 = await ledger.crud.get_melt_quote(
+        quote_id=melt_quote1.quote, db=ledger.db
+    )
+    quote_db2 = await ledger.crud.get_melt_quote(
+        quote_id=melt_quote2.quote, db=ledger.db
+    )
+
     results = await asyncio.gather(
         ledger.db_write._set_melt_quote_pending(quote_db1),
         ledger.db_write._set_melt_quote_pending(quote_db2),
-        return_exceptions=True
+        return_exceptions=True,
     )
     errors = [r for r in results if isinstance(r, Exception)]
     assert len(errors) == 0, f"Expected 0 errors, got: {errors}"
@@ -977,22 +1012,27 @@ async def test_concurrent_swap_same_proofs(wallet: Wallet, ledger: Ledger):
     mint_quote = await wallet.request_mint(64)
     await pay_if_regtest(mint_quote.request)
     await wallet.mint(64, quote_id=mint_quote.quote)
-    
+
     secrets, rs, _ = await wallet.generate_n_secrets(2)
     outputs, _ = wallet._construct_outputs([32, 32], secrets, rs)
-    
+
     results = await asyncio.gather(
         ledger.swap(proofs=wallet.proofs, outputs=outputs),
         ledger.swap(proofs=wallet.proofs, outputs=outputs),
-        return_exceptions=True
+        return_exceptions=True,
     )
-    
+
     success = sum(1 for r in results if not isinstance(r, Exception))
     errors = [r for r in results if isinstance(r, Exception)]
     assert success == 1, f"Expected 1 success, got {success}. Errors: {errors}"
     assert len(errors) == 1, f"Expected 1 error, got {len(errors)}"
     err_str = str(errors[0])
-    assert "lock" in err_str.lower() or "pending" in err_str.lower() or "locked" in err_str.lower() or "spent" in err_str.lower(), f"Unexpected error: {err_str}"
+    assert (
+        "lock" in err_str.lower()
+        or "pending" in err_str.lower()
+        or "locked" in err_str.lower()
+        or "spent" in err_str.lower()
+    ), f"Unexpected error: {err_str}"
 
 
 @pytest.mark.asyncio
@@ -1004,20 +1044,20 @@ async def test_concurrent_swap_different_proofs(wallet: Wallet, ledger: Ledger):
     mint_quote = await wallet.request_mint(64)
     await pay_if_regtest(mint_quote.request)
     await wallet.mint(64, quote_id=mint_quote.quote, split=[32, 32])
-    
+
     proofs1 = wallet.proofs[:1]
     proofs2 = wallet.proofs[1:]
-    
+
     secrets1, rs1, _ = await wallet.generate_n_secrets(1)
     outputs1, _ = wallet._construct_outputs([32], secrets1, rs1)
-    
+
     secrets2, rs2, _ = await wallet.generate_n_secrets(1)
     outputs2, _ = wallet._construct_outputs([32], secrets2, rs2)
-    
+
     results = await asyncio.gather(
         ledger.swap(proofs=proofs1, outputs=outputs1),
         ledger.swap(proofs=proofs2, outputs=outputs2),
-        return_exceptions=True
+        return_exceptions=True,
     )
     errors = [r for r in results if isinstance(r, Exception)]
     assert len(errors) == 0, f"Expected 0 errors, got: {errors}"

--- a/tests/mint/test_mint_migrations.py
+++ b/tests/mint/test_mint_migrations.py
@@ -6,6 +6,21 @@ from cashu.mint import migrations as mint_migrations
 
 
 @pytest.mark.asyncio
+async def test_m038_remove_dleq_from_promises(tmp_path):
+    db = Database("mint", str(tmp_path / "mint"))
+    await migrate_databases(db, mint_migrations)
+
+    async with db.connect() as conn:
+        columns = await conn.fetchall(
+            f"PRAGMA table_info({db.table_with_schema('promises')})"
+        )
+
+    column_names = {column["name"] for column in columns}
+    assert "dleq_e" not in column_names
+    assert "dleq_s" not in column_names
+
+
+@pytest.mark.asyncio
 async def test_m029_witness_cleanup():
     db = Database("mint", "./test_data/mig_witness_cleanup")
 


### PR DESCRIPTION
## Summary

- stop persisting deterministic DLEQ proof values with mint promises
- drop the `dleq_e` and `dleq_s` columns from mint and auth-mint databases
- regenerate and validate DLEQ proofs when a client calls the restore endpoint
- verify restored deterministic proofs match the originally issued proofs

## Rationale

DLEQ nonces are now derived deterministically from the mint private key and proof context. The mint can therefore reconstruct the proof from the stored blinded signature metadata and keyset instead of retaining `e` and `s` in the database.

Promises issued before deterministic nonce generation may receive a different DLEQ after restore. This remains valid: DLEQ proof serialization is not an identity for the blind signature, and clients verify the returned proof against the unchanged `A`, `B'`, and `C'` values.

## Review notes

This includes database migrations and cryptographic proof handling, so it requires maintainer review under the repository contribution guidance. The migration only removes derived proof data; it does not alter stored blind signatures or key material.

## Testing

- `poetry run pytest tests/mint/test_mint_migrations.py tests/mint/test_mint_api.py::test_api_restore -q` — 3 passed
- `make check` — Ruff and mypy passed
