### PR TITLE
fix(mint): validate blinded output points

### DIFF
--- a/cashu/mint/verification.py
+++ b/cashu/mint/verification.py
@@ -123,7 +123,6 @@ class LedgerVerification(
         expected_unit: Optional[Unit] = None,
         conn: Optional[Connection] = None,
     ):
-
         """Verify that the outputs are valid."""
         logger.trace(f"Verifying {len(outputs)} outputs.")
         if not outputs:
@@ -140,6 +139,12 @@ class LedgerVerification(
             raise TransactionError(
                 f"output unit {self.keysets[outputs[0].id].unit.name} does not match quote unit {expected_unit.name}"
             )
+        # Verify that all blinded messages are valid curve points
+        for output in outputs:
+            try:
+                PublicKey(bytes.fromhex(output.B_))
+            except ValueError:
+                raise TransactionError("invalid blinded message.")
         # Verify amounts of outputs
         # we skip the amount check for NUT-8 change outputs (which can have amount 0)
         if not skip_amount_check:

--- a/cashu/mint/verification.py
+++ b/cashu/mint/verification.py
@@ -140,11 +140,8 @@ class LedgerVerification(
                 f"output unit {self.keysets[outputs[0].id].unit.name} does not match quote unit {expected_unit.name}"
             )
         # Verify that all blinded messages are valid curve points
-        for output in outputs:
-            try:
-                PublicKey(bytes.fromhex(output.B_))
-            except ValueError:
-                raise TransactionError("invalid blinded message.")
+        if not all([self._verify_blinded_message(o) for o in outputs]):
+            raise TransactionError("invalid blinded message.")
         # Verify amounts of outputs
         # we skip the amount check for NUT-8 change outputs (which can have amount 0)
         if not skip_amount_check:
@@ -262,6 +259,14 @@ class LedgerVerification(
     def _verify_no_duplicate_outputs(self, outputs: List[BlindedMessage]) -> bool:
         B_s = [od.B_ for od in outputs]
         if len(B_s) != len(list(set(B_s))):
+            return False
+        return True
+
+    def _verify_blinded_message(self, output: BlindedMessage) -> bool:
+        """Verifies that a blinded message is a valid curve point."""
+        try:
+            PublicKey(bytes.fromhex(output.B_))
+        except ValueError:
             return False
         return True
 

--- a/tests/mint/test_mint.py
+++ b/tests/mint/test_mint.py
@@ -116,7 +116,7 @@ async def test_mint_invalid_blinded_message(ledger: Ledger):
     ]
     await assert_err(
         ledger.mint(outputs=blinded_messages_mock_invalid_key, quote_id=quote.quote),
-        "The public key could not be parsed or is invalid.",
+        "invalid blinded message.",
     )
 
 

--- a/tests/mint/test_mint_verification.py
+++ b/tests/mint/test_mint_verification.py
@@ -542,6 +542,17 @@ async def test_verify_outputs_rejects_inactive_keyset(ledger: Ledger):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("blinded_message", ["not-hex", "deadbeefcafe"])
+async def test_verify_outputs_rejects_invalid_blinded_message(
+    ledger: Ledger, blinded_message: str
+):
+    output = _blinded_output(ledger).model_copy(update={"B_": blinded_message})
+
+    with pytest.raises(TransactionError, match="invalid blinded message"):
+        await ledger._verify_outputs([output], skip_amount_check=True)
+
+
+@pytest.mark.asyncio
 async def test_verify_outputs_rejects_duplicate_blinds(ledger: Ledger):
     o = _blinded_output(ledger, label="dupb")
     with pytest.raises(TransactionDuplicateOutputsError):


### PR DESCRIPTION
## Summary

- validate blinded output values as secp256k1 points during output verification
- return a transaction error for malformed values
- cover invalid hex and invalid point encodings

## Testing

- `poetry run pytest tests/mint/test_mint_verification.py -q`
- `poetry run ruff check cashu/mint/verification.py tests/mint/test_mint_verification.py`
- `poetry run mypy cashu/mint/verification.py`