### PR TITLE
fix: handle batch mint times and base64url keysets

### DIFF
--- a/cashu/core/crypto/keys.py
+++ b/cashu/core/crypto/keys.py
@@ -143,8 +143,9 @@ def is_base64_keyset_id(keyset_id: str) -> bool:
     if keyset_id.startswith("00") or keyset_id.startswith("01"):
         return False
 
-    # Try to decode as URL-safe base64 to confirm. Legacy keyset IDs can use
-    # either the standard or URL-safe alphabet.
+    # Use b64decode with URL-safe alternative characters instead of
+    # urlsafe_b64decode because only b64decode supports validate=True. This
+    # accepts both Base64 alphabets while strictly rejecting malformed IDs.
     try:
         base64.b64decode(keyset_id, altchars=b"-_", validate=True)
         return True

--- a/cashu/core/crypto/keys.py
+++ b/cashu/core/crypto/keys.py
@@ -130,7 +130,7 @@ def is_base64_keyset_id(keyset_id: str) -> bool:
 
     Base64 keyset IDs:
     - Don't start with "00" or "01" version prefix
-    - Are typically 12 characters long
+    - Are exactly 12 characters long
     - Are valid base64 strings
 
     Args:
@@ -139,8 +139,12 @@ def is_base64_keyset_id(keyset_id: str) -> bool:
     Returns:
         True if the keyset ID is base64 format, False otherwise
     """
-    # If it starts with a known version prefix, it's not base64
-    if keyset_id.startswith("00") or keyset_id.startswith("01"):
+    # Legacy IDs are the first 12 characters of a Base64-encoded digest.
+    if len(keyset_id) != 12:
+        return False
+
+    # If it starts with a known version prefix, it's not Base64.
+    if keyset_id.startswith(("00", "01")):
         return False
 
     # Use b64decode with URL-safe alternative characters instead of

--- a/cashu/core/crypto/keys.py
+++ b/cashu/core/crypto/keys.py
@@ -143,9 +143,10 @@ def is_base64_keyset_id(keyset_id: str) -> bool:
     if keyset_id.startswith("00") or keyset_id.startswith("01"):
         return False
 
-    # Try to decode as base64 to confirm
+    # Try to decode as URL-safe base64 to confirm. Legacy keyset IDs can use
+    # either the standard or URL-safe alphabet.
     try:
-        base64.b64decode(keyset_id, validate=True)
+        base64.b64decode(keyset_id, altchars=b"-_", validate=True)
         return True
     except Exception:
         return False

--- a/cashu/mint/db/write.py
+++ b/cashu/mint/db/write.py
@@ -41,6 +41,17 @@ class DbWriteHelper:
         self.events = events
         self.db_read = db_read
 
+    @staticmethod
+    def _set_mint_quote_state(quote: MintQuote, state: MintQuoteState) -> None:
+        """Set a mint quote state and its corresponding timestamps."""
+        now = int(time.time())
+        quote.state = state
+        quote.updated_at = now
+        if state == MintQuoteState.paid and not quote.paid_time:
+            quote.paid_time = now
+        if state == MintQuoteState.issued and not quote.issued_time:
+            quote.issued_time = now
+
     async def _verify_spent_proofs_and_set_pending(
         self,
         proofs: List[Proof],
@@ -166,8 +177,7 @@ class DbWriteHelper:
             if not quote.paid:
                 raise TransactionError("Mint quote is not paid yet.")
             # set the quote as pending
-            quote.state = MintQuoteState.pending
-            quote.updated_at = int(time.time())
+            self._set_mint_quote_state(quote, MintQuoteState.pending)
             logger.trace(f"crud: setting quote {quote_id} as PENDING")
             await self.crud.update_mint_quote(quote=quote, db=self.db, conn=conn)
         if quote is None:
@@ -208,8 +218,7 @@ class DbWriteHelper:
                     raise TransactionError(f"Mint quote {quote_id} is not paid yet.")
                 
                 # set the quote as pending
-                quote.state = MintQuoteState.pending
-                quote.updated_at = int(time.time())
+                self._set_mint_quote_state(quote, MintQuoteState.pending)
                 logger.trace(f"crud: setting quote {quote_id} as PENDING")
                 await self.crud.update_mint_quote(quote=quote, db=self.db, conn=conn)
                 quotes.append(quote)
@@ -241,11 +250,7 @@ class DbWriteHelper:
                     f"Mint quote not pending: {quote.state.value}. Cannot set as {state.value}."
                 )
             # set the quote to previous state
-            quote.state = state
-            now = int(time.time())
-            quote.updated_at = now
-            if state == MintQuoteState.issued and not quote.issued_time:
-                quote.issued_time = now
+            self._set_mint_quote_state(quote, state)
             logger.trace(f"crud: setting quote {quote_id} as {state.value}")
             await self.crud.update_mint_quote(quote=quote, db=self.db, conn=conn)
         if quote is None:
@@ -286,11 +291,7 @@ class DbWriteHelper:
                         f"Mint quote {quote_id} not pending: {quote.state.value}. Cannot set as {state.value}."
                     )
                 # set the quote to previous state
-                quote.state = state
-                now = int(time.time())
-                quote.updated_at = now
-                if state == MintQuoteState.issued and not quote.issued_time:
-                    quote.issued_time = now
+                self._set_mint_quote_state(quote, state)
                 logger.trace(f"crud: setting quote {quote_id} as {state.value}")
                 await self.crud.update_mint_quote(quote=quote, db=self.db, conn=conn)
                 quotes.append(quote)

--- a/cashu/mint/db/write.py
+++ b/cashu/mint/db/write.py
@@ -47,8 +47,6 @@ class DbWriteHelper:
         now = int(time.time())
         quote.state = state
         quote.updated_at = now
-        if state == MintQuoteState.paid and not quote.paid_time:
-            quote.paid_time = now
         if state == MintQuoteState.issued and not quote.issued_time:
             quote.issued_time = now
 

--- a/cashu/mint/db/write.py
+++ b/cashu/mint/db/write.py
@@ -287,7 +287,10 @@ class DbWriteHelper:
                     )
                 # set the quote to previous state
                 quote.state = state
-                quote.updated_at = int(time.time())
+                now = int(time.time())
+                quote.updated_at = now
+                if state == MintQuoteState.issued and not quote.issued_time:
+                    quote.issued_time = now
                 logger.trace(f"crud: setting quote {quote_id} as {state.value}")
                 await self.crud.update_mint_quote(quote=quote, db=self.db, conn=conn)
                 quotes.append(quote)
@@ -592,4 +595,3 @@ class DbWriteHelper:
         await self.events.submit(quote_copy)
 
         return quote_copy
-

--- a/cashu/wallet/secrets.py
+++ b/cashu/wallet/secrets.py
@@ -151,7 +151,7 @@ class WalletSecrets(SupportsDb, SupportsKeysets):
             # BEGIN: BACKWARDS COMPATIBILITY < 0.15.0 keyset id is not hex
             # calculate an integer keyset id from the base64 encoded keyset id
             keyest_id_int = int.from_bytes(
-                base64.urlsafe_b64decode(keyset_id), "big"
+                base64.b64decode(keyset_id, altchars=b"-_", validate=True), "big"
             ) % (2**31 - 1)
             # END: BACKWARDS COMPATIBILITY < 0.15.0 keyset id is not hex
 

--- a/cashu/wallet/secrets.py
+++ b/cashu/wallet/secrets.py
@@ -150,9 +150,9 @@ class WalletSecrets(SupportsDb, SupportsKeysets):
         except ValueError:
             # BEGIN: BACKWARDS COMPATIBILITY < 0.15.0 keyset id is not hex
             # calculate an integer keyset id from the base64 encoded keyset id
-            keyest_id_int = int.from_bytes(base64.b64decode(keyset_id), "big") % (
-                2**31 - 1
-            )
+            keyest_id_int = int.from_bytes(
+                base64.urlsafe_b64decode(keyset_id), "big"
+            ) % (2**31 - 1)
             # END: BACKWARDS COMPATIBILITY < 0.15.0 keyset id is not hex
 
         logger.trace(f"BIP32: keyset id: {keyset_id} becomes {keyest_id_int}")

--- a/tests/mint/test_mint_batch.py
+++ b/tests/mint/test_mint_batch.py
@@ -81,6 +81,11 @@ async def test_ledger_mint_batch_success(ledger: Ledger, wallet: Wallet):
     assert promises[0].amount == 64
     assert promises[1].amount == 32
 
+    quote1 = await ledger.get_mint_quote(mint_quote1.quote)
+    quote2 = await ledger.get_mint_quote(mint_quote2.quote)
+    assert quote1.issued_time is not None
+    assert quote2.issued_time is not None
+
 
 @pytest.mark.asyncio
 async def test_ledger_mint_batch_wrong_amount(ledger: Ledger, wallet: Wallet):

--- a/tests/mint/test_mint_db.py
+++ b/tests/mint/test_mint_db.py
@@ -226,6 +226,11 @@ async def test_mint_quote_set_pending(wallet: Wallet, ledger: Ledger):
     assert quote is not None
     assert quote.state == MintQuoteState.paid
 
+    # Legacy paid quotes may not have a payment timestamp. Moving through
+    # PENDING and back to PAID must not invent one during rollback.
+    quote.paid_time = None
+    await ledger.crud.update_mint_quote(quote=quote, db=ledger.db)
+
     previous_state = MintQuoteState.paid
     await ledger.db_write._set_mint_quote_pending(quote.quote)
     quote = await ledger.crud.get_mint_quote(quote_id=mint_quote.quote, db=ledger.db)
@@ -244,6 +249,7 @@ async def test_mint_quote_set_pending(wallet: Wallet, ledger: Ledger):
     assert quote is not None
     assert quote.state == previous_state
     assert quote.state == MintQuoteState.paid
+    assert quote.paid_time is None
 
     # # set paid and mint again
     # quote.state = MintQuoteState.paid

--- a/tests/wallet/test_wallet_keysets_v2.py
+++ b/tests/wallet/test_wallet_keysets_v2.py
@@ -18,6 +18,7 @@ from cashu.core.crypto.keys import (
     get_keyset_id_version,
     is_base64_keyset_id,
     is_keyset_id_v2,
+    is_supported_keyset_version,
 )
 from cashu.core.crypto.secp import PrivateKey
 from cashu.wallet.keyset_manager import KeysetManager
@@ -29,6 +30,7 @@ MNEMONIC = "half depart obvious quality work element tank gorilla view sugar pic
 LEGACY_V1_KEYSET_ID = "009a1f293253e41e"
 V2_KEYSET_ID = "01d8a63077d0a51f9855f066409782ffcb322dc8a2265291865221ed06c039f6bc"
 BASE64_KEYSET_ID = "yjzQhxghPdrr"
+BASE64URL_KEYSET_ID = "DfVs_IPltHaB"
 
 
 @pytest.mark.asyncio
@@ -367,7 +369,7 @@ async def test_error_handling():
     secrets.seed = b"test_seed"
     
     # Test unsupported version
-    invalid_keyset_id = "99invalid_version_id"
+    invalid_keyset_id = "99invalid.version_id"
     secrets.keyset_id = invalid_keyset_id
     
     with pytest.raises(ValueError, match="Unsupported keyset version"):
@@ -379,6 +381,11 @@ def test_base64_keyset_id_detection():
     # Test base64 keyset ID is detected correctly
     assert is_base64_keyset_id(BASE64_KEYSET_ID)
     assert get_keyset_id_version(BASE64_KEYSET_ID) == "base64"
+
+    # URL-safe legacy IDs must not be mistaken for unsupported hex versions
+    assert is_base64_keyset_id(BASE64URL_KEYSET_ID)
+    assert get_keyset_id_version(BASE64URL_KEYSET_ID) == "base64"
+    assert is_supported_keyset_version(BASE64URL_KEYSET_ID)
     
     # Test v1 keyset is not detected as base64
     assert not is_base64_keyset_id(LEGACY_V1_KEYSET_ID)
@@ -413,3 +420,20 @@ async def test_base64_keyset_secret_derivation():
     keyset_id_int = int.from_bytes(base64.b64decode(BASE64_KEYSET_ID), "big") % (2**31 - 1)
     expected_path = f"m/129372'/0'/{keyset_id_int}'/1'"
     assert expected_path in path
+
+
+@pytest.mark.asyncio
+async def test_base64url_keyset_secret_derivation():
+    secrets = WalletSecrets()
+    secrets.keyset_id = BASE64URL_KEYSET_ID
+    secrets.seed = b"test_seed_for_base64url"
+    secrets.bip32 = BIP32.from_seed(secrets.seed)
+
+    _, _, path = await secrets.generate_determinstic_secret(1)
+
+    import base64
+
+    keyset_id_int = int.from_bytes(
+        base64.urlsafe_b64decode(BASE64URL_KEYSET_ID), "big"
+    ) % (2**31 - 1)
+    assert f"m/129372'/0'/{keyset_id_int}'/1'" in path

--- a/tests/wallet/test_wallet_keysets_v2.py
+++ b/tests/wallet/test_wallet_keysets_v2.py
@@ -369,7 +369,7 @@ async def test_error_handling():
     secrets.seed = b"test_seed"
     
     # Test unsupported version
-    invalid_keyset_id = "99invalid.version_id"
+    invalid_keyset_id = "99invalid_version_id"
     secrets.keyset_id = invalid_keyset_id
     
     with pytest.raises(ValueError, match="Unsupported keyset version"):
@@ -386,6 +386,10 @@ def test_base64_keyset_id_detection():
     assert is_base64_keyset_id(BASE64URL_KEYSET_ID)
     assert get_keyset_id_version(BASE64URL_KEYSET_ID) == "base64"
     assert is_supported_keyset_version(BASE64URL_KEYSET_ID)
+
+    # Valid Base64URL with the wrong length is not a legacy keyset ID
+    assert not is_base64_keyset_id("99invalid_version_id")
+    assert not is_supported_keyset_version("99invalid_version_id")
     
     # Test v1 keyset is not detected as base64
     assert not is_base64_keyset_id(LEGACY_V1_KEYSET_ID)


### PR DESCRIPTION
## Summary

- set `issued_time` when batch mint quotes transition to `ISSUED`, matching single-quote minting
- recognize legacy URL-safe Base64 keyset IDs before interpreting their prefixes as version bytes
- decode URL-safe legacy keyset IDs consistently during BIP32 secret derivation
- add regression coverage for batch quote timestamps and the reported `DfVs_IPltHaB` keyset ID

## Review note

The legacy keyset compatibility change touches keyset identification and derivation-path selection and should receive the project-required maintainer review.

## Tests

- `poetry run pytest tests/mint/test_mint_batch.py -q` (17 passed)
- `poetry run pytest tests/wallet/test_wallet_keysets_v2.py -q` (16 passed)
- `make check`

Closes #1073
Closes #1072