### PR TITLE
feat(cli): add --timelock/-t option to send command

### DIFF
--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -821,6 +821,13 @@ async def balance(ctx: Context, verbose):
     help="Force swap token.",
     type=bool,
 )
+@click.option(
+    "--timelock",
+    "-t",
+    default=None,
+    help="Locktime in seconds after which the refund pubkey can claim the tokens.",
+    type=int,
+)
 @click.pass_context
 @coro
 @init_auth_wallet
@@ -835,6 +842,7 @@ async def send_command(
     offline: bool,
     include_fees: bool,
     force_swap: bool,
+    timelock: Optional[int],
 ):
     wallet: Wallet = ctx.obj["WALLET"]
     amount = int(
@@ -850,6 +858,7 @@ async def send_command(
         memo=memo,
         force_swap=force_swap,
         refund_pubkeys=list(refund) if refund else None,
+        timelock_seconds=timelock,
     )
     await print_balance(ctx)
 
@@ -1196,6 +1205,8 @@ async def lock_p2pk(ctx: Context, timelock: Optional[int], refund: tuple):
         print("")
 
     send_cmd = f"cashu send <amount> --lock {lock_str}"
+    if timelock:
+        send_cmd += f" --timelock {timelock}"
     if refund:
         for r in refund:
             send_cmd += f" --refund {r}"

--- a/cashu/wallet/helpers.py
+++ b/cashu/wallet/helpers.py
@@ -157,7 +157,7 @@ async def send(
             if timelock_seconds is not None
             else settings.locktime_delta_seconds
         )
-        # we add a time lock to the P2PK lock by appending the current unix time + 14 days
+        # we add a time lock by appending the current unix time + locktime_seconds
         if lock.startswith("P2PK:") or lock.startswith("P2PK-SIGALL:"):
             sigall = lock.startswith("P2PK-SIGALL:")
             logger.debug(f"Locking token to: {lock}")

--- a/cashu/wallet/helpers.py
+++ b/cashu/wallet/helpers.py
@@ -141,6 +141,7 @@ async def send(
     memo: Optional[str] = None,
     force_swap: bool = False,
     refund_pubkeys: Optional[List[str]] = None,
+    timelock_seconds: Optional[int] = None,
 ):
     """
     Prints token to send to stdout.
@@ -151,20 +152,23 @@ async def send(
         assert len(lock) > 21, Exception(
             "Error: lock has to be at least 22 characters long."
         )
+        locktime_seconds = (
+            timelock_seconds
+            if timelock_seconds is not None
+            else settings.locktime_delta_seconds
+        )
         # we add a time lock to the P2PK lock by appending the current unix time + 14 days
         if lock.startswith("P2PK:") or lock.startswith("P2PK-SIGALL:"):
             sigall = lock.startswith("P2PK-SIGALL:")
             logger.debug(f"Locking token to: {lock}")
-            logger.debug(
-                f"Adding a time lock of {settings.locktime_delta_seconds} seconds."
-            )
+            logger.debug(f"Adding a time lock of {locktime_seconds} seconds.")
             tags = None
             if refund_pubkeys:
                 tags = Tags()
                 tags["refund"] = refund_pubkeys
             secret_lock = await wallet.create_p2pk_lock(
                 lock.split(":")[1],
-                locktime_seconds=settings.locktime_delta_seconds,
+                locktime_seconds=locktime_seconds,
                 sig_all=sigall,
                 n_sigs=1,
                 tags=tags,
@@ -173,16 +177,14 @@ async def send(
         elif lock.startswith("P2BK:") or lock.startswith("P2BK-SIGALL:"):
             sigall = lock.startswith("P2BK-SIGALL:")
             logger.debug(f"Locking token with P2BK to: {lock}")
-            logger.debug(
-                f"Adding a time lock of {settings.locktime_delta_seconds} seconds."
-            )
+            logger.debug(f"Adding a time lock of {locktime_seconds} seconds.")
             tags = None
             if refund_pubkeys:
                 tags = Tags()
                 tags["refund"] = refund_pubkeys
             secret_lock, p2pk_e = await wallet.create_p2bk_lock(
                 lock.split(":")[1],
-                locktime_seconds=settings.locktime_delta_seconds,
+                locktime_seconds=locktime_seconds,
                 sig_all=sigall,
                 n_sigs=1,
                 tags=tags,

--- a/tests/wallet/test_wallet_cli.py
+++ b/tests/wallet/test_wallet_cli.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from typing import Tuple
 
 import bolt11
@@ -6,6 +7,7 @@ import pytest
 from click.testing import CliRunner
 
 from cashu.core.base import TokenV4
+from cashu.core.p2pk import P2PKSecret
 from cashu.core.settings import settings
 from cashu.wallet.cli.cli import cli
 from cashu.wallet.wallet import Wallet
@@ -685,6 +687,74 @@ def test_send_with_lock_and_refund(mint, cli_prefix):
     assert "cashuB" in token_str, "output does not have a token"
     token = TokenV4.deserialize(token_str).to_tokenv3()
     assert fake_refund_pubkey in token.token[0].proofs[0].secret
+
+
+def test_send_with_lock_and_timelock(mint, cli_prefix):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "locks"],
+    )
+    assert result.exception is None
+    lock = None
+    for word in result.output.split(" "):
+        word = word.strip()
+        if word.startswith("P2PK:"):
+            lock = word
+            break
+    assert lock is not None, "no lock found"
+
+    before = int(time.time())
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "send", "10", "--lock", lock, "--timelock", "5"],
+    )
+    after = int(time.time())
+    assert result.exception is None
+    print("test_send_with_lock_and_timelock", result.output)
+    token_str = result.output.split("\n")[0]
+    assert "cashuB" in token_str, "output does not have a token"
+    token = TokenV4.deserialize(token_str).to_tokenv3()
+    secret = P2PKSecret.deserialize(token.token[0].proofs[0].secret)
+    assert secret.locktime is not None
+    assert before + 5 <= secret.locktime <= after + 5
+
+
+def test_send_with_lock_uses_locktime_delta_seconds_by_default(mint, cli_prefix):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "locks"],
+    )
+    assert result.exception is None
+    lock = None
+    for word in result.output.split(" "):
+        word = word.strip()
+        if word.startswith("P2PK:"):
+            lock = word
+            break
+    assert lock is not None, "no lock found"
+
+    before = int(time.time())
+    result = runner.invoke(
+        cli,
+        [*cli_prefix, "send", "10", "--lock", lock],
+    )
+    after = int(time.time())
+    assert result.exception is None
+    print(
+        "test_send_with_lock_uses_locktime_delta_seconds_by_default", result.output
+    )
+    token_str = result.output.split("\n")[0]
+    assert "cashuB" in token_str, "output does not have a token"
+    token = TokenV4.deserialize(token_str).to_tokenv3()
+    secret = P2PKSecret.deserialize(token.token[0].proofs[0].secret)
+    assert secret.locktime is not None
+    assert (
+        before + settings.locktime_delta_seconds
+        <= secret.locktime
+        <= after + settings.locktime_delta_seconds
+    )
 
 
 def mint_tokens(runner, cli_prefix, amount: str):


### PR DESCRIPTION
## Summary

`send`'s locktime was env-var-only: `settings.locktime_delta_seconds` was passed unconditionally to `create_p2pk_lock`/`create_p2bk_lock` with no per-invocation way to override it. Testing a short refund window required setting `LOCKTIME_DELTA_SECONDS=10` as an environment variable at send time.

The inconsistency this resolves: `cashu lock p2pk` already exposes `--timelock/-t` and prints a `cashu send <amount> --lock <lock>` command as next-step guidance, but that guidance silently dropped the user's `--timelock` value, because `send` had no flag to carry it.

**Fix**: add `--timelock/-t <seconds>` to `send`, threaded through `helpers.send()` as an optional override (`Optional[int] = None`) that falls back to `settings.locktime_delta_seconds` when omitted. Also fixed `lock_p2pk`'s printed `send` command to include `--timelock <n>` when the user set one.

- This UX feature was found while interop-testing NUT-28 (https://github.com/cashubtc/nutshell/pull/950);
- Tests added to confirm fix works
- Also tested manually after the fix confirming it works and no existing feature was broken.