### PR TITLE
fix(wallet): pass wallet name when constructing mint_wallet on receive paths

### DIFF
--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -876,7 +876,7 @@ async def receive_cli(
         mint_url = token_obj.mint
         mint_wallet = await Wallet.with_db(
             mint_url,
-            os.path.join(settings.cashu_dir, wallet.name),
+            wallet.db.db_location,
             name=wallet.name,
             unit=token_obj.unit,
             auth_db=wallet.auth_db.db_location if wallet.auth_db else None,

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -877,6 +877,7 @@ async def receive_cli(
         mint_wallet = await Wallet.with_db(
             mint_url,
             os.path.join(settings.cashu_dir, wallet.name),
+            name=wallet.name,
             unit=token_obj.unit,
             auth_db=wallet.auth_db.db_location if wallet.auth_db else None,
             auth_keyset_id=wallet.auth_keyset_id,

--- a/cashu/wallet/helpers.py
+++ b/cashu/wallet/helpers.py
@@ -1,5 +1,4 @@
 import hashlib
-import os
 from typing import List, Optional
 
 from loguru import logger
@@ -56,7 +55,7 @@ async def redeem_TokenV3(wallet: Wallet, token: TokenV3) -> Wallet:
         assert t.mint, Exception("redeem_TokenV3: multimint redeem without URL")
         mint_wallet = await Wallet.with_db(
             t.mint,
-            os.path.join(settings.cashu_dir, wallet.name),
+            wallet.db.db_location,
             name=wallet.name,
             unit=token.unit or wallet.unit.name,
             auth_db=wallet.auth_db.db_location if wallet.auth_db else None,

--- a/cashu/wallet/helpers.py
+++ b/cashu/wallet/helpers.py
@@ -57,6 +57,7 @@ async def redeem_TokenV3(wallet: Wallet, token: TokenV3) -> Wallet:
         mint_wallet = await Wallet.with_db(
             t.mint,
             os.path.join(settings.cashu_dir, wallet.name),
+            name=wallet.name,
             unit=token.unit or wallet.unit.name,
             auth_db=wallet.auth_db.db_location if wallet.auth_db else None,
             auth_keyset_id=wallet.auth_keyset_id,

--- a/tests/wallet/test_wallet_receive_named.py
+++ b/tests/wallet/test_wallet_receive_named.py
@@ -77,3 +77,26 @@ async def test_redeem_tokenv3_reuses_receivers_private_key(
     mint_wallet = await redeem_TokenV3(wallet_bob, token)
 
     assert mint_wallet.private_key.to_hex() == wallet_bob.private_key.to_hex()
+
+
+@pytest.mark.asyncio
+async def test_redeem_tokenv3_custom_db_dir_reuses_receivers_private_key(
+    wallet_sender: Wallet,
+):
+    """Pins that the mint_wallet built inside redeem_TokenV3 derives its db
+    directory from the receiver wallet's actual db.db_location, not from
+    settings.cashu_dir + wallet.name. A wallet created with a custom db
+    directory (library/test usage) must still redeem into itself instead of
+    opening whatever wallet happens to live under <cashu_dir>/<name>.
+    """
+    wallet_receiver = await Wallet.with_db(
+        SERVER_ENDPOINT, "test_data/wallet_receive_named_custom_dir", name="bob"
+    )
+    await wallet_receiver.load_mint()
+
+    send_proofs = await _mint_p2pk_locked_proofs_to(wallet_sender, wallet_receiver, 8)
+    token = TokenV3(token=[TokenV3Token(mint=wallet_sender.url, proofs=send_proofs)])
+
+    mint_wallet = await redeem_TokenV3(wallet_receiver, token)
+
+    assert mint_wallet.private_key.to_hex() == wallet_receiver.private_key.to_hex()

--- a/tests/wallet/test_wallet_receive_named.py
+++ b/tests/wallet/test_wallet_receive_named.py
@@ -1,0 +1,79 @@
+import os
+
+import pytest
+import pytest_asyncio
+
+from cashu.core.base import Proof, TokenV3, TokenV3Token
+from cashu.core.settings import settings
+from cashu.wallet.helpers import receive, redeem_TokenV3
+from cashu.wallet.wallet import Wallet
+from tests.conftest import SERVER_ENDPOINT
+from tests.helpers import pay_if_regtest
+
+
+@pytest_asyncio.fixture(scope="function")
+async def wallet_sender():
+    wallet = await Wallet.with_db(
+        SERVER_ENDPOINT, "test_data/wallet_receive_named_sender", name="sender"
+    )
+    await wallet.load_mint()
+    yield wallet
+
+
+@pytest_asyncio.fixture(scope="function")
+async def wallet_bob():
+    # Mirrors how the CLI constructs the main wallet: db directory is
+    # <cashu_dir>/<wallet_name>, same convention receive_cli/redeem_TokenV3 assume.
+    wallet = await Wallet.with_db(
+        SERVER_ENDPOINT, os.path.join(settings.cashu_dir, "bob"), name="bob"
+    )
+    await wallet.load_mint()
+    yield wallet
+
+
+async def _mint_p2pk_locked_proofs_to(
+    wallet_sender: Wallet, wallet_receiver: Wallet, amount: int
+) -> list[Proof]:
+    mint_quote = await wallet_sender.request_mint(64)
+    await pay_if_regtest(mint_quote.request)
+    await wallet_sender.mint(64, quote_id=mint_quote.quote)
+    pubkey_receiver = await wallet_receiver.create_p2pk_pubkey()
+    secret_lock = await wallet_sender.create_p2pk_lock(pubkey_receiver)
+    _, send_proofs = await wallet_sender.swap_to_send(
+        wallet_sender.proofs, amount, secret_lock=secret_lock
+    )
+    return send_proofs
+
+
+@pytest.mark.asyncio
+async def test_receive_p2pk_locked_token_named_wallet_succeeds(
+    wallet_sender: Wallet, wallet_bob: Wallet
+):
+    """Regression test: receiving a P2PK-locked token into a non-default-named
+    wallet used to silently open a different (empty) database, generate a
+    fresh mnemonic, and submit the proof without a witness, which the mint
+    rejected with "Witness is missing for p2pk signature".
+    """
+    send_proofs = await _mint_p2pk_locked_proofs_to(wallet_sender, wallet_bob, 8)
+    token = TokenV3(token=[TokenV3Token(mint=wallet_sender.url, proofs=send_proofs)])
+
+    await receive(wallet_bob, token)
+
+    await wallet_bob.load_proofs(reload=True)
+    assert wallet_bob.available_balance.amount == 8
+
+
+@pytest.mark.asyncio
+async def test_redeem_tokenv3_reuses_receivers_private_key(
+    wallet_sender: Wallet, wallet_bob: Wallet
+):
+    """Pins the invariant behind the fix: the throwaway mint_wallet constructed
+    inside redeem_TokenV3 must share the receiving wallet's private key (i.e.
+    open the same on-disk wallet), not silently create a new identity.
+    """
+    send_proofs = await _mint_p2pk_locked_proofs_to(wallet_sender, wallet_bob, 8)
+    token = TokenV3(token=[TokenV3Token(mint=wallet_sender.url, proofs=send_proofs)])
+
+    mint_wallet = await redeem_TokenV3(wallet_bob, token)
+
+    assert mint_wallet.private_key.to_hex() == wallet_bob.private_key.to_hex()


### PR DESCRIPTION
## Summary

Receiving a locked token (P2PK, P2BK, HTLC-with-pubkeys) into a wallet with a non-default name silently fails: the mint rejects the swap with `Witness is missing for p2pk signature`.

**Root cause** `Wallet.with_db()` derives the sqlite *filename* from its `name` kwarg (default `"wallet"`), while the directory is passed separately. `receive_cli` and `redeem_TokenV3` pass the directory but omit `name=`, so the throwaway `mint_wallet` they construct opens `<cashu_dir>/<walletname>/wallet.sqlite3` instead of `<cashu_dir>/<walletname>/<walletname>.sqlite3` whenever `walletname != "wallet"`. That's a different, empty database, so `_init_private_key` treats it as first-run and silently generates a fresh mnemonic. The new key doesn't match the lock, so `filter_proofs_locked_to_our_pubkey` finds nothing, the proof is submitted with `witness=None`, and the mint rejects it.

This is invisible with the default wallet name (`wallet` == `wallet`), which is why it went unnoticed.

**Fix**: pass `name=wallet.name` at both call sites.

- This issue was found while interop-testing NUT-28 (#950); unrelated to it. Confirmed general by reproducing with plain P2PK on unmodified `main` (not P2BK-specific).
- Tests added to confirm fix works
- Also tested manually after the fix confirming it works.