### PR TITLE
fix(mint): fix rotate_next_keyset

### DIFF
--- a/cashu/mint/keysets.py
+++ b/cashu/mint/keysets.py
@@ -71,6 +71,7 @@ class LedgerKeysets(SupportsKeysets, SupportsSeed, SupportsDb):
                 )
                 if keyset_derivation_counter > selected_keyset_counter:
                     selected_keyset = keyset
+                    selected_keyset_counter = keyset_derivation_counter 
 
         # If no selected keyset, then there is no keyset for this unit
         if not selected_keyset:
@@ -111,7 +112,7 @@ class LedgerKeysets(SupportsKeysets, SupportsSeed, SupportsDb):
         await self.crud.update_keyset(keyset=selected_keyset, db=self.db)
         self.keysets[selected_keyset.id] = selected_keyset
 
-        logger.debug(f"Keyset {keyset.id} was de-activated")
+        logger.debug(f"Keyset {selected_keyset.id} was de-activated")
         return new_keyset
 
     async def activate_keyset(


### PR DESCRIPTION
**Summary**

`cashu/mint/keysets.py:37` (`rotate_next_keyset`) failed to update `selected_keyset_counter` inside its selection loop, so the "select the active keyset with the highest counter" comparison always ran against its initial value instead of the running maximum. With a single active keyset per unit — the only case exercised so far — this has no observable effect, since there's nothing to compare against. However, the moment more than one active keyset exists for the same unit (a state NUT-02 permits), selection becomes dependent on dict iteration order rather than actual counter value, which can silently select the wrong keyset for rotation.

Fixing this is low-risk and preserves current single-keyset behavior exactly, while making the function correct if that assumption ever doesn't hold — whether from future multi-keyset support, migrations, or manual DB state.

Also replaced a stray `keyset.id` reference in the final debug log with `selected_keyset.id`. `keyset` was a leftover loop variable from the selection loop above and no longer holds a meaningful value once the loop exits; using it there could log the wrong keyset ID as the one deactivated.

**Changes**

- `rotate_next_keyset`: correctly track `selected_keyset_counter` on each iteration
- `rotate_next_keyset`: fix debug log to reference `selected_keyset.id` instead of stale `keyset.id`

**Testing**

```
pytest tests/mint/test_mint_keysets.py::test_keyset_rotation
```

No behavioral change for the existing single-active-keyset code path, so the existing test suite passes unmodified.