### PR TITLE
fix(mint): commit PENDING before async melt response

### DIFF
--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -1024,31 +1024,28 @@ class Ledger(
     ) -> PostMeltQuoteResponse:
         """Invalidates proofs and pays a Lightning invoice asynchronously.
 
+        Locks the melt quote and proofs as PENDING before returning, then runs
+        the Lightning payment in the background.
+
         Args:
             proofs (List[Proof]): Proofs provided for paying the Lightning invoice
             quote (str): ID of the melt quote.
             outputs (Optional[List[BlindedMessage]]): Blank outputs for returning overpaid fees to the wallet.
 
         Returns:
-            PostMeltQuoteResponse: Melt quote response with pending state.
+            PostMeltQuoteResponse: Melt quote response after PENDING is committed.
         """
-        # get melt quote
-        melt_quote = await self.get_melt_quote(quote_id=quote)
-        if not melt_quote:
-            raise TransactionError("melt quote not found")
-        if not melt_quote.unpaid:
-            raise TransactionError(f"melt quote is not unpaid: {melt_quote.state}")
+        melt_quote = await self._prepare_melt(
+            proofs=proofs, quote=quote, outputs=outputs
+        )
 
-        # Launch actual melt task
         async def melt_task():
             try:
-                await self.melt(proofs=proofs, quote=quote, outputs=outputs)
+                await self._execute_melt_payment(melt_quote, proofs, outputs)
             except Exception as e:
                 logger.error(f"Error in background melt task: {e}")
 
         asyncio.create_task(melt_task())
-
-        melt_quote.state = MeltQuoteState.pending
         return PostMeltQuoteResponse.from_melt_quote(melt_quote)
 
     async def melt(
@@ -1071,6 +1068,19 @@ class Ledger(
         Returns:
             PostMeltQuoteResponse: Melt quote response.
         """
+        melt_quote = await self._prepare_melt(
+            proofs=proofs, quote=quote, outputs=outputs
+        )
+        return await self._execute_melt_payment(melt_quote, proofs, outputs)
+
+    async def _prepare_melt(
+        self,
+        *,
+        proofs: List[Proof],
+        quote: str,
+        outputs: Optional[List[BlindedMessage]] = None,
+    ) -> MeltQuote:
+        """Validates a melt request and durably sets the quote and proofs to pending."""
         # make sure we're allowed to melt
         if self.disable_melt and settings.mint_disable_melt_on_error:
             raise NotAllowedError("Melt is disabled. Please contact the operator.")
@@ -1080,9 +1090,7 @@ class Ledger(
         if not melt_quote.unpaid:
             raise TransactionError(f"melt quote is not unpaid: {melt_quote.state}")
 
-        unit, method = self._verify_and_get_unit_method(
-            melt_quote.unit, melt_quote.method
-        )
+        unit, _ = self._verify_and_get_unit_method(melt_quote.unit, melt_quote.method)
 
         # make sure that the proofs are in the same unit as the quote
         self._verify_proofs_unit(proofs, expected_unit=unit)
@@ -1127,7 +1135,32 @@ class Ledger(
             # store the change outputs
             if outputs:
                 await self._store_blinded_messages(outputs, melt_id=melt_quote.quote)
+        except Exception as e:
+            logger.debug(f"Melt failed before backend payment: {e}")
+            await self.db_write.unset_melt_quote_pending_and_proofs(
+                quote=melt_quote,
+                proofs=proofs,
+                keysets=self.keysets,
+                state=MeltQuoteState.unpaid,
+            )
+            raise e
 
+        return melt_quote
+
+    async def _execute_melt_payment(
+        self,
+        melt_quote: MeltQuote,
+        proofs: List[Proof],
+        outputs: Optional[List[BlindedMessage]],
+    ) -> PostMeltQuoteResponse:
+        """Pays the Lightning invoice for a pending melt quote and finalizes it."""
+        unit, method = self._verify_and_get_unit_method(
+            melt_quote.unit, melt_quote.method
+        )
+        input_fees = self.get_fees_for_proofs(proofs)
+        fee_reserve_provided = sum_proofs(proofs) - melt_quote.amount - input_fees
+
+        try:
             # if the melt corresponds to an internal mint, mark both as paid
             melt_quote = await self.melt_mint_settle_internally(melt_quote, proofs)
         except Exception as e:

--- a/tests/mint/test_async_melt.py
+++ b/tests/mint/test_async_melt.py
@@ -3,11 +3,14 @@ import asyncio
 import httpx
 import pytest
 
-from cashu.core.base import MeltQuoteState
+from cashu.core.base import Amount, MeltQuoteState, Method, Unit
+from cashu.core.models import PostMeltQuoteRequest
+from cashu.core.settings import settings
 from tests.conftest import SERVER_ENDPOINT
 from tests.helpers import is_fake, pay_if_regtest
 
 BASE_URL = "http://localhost:3337"
+
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not is_fake, reason="only on fakewallet")
@@ -15,7 +18,12 @@ async def test_async_melt(ledger):
     # This test uses direct API calls because the wallet fixture issue
     # for async melt is complex in this setup.
     from cashu.wallet.wallet import Wallet
-    wallet = await Wallet.with_db(url=SERVER_ENDPOINT, db="test_data/wallet_async_melt", name="wallet_async_melt")
+
+    wallet = await Wallet.with_db(
+        url=SERVER_ENDPOINT,
+        db="test_data/wallet_async_melt",
+        name="wallet_async_melt",
+    )
     await wallet.load_mint()
 
     # Setup: get some funds
@@ -45,15 +53,89 @@ async def test_async_melt(ledger):
     assert response.status_code == 200
     result = response.json()
     assert result["state"] == MeltQuoteState.pending.value
-    
+
     # Wait a bit for the background task to complete
     await asyncio.sleep(2)
-    
+
     # Verify it became paid
     response = httpx.get(f"{BASE_URL}/v1/melt/quote/bolt11/{quote.quote}")
     assert response.status_code == 200
     result = response.json()
     assert result["state"] == MeltQuoteState.paid.value
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not is_fake, reason="only on fakewallet")
+async def test_async_melt_commits_pending_before_returning(ledger):
+    """async_melt must persist PENDING before returning PENDING.
+
+    Deferred commit into the detached task lets a poller see stale UNPAID, which
+    NUT-05 clients treat as a terminal payment failure.
+    """
+    from cashu.wallet.wallet import Wallet
+
+    wallet = await Wallet.with_db(
+        url=SERVER_ENDPOINT,
+        db="test_data/wallet_async_melt_race",
+        name="wallet_async_melt_race",
+    )
+    await wallet.load_mint()
+    mint_quote = await wallet.request_mint(64)
+    await pay_if_regtest(mint_quote.request)
+    await wallet.mint(64, quote_id=mint_quote.quote)
+
+    # External invoice (no matching mint quote) so melt takes the Lightning path.
+    invoice = await ledger.backends[Method.bolt11][Unit.sat].create_invoice(
+        Amount(Unit.sat, 32)
+    )
+    melt_quote = await ledger.melt_quote(
+        PostMeltQuoteRequest(request=invoice.payment_request, unit="sat")
+    )
+    _, send_proofs = await wallet.swap_to_send(
+        wallet.proofs, melt_quote.amount + melt_quote.fee_reserve
+    )
+    # Blank outputs for fee return — must be stored during prepare, before return.
+    n_change_outputs = 4
+    secrets, rs, _ = await wallet.generate_n_secrets(n_change_outputs, skip_bump=True)
+    change_outputs, _ = wallet._construct_outputs(n_change_outputs * [1], secrets, rs)
+
+    original_delay = settings.fakewallet_delay_outgoing_payment
+    settings.fakewallet_delay_outgoing_payment = 1.0
+    try:
+        resp = await ledger.async_melt(
+            proofs=send_proofs, quote=melt_quote.quote, outputs=change_outputs
+        )
+        assert resp.state == MeltQuoteState.pending.value
+
+        # Raw DB state as NUT-17 snapshot sees it (not public get_melt_quote,
+        # which re-polls the backend and may settle the quote).
+        persisted = await ledger.crud.get_melt_quote(
+            quote_id=melt_quote.quote, db=ledger.db
+        )
+        assert persisted is not None
+        assert persisted.state == MeltQuoteState.pending
+
+        states = await ledger.db_read.get_proofs_states([p.Y for p in send_proofs])
+        assert all(s.pending for s in states)
+
+        stored_outputs = await ledger.crud.get_blinded_messages_melt_id(
+            melt_id=melt_quote.quote, db=ledger.db
+        )
+        assert len(stored_outputs) == n_change_outputs
+
+        for _ in range(30):
+            persisted = await ledger.crud.get_melt_quote(
+                quote_id=melt_quote.quote, db=ledger.db
+            )
+            assert persisted is not None
+            if persisted.state == MeltQuoteState.paid:
+                break
+            await asyncio.sleep(0.1)
+        else:
+            pytest.fail("background async melt did not settle before test exit")
+    finally:
+        settings.fakewallet_delay_outgoing_payment = original_delay
+
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not is_fake, reason="only on fakewallet")


### PR DESCRIPTION
## Summary
- Fixes a race in `prefer_async` / `async_melt` where the HTTP response claimed `PENDING` while the quote and proofs were still `UNPAID`/`unspent` until a background `melt()` task locked them.
- Clients polling or watching NUT-17 in that window could see `UNPAID` (terminal failure under NUT-05) while the mint later spent the proofs.
- Split melt into shared `_prepare_melt` (validate, durable PENDING lock on quote+proofs, store blank change outputs) and `_execute_melt_payment` (internal settle / LN pay / rollback / finalize). `async_melt` prepares first, returns that durable state, then pays in the background. Existing rollback paths are reused unchanged.

## Related
Supersedes #1071 (same race). Prefer this cut: prepare only commits durable `PENDING`; internal settle stays in `_execute_melt_payment`, so the response always matches DB state (no `model_copy` overlay of PENDING on PAID).

## Confirmation
`_prepare_melt` stores blank outputs before return:
```python
if outputs:
    await self._store_blinded_messages(outputs, melt_id=melt_quote.quote)
```
Regression test asserts quote PENDING, proofs pending, and blank outputs persisted right after `async_melt` returns.

## Test plan
- [x] `tests/mint/test_async_melt.py` (FakeWallet)
- [x] Regression: `test_async_melt_commits_pending_before_returning` (DB PENDING + proofs + blank outputs before return, then settles)
- [ ] CI full mint suite