### PR TITLE
Refactor: use central constants for method and subscription kind strings

### DIFF
--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -348,7 +348,7 @@ class MeltQuote(LedgerEvent):
     def from_resp_wallet(cls, melt_quote_resp, mint: str, unit: str, request: str):
         return cls(
             quote=melt_quote_resp.quote,
-            method="bolt11",
+            method=Method.bolt11.name,
             request=melt_quote_resp.request
             or request,  # BACKWARDS COMPATIBILITY mint response < 0.17.0
             checking_id="",
@@ -547,7 +547,7 @@ class MintQuote(LedgerEvent):
 
         return cls(
             quote=mint_quote_resp.quote,
-            method="bolt11",
+            method=Method.bolt11.name,
             request=mint_quote_resp.request,
             checking_id="",
             unit=mint_quote_resp.unit

--- a/cashu/core/mint_info.py
+++ b/cashu/core/mint_info.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel
 
 from .base import Method, Unit
+from .json_rpc.base import JSONRPCSubscriptionKinds
 from .models import MintInfoContact, MintInfoProtectedEndpoint, Nut15MppSupport
 from .nuts.nuts import BLIND_AUTH_NUT, CLEAR_AUTH_NUT, MPP_NUT, WEBSOCKETS_NUT
 
@@ -76,7 +77,10 @@ class MintInfo(BaseModel):
         websocket_supported = websocket_settings["supported"]
         for entry in websocket_supported:
             if entry["method"] == method.name and entry["unit"] == unit.name:
-                if "bolt11_mint_quote" in entry["commands"]:
+                if (
+                    JSONRPCSubscriptionKinds.BOLT11_MINT_QUOTE.value
+                    in entry["commands"]
+                ):
                     return True
         return False
 

--- a/cashu/core/nuts/nut26.py
+++ b/cashu/core/nuts/nut26.py
@@ -12,7 +12,7 @@ from bech32 import (
     bech32_encode as _bech32_encode,
 )
 
-from ..base import NUT10Option, PaymentRequest, Transport
+from ..base import NUT10Option, PaymentRequest, Transport, Unit
 
 BECH32M_CONST = 0x2BC830A3
 HRP = "creqb"
@@ -257,7 +257,7 @@ def _pr_to_tlv(pr: PaymentRequest) -> bytes:
     if pr.a is not None:
         out += _tlv_entry(0x02, struct.pack(">Q", pr.a))
     if pr.u is not None:
-        if pr.u == "sat":
+        if pr.u == Unit.sat.name:
             out += _tlv_entry(0x03, bytes([0x00]))
         else:
             out += _tlv_entry(0x03, pr.u.encode())
@@ -292,7 +292,7 @@ def _tlv_to_pr(data: bytes) -> PaymentRequest:
             kwargs["a"] = struct.unpack(">Q", val)[0]
         elif tag == 0x03:
             if len(val) == 1 and val[0] == 0x00:
-                kwargs["u"] = "sat"
+                kwargs["u"] = Unit.sat.name
             else:
                 kwargs["u"] = val.decode()
         elif tag == 0x04:

--- a/cashu/mint/features.py
+++ b/cashu/mint/features.py
@@ -34,7 +34,6 @@ _VERSION_PREFIX = "Nutshell"
 _SUPPORTED = "supported"
 _METHOD = "method"
 _UNIT = "unit"
-_BOLT11 = "bolt11"
 _MPP = "mpp"
 _COMMANDS = "commands"
 _BOLT11_MINT_QUOTE = "bolt11_mint_quote"
@@ -166,7 +165,7 @@ class LedgerFeatures(SupportsBackends, SupportsPubkey):
         }
         # we check the backend to see if "bolt11_mint_quote" is supported as well
         for method, unit_dict in self.backends.items():
-            if method == Method[_BOLT11]:
+            if method == Method.bolt11:
                 for unit in unit_dict.keys():
                     websocket_features[_SUPPORTED].append(
                         {

--- a/cashu/mint/features.py
+++ b/cashu/mint/features.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Union
 
 from ..core.base import Method
+from ..core.json_rpc.base import JSONRPCSubscriptionKinds
 from ..core.mint_info import MintInfo
 from ..core.models import (
     MeltMethodSetting,
@@ -34,11 +35,7 @@ _VERSION_PREFIX = "Nutshell"
 _SUPPORTED = "supported"
 _METHOD = "method"
 _UNIT = "unit"
-_MPP = "mpp"
 _COMMANDS = "commands"
-_BOLT11_MINT_QUOTE = "bolt11_mint_quote"
-_BOLT11_MELT_QUOTE = "bolt11_melt_quote"
-_PROOF_STATE = "proof_state"
 _PROTECTED_ENDPOINTS = "protected_endpoints"
 _BAT_MAX_MINT = "bat_max_mint"
 _OPENID_DISCOVERY = "openid_discovery"
@@ -171,7 +168,10 @@ class LedgerFeatures(SupportsBackends, SupportsPubkey):
                         {
                             _METHOD: method.name,
                             _UNIT: unit.name,
-                            _COMMANDS: [_BOLT11_MELT_QUOTE, _PROOF_STATE],
+                            _COMMANDS: [
+                                JSONRPCSubscriptionKinds.BOLT11_MELT_QUOTE.value,
+                                JSONRPCSubscriptionKinds.PROOF_STATE.value,
+                            ],
                         }
                     )
                     if unit_dict[unit].supports_incoming_payment_stream:
@@ -179,7 +179,8 @@ class LedgerFeatures(SupportsBackends, SupportsPubkey):
                             websocket_features[_SUPPORTED][-1][_COMMANDS]
                         )
                         websocket_features[_SUPPORTED][-1][_COMMANDS] = (
-                            supported_features + [_BOLT11_MINT_QUOTE]
+                            supported_features
+                            + [JSONRPCSubscriptionKinds.BOLT11_MINT_QUOTE.value]
                         )
 
         if websocket_features:

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -583,7 +583,7 @@ class Ledger(
         methods = set([q.method for q in quotes])
         if len(methods) > 1:
             raise TransactionError("all quotes must have the same method")
-        if "bolt11" not in methods:
+        if Method.bolt11.name not in methods:
             raise TransactionError("all quotes must be of bolt11 method")
 
         # Check currency unit consistency
@@ -607,7 +607,7 @@ class Ledger(
                 raise TransactionError("quote_amounts length must match quotes length")
             for i, quote in enumerate(quotes):
                 if (
-                    quote.method == "bolt11"
+                    quote.method == Method.bolt11.name
                     and payload.quote_amounts[i] != quote.amount
                 ):
                     raise TransactionError(
@@ -619,7 +619,7 @@ class Ledger(
                     )
 
         quote_amounts = payload.quote_amounts or [q.amount for q in quotes]
-        if "bolt11" in methods:
+        if Method.bolt11.name in methods:
             if sum(quote_amounts) != sum_amount_outputs:
                 raise TransactionError(
                     "amount to mint does not match quote amounts sum"

--- a/cashu/mint/router_deprecated.py
+++ b/cashu/mint/router_deprecated.py
@@ -144,7 +144,9 @@ async def request_mint_deprecated(
         raise CashuError(code=0, detail="Amount must be a valid amount of sat.")
     if settings.mint_bolt11_disable_mint:
         raise CashuError(code=0, detail="Mint does not allow minting new tokens.")
-    quote = await ledger.mint_quote(PostMintQuoteRequest(amount=amount, unit="sat"))
+    quote = await ledger.mint_quote(
+        PostMintQuoteRequest(amount=amount, unit=Unit.sat.name)
+    )
     resp = GetMintResponse_deprecated(pr=quote.request, hash=quote.quote)
     logger.trace(f"< GET /mint: {resp}")
     return resp
@@ -228,7 +230,7 @@ async def melt_deprecated(
         outputs = []
     # END BACKWARDS COMPATIBILITY < 0.14
     quote = await ledger.melt_quote(
-        PostMeltQuoteRequest(request=payload.pr, unit="sat")
+        PostMeltQuoteRequest(request=payload.pr, unit=Unit.sat.name)
     )
     melt_resp = await ledger.melt(
         proofs=payload.proofs, quote=quote.quote, outputs=outputs
@@ -258,7 +260,7 @@ async def check_fees(
     """
     logger.trace(f"> POST /checkfees: {payload}")
     quote = await ledger.melt_quote(
-        PostMeltQuoteRequest(request=payload.pr, unit="sat")
+        PostMeltQuoteRequest(request=payload.pr, unit=Unit.sat.name)
     )
     fees_sat = quote.fee_reserve
     logger.trace(f"< POST /checkfees: {fees_sat}")

--- a/cashu/wallet/cli/cli.py
+++ b/cashu/wallet/cli/cli.py
@@ -575,7 +575,7 @@ async def invoice(
     # user requests an invoice
     if amount and not id:
         mint_supports_websockets = wallet.mint_info.supports_websocket_mint_quote(
-            Method["bolt11"], wallet.unit
+            Method.bolt11, wallet.unit
         )
         if mint_supports_websockets and not no_check:
             mint_quote, subscription = await wallet.request_mint_with_callback(

--- a/cashu/wallet/mint_info.py
+++ b/cashu/wallet/mint_info.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel
 
 from ..core.base import Method, Unit
+from ..core.json_rpc.base import JSONRPCSubscriptionKinds
 from ..core.models import MintInfoContact, Nut15MppSupport
 from ..core.nuts.nuts import MINT_QUOTE_SIGNATURE_NUT, MPP_NUT, WEBSOCKETS_NUT
 
@@ -51,7 +52,10 @@ class MintInfo(BaseModel):
         websocket_supported = websocket_settings["supported"]
         for entry in websocket_supported:
             if entry["method"] == method.name and entry["unit"] == unit.name:
-                if "bolt11_mint_quote" in entry["commands"]:
+                if (
+                    JSONRPCSubscriptionKinds.BOLT11_MINT_QUOTE.value
+                    in entry["commands"]
+                ):
                     return True
         return False
 

--- a/cashu/wallet/v1_api.py
+++ b/cashu/wallet/v1_api.py
@@ -561,7 +561,7 @@ class LedgerAPI(SupportsAuth):
             return PostMeltQuoteResponse(
                 quote=quote,
                 amount=0,
-                unit="sat",
+                unit=Unit.sat.name,
                 method=Method.bolt11.name,
                 request="lnbc0",
                 fee_reserve=0,

--- a/cashu/wallet/v1_api.py
+++ b/cashu/wallet/v1_api.py
@@ -13,6 +13,7 @@ from ..core.base import (
     BlindedMessage,
     BlindedSignature,
     MeltQuoteState,
+    Method,
     Proof,
     ProofSpentState,
     ProofState,
@@ -561,7 +562,7 @@ class LedgerAPI(SupportsAuth):
                 quote=quote,
                 amount=0,
                 unit="sat",
-                method="bolt11",
+                method=Method.bolt11.name,
                 request="lnbc0",
                 fee_reserve=0,
                 state=(

--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -14,6 +14,7 @@ from ..core.base import (
     DLEQWallet,
     MeltQuote,
     MeltQuoteState,
+    Method,
     MintQuote,
     MintQuoteState,
     Proof,
@@ -832,7 +833,9 @@ class Wallet(
         """
         Fetches a melt quote from the mint and either uses the amount in the invoice or the amount provided.
         """
-        if amount_msat and not self.mint_info.supports_mpp("bolt11", self.unit):
+        if amount_msat and not self.mint_info.supports_mpp(
+            Method.bolt11.name, self.unit
+        ):
             raise Exception("Mint does not support MPP, cannot specify amount.")
         melt_quote_resp = await super().melt_quote(invoice, self.unit, amount_msat)
         logger.debug(


### PR DESCRIPTION
## Fixes #1066 

## Summary
This is a move only refactor and every changed line replaces a hardcoded literal with a reference to a constant that already exists in a central place. No behavior, wire format, or stored database values change.

What moved:
- The ten `"bolt11"` method literals to the `Method` enum (`.name` in string contexts, the member itself where the callee is typed `Method`); 
- The websocket subscription kinds to `JSONRPCSubscriptionKinds` (`.value` is used here since that enum is string-valued) and deletion of the redundant `_BOLT11`/`_BOLT11_*`/`_PROOF_STATE` locals plus the unused `_MPP`. 
- No new central constants were introduced — they all already existed, and NUT numbers are already fully centralized.

Verification:
- ruff, ruff-format, mypy and 677 tests all pass unchanged. 
- Existing tests deliberately untouched, since the ones asserting literal wire values are what prove behavior-neutrality.

Possible follow-ups: 
- unit="sat" to Unit.sat.name, 
- the sat/msat 1000 factor,