### PR TITLE
chore: remove dead regtest tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,7 +98,7 @@ MINT_CLNREST_RUNE="Base64string== or path to file containing the rune"
 # Use with CoreLightningRestWallet
 # Note: CoreLightningRestWallet is deprecated, use CLNRestWallet instead
 MINT_CORELIGHTNING_REST_URL=https://localhost:3001
-MINT_CORELIGHTNING_REST_MACAROON="./clightning-rest/access.macaroon"
+MINT_CORELIGHTNING_REST_MACAROON="./clightning-2-rest/access.macaroon"
 MINT_CORELIGHTNING_REST_CERT="./clightning-2-rest/certificate.pem"
 
 # Use with LNbitsWallet

--- a/Makefile
+++ b/Makefile
@@ -43,15 +43,6 @@ test-mint:
 	DEBUG=true \
 	poetry run pytest tests/mint --cov-report xml --cov cashu
 
-test-lndrest:
-	PYTHONUNBUFFERED=1 \
-	DEBUG=true \
-	MINT_BACKEND_BOLT11_SAT=LndRestWallet \
-	MINT_LND_REST_ENDPOINT=https://localhost:8081/ \
-	MINT_LND_REST_CERT=../cashu-regtest-enviroment/data/lnd-3/tls.cert \
-	MINT_LND_REST_MACAROON=../cashu-regtest-enviroment/data/lnd-3/data/chain/bitcoin/regtest/admin.macaroon \
-	poetry run pytest tests/test_cli.py --cov-report xml --cov cashu
-
 install:
 	make clean
 	python setup.py sdist bdist_wheel

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -81,17 +81,6 @@ docker_lightning_cli = [
     "--rpcserver=lnd-1",
 ]
 
-docker_bitcoin_cli = [
-    "docker",
-    "exec",
-    "cashu-bitcoind-1",
-    "bitcoin-cli",
-    "-rpcuser=cashu",
-    "-rpcpassword=cashu",
-    "-regtest",
-]
-
-
 docker_lightning_unconnected_cli = [
     "docker",
     "exec",
@@ -199,31 +188,12 @@ def get_real_invoice_cln(sats: int) -> str:
     return result["bolt11"]
 
 
-def mine_blocks(blocks: int = 1) -> str:
-    cmd = docker_bitcoin_cli.copy()
-    cmd.extend(["-generate", str(blocks)])
-    return run_cmd(cmd)
-
-
 def get_unconnected_node_uri() -> str:
     cmd = docker_lightning_unconnected_cli.copy()
     cmd.append("getinfo")
     info = run_cmd_json(cmd)
     pubkey = info["identity_pubkey"]
     return f"{pubkey}@lnd-2:9735"
-
-
-def create_onchain_address(address_type: str = "bech32") -> str:
-    cmd = docker_bitcoin_cli.copy()
-    cmd.extend(["getnewaddress", address_type])
-    return run_cmd(cmd)
-
-
-def pay_onchain(address: str, sats: int) -> str:
-    btc = sats * 0.00000001
-    cmd = docker_bitcoin_cli.copy()
-    cmd.extend(["sendtoaddress", address, str(btc)])
-    return run_cmd(cmd)
 
 
 async def pay_if_regtest(bolt11: str) -> None:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -84,9 +84,10 @@ docker_lightning_cli = [
 docker_bitcoin_cli = [
     "docker",
     "exec",
-    "cashu-bitcoind-1-1bitcoin-cli",
-    "-rpcuser=lnbits",
-    "-rpcpassword=lnbits",
+    "cashu-bitcoind-1",
+    "bitcoin-cli",
+    "-rpcuser=cashu",
+    "-rpcpassword=cashu",
     "-regtest",
 ]
 


### PR DESCRIPTION
## Summary

Cleanup of regtest test tooling ahead of planned improvements to the integration test suite. Everything removed here has been broken or unreferenced for over a year, so there is no change in test behavior.

## Changes

- **Removed dead bitcoind test helpers** : `docker_bitcoin_cli` and the `mine_blocks`, `create_onchain_address`, and `pay_onchain` functions built on it. 

- **Removed stale `test-lndrest` make target** : it runs a test file that was renamed in 2024, and nothing invokes it now.


## Bug Fixes

- **Corrected CoreLightningRest macaroon path in `.env.example`** : Macaroon and cert were mismatched referencing two different paths