### PR TITLE
chore(release): bump version to 0.20.3

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: 'Tag to build and push (e.g. 0.20.2)'
+        description: 'Tag to build and push (e.g. 0.20.3)'
         required: true
         type: string
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ This command runs the mint on your local computer. Skip this step if you want to
 Run the mint using the pre-built Docker image. This method sets environment variables directly and works reliably regardless of local `.env` files:
 
 ```bash
-docker run -d -p 3338:3338 --name nutshell -e MINT_BACKEND_BOLT11_SAT=FakeWallet -e MINT_LISTEN_HOST=0.0.0.0 -e MINT_LISTEN_PORT=3338 -e MINT_PRIVATE_KEY=TEST_PRIVATE_KEY cashubtc/nutshell:0.20.2 poetry run mint
+docker run -d -p 3338:3338 --name nutshell -e MINT_BACKEND_BOLT11_SAT=FakeWallet -e MINT_LISTEN_HOST=0.0.0.0 -e MINT_LISTEN_PORT=3338 -e MINT_PRIVATE_KEY=TEST_PRIVATE_KEY cashubtc/nutshell:0.20.3 poetry run mint
 ```
 
 ## From this repository

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -9,7 +9,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 env = Env()
 
-VERSION = "0.20.2"
+VERSION = "0.20.3"
 
 
 def find_env_file():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cashu"
-version = "0.20.2"
+version = "0.20.3"
 description = "Ecash wallet and mint"
 authors = ["calle <callebtc@protonmail.com>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ entry_points = {"console_scripts": ["cashu = cashu.wallet.cli.cli:cli"]}
 
 setuptools.setup(
     name="cashu",
-    version="0.20.2",
+    version="0.20.3",
     description="Ecash wallet and mint",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tor/docker-compose.yaml
+++ b/tor/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   mint:
-    image: cashubtc/nutshell:0.20.2
+    image: cashubtc/nutshell:0.20.3
   #  build:
   #   context: ..
   #   dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
- Bump Nutshell release version from 0.20.2 to 0.20.3 in project metadata, runtime `VERSION`, setup, Docker tags, and docs.

## Test plan
- [ ] Confirm version strings are 0.20.3 in `pyproject.toml`, `cashu/core/settings.py`, `setup.py`, `tor/docker-compose.yaml`, `README.md`, and `.github/workflows/docker.yaml`
- [ ] Confirm dependency pins and historical test fixtures were left unchanged