### PR TITLE
feat(lightning): add setting to allow LND self-payments  Closes #1092

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,10 @@ MINT_LND_REST_CERT="/home/lnd/.lnd/tls.cert"
 MINT_LND_REST_MACAROON="/home/lnd/.lnd/data/chain/bitcoin/regtest/admin.macaroon"
 MINT_LND_REST_CERT_VERIFY=TRUE
 
+# Allow LND to pay its own invoices (self-payments). Applies to both
+# LndRPCWallet and LndRestWallet. Default is FALSE.
+# MINT_LND_ALLOW_SELF_PAYMENT=FALSE
+
 # Use with CLNRestWallet
 MINT_CLNREST_URL=https://localhost:3010
 MINT_CLNREST_CERT="./clightning-2/regtest/ca.pem"

--- a/cashu/core/settings.py
+++ b/cashu/core/settings.py
@@ -316,12 +316,14 @@ class LndRestFundingSource(MintSettings):
     mint_lnd_rest_admin_macaroon: Optional[str] = Field(default=None)
     mint_lnd_rest_invoice_macaroon: Optional[str] = Field(default=None)
     mint_lnd_enable_mpp: bool = Field(default=True)
+    mint_lnd_allow_self_payment: bool = Field(default=False)
 
 
 class LndRPCFundingSource(MintSettings):
     mint_lnd_rpc_endpoint: Optional[str] = Field(default=None)
     mint_lnd_rpc_cert: Optional[str] = Field(default=None)
     mint_lnd_rpc_macaroon: Optional[str] = Field(default=None)
+    mint_lnd_allow_self_payment: bool = Field(default=False)
 
 
 class CLNRestFundingSource(MintSettings):

--- a/cashu/lightning/lnd_grpc/lnd_grpc.py
+++ b/cashu/lightning/lnd_grpc/lnd_grpc.py
@@ -177,6 +177,7 @@ class LndRPCWallet(LightningBackend):
             fee_limit_msat=fee_limit_msat,
             timeout_seconds=PAYMENT_TIMEOUT_SECONDS,
             no_inflight_updates=True,
+            allow_self_payment=settings.mint_lnd_allow_self_payment,
         )
         try:
             async with grpc.aio.secure_channel(

--- a/cashu/lightning/lndrest.py
+++ b/cashu/lightning/lndrest.py
@@ -210,6 +210,7 @@ class LndRestWallet(LightningBackend):
             "fee_limit_msat": str(fee_limit_msat),
             "timeout_seconds": PAYMENT_TIMEOUT_SECONDS,
             "no_inflight_updates": True,
+            "allow_self_payment": settings.mint_lnd_allow_self_payment,
         }
 
         async with self.client.stream(

--- a/tests/lightning/test_lightning_backends_mocked.py
+++ b/tests/lightning/test_lightning_backends_mocked.py
@@ -425,6 +425,51 @@ async def test_lndrest_pay_invoice_settled_reads_stream_result(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("enabled, expected", [(True, True), (False, False)])
+async def test_lndrest_pay_invoice_sends_allow_self_payment(
+    monkeypatch, enabled, expected
+):
+    wallet = object.__new__(LndRestWallet)
+    wallet.unit = Unit.sat
+    wallet.supports_mpp = False
+
+    captured: dict[str, Any] = {}
+
+    lines = [
+        json.dumps(
+            {
+                "result": {
+                    "status": "SUCCEEDED",
+                    "payment_hash": "11" * 32,
+                    "fee_msat": "7",
+                    "payment_preimage": "ab" * 32,
+                }
+            }
+        )
+    ]
+
+    class Client:
+        def stream(self, method, url, json=None, timeout=None):
+            captured["json"] = json
+            return _StreamResponse(lines)
+
+    cast(Any, wallet).client = Client()
+    monkeypatch.setattr(
+        "cashu.lightning.lndrest.bolt11.decode",
+        lambda request: SimpleNamespace(amount_msat=1000),
+    )
+    monkeypatch.setattr(
+        "cashu.lightning.lndrest.settings.mint_lnd_allow_self_payment",
+        enabled,
+    )
+    result = await wallet.pay_invoice(
+        _quote("lnbc1fake", amount=1), fee_limit_msat=1000
+    )
+    assert result.result == PaymentResult.SETTLED
+    assert captured["json"]["allow_self_payment"] is expected
+
+
+@pytest.mark.asyncio
 async def test_lndrest_pay_invoice_returns_failed_on_payment_failure(monkeypatch):
     wallet = object.__new__(LndRestWallet)
     wallet.unit = Unit.sat

--- a/tests/lightning/test_lnd_grpc_pay_invoice.py
+++ b/tests/lightning/test_lnd_grpc_pay_invoice.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from cashu.core.base import MeltQuote, MeltQuoteState, Unit
+from cashu.lightning.base import PaymentResult
+from cashu.lightning.lnd_grpc.lnd_grpc import LndRPCWallet
+
+
+def _quote(request: str, amount: int = 1) -> MeltQuote:
+    return MeltQuote(
+        quote="q1",
+        method="bolt11",
+        request=request,
+        checking_id="checking-1",
+        unit="sat",
+        amount=amount,
+        fee_reserve=1,
+        state=MeltQuoteState.unpaid,
+    )
+
+
+class FakePayment:
+    status = 2
+    payment_hash = "11" * 32
+    fee_msat = 7
+    payment_preimage = "ab" * 32
+    failure_reason = 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("enabled, expected", [(True, True), (False, False)])
+async def test_lndrpc_pay_invoice_sends_allow_self_payment(
+    monkeypatch, enabled, expected
+):
+    wallet = object.__new__(LndRPCWallet)
+    wallet.unit = Unit.sat
+    wallet.supports_mpp = False
+    wallet.endpoint = "localhost:10009"
+    wallet.combined_creds = None
+
+    captured: dict[str, Any] = {}
+
+    class FakeStub:
+        def __init__(self, channel):
+            pass
+
+        async def SendPaymentV2(self, request):
+            captured["request"] = request
+            yield FakePayment()
+
+    class FakeChannel:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(
+        "cashu.lightning.lnd_grpc.lnd_grpc.grpc.aio.secure_channel",
+        lambda *args, **kwargs: FakeChannel(),
+    )
+    monkeypatch.setattr(
+        "cashu.lightning.lnd_grpc.lnd_grpc.routerstub.RouterStub",
+        FakeStub,
+    )
+    monkeypatch.setattr(
+        "cashu.lightning.lnd_grpc.lnd_grpc.bolt11.decode",
+        lambda request: SimpleNamespace(amount_msat=1000),
+    )
+    monkeypatch.setattr(
+        "cashu.lightning.lnd_grpc.lnd_grpc.settings.mint_lnd_allow_self_payment",
+        enabled,
+    )
+
+    result = await wallet.pay_invoice(
+        _quote("lnbc1fake", amount=1), fee_limit_msat=1000
+    )
+    assert result.result == PaymentResult.SETTLED
+    assert captured["request"].allow_self_payment is expected

--- a/tests/lightning/test_lnd_self_payment_regtest.py
+++ b/tests/lightning/test_lnd_self_payment_regtest.py
@@ -1,0 +1,51 @@
+import importlib
+
+import pytest
+
+from cashu.core.base import Amount, MeltQuote, MeltQuoteState, Unit
+from cashu.core.settings import settings
+from cashu.lightning.base import LightningBackend, PaymentResult
+
+LND_BACKENDS = {"LndRPCWallet", "LndRestWallet"}
+
+
+@pytest.mark.asyncio
+async def test_lnd_can_pay_its_own_invoice_when_enabled(monkeypatch):
+    backend_name = settings.mint_backend_bolt11_sat
+    if backend_name not in LND_BACKENDS:
+        pytest.skip("requires an LND regtest backend")
+
+    monkeypatch.setattr(settings, "mint_lnd_allow_self_payment", True)
+    wallets_module = importlib.import_module("cashu.lightning")
+    backend: LightningBackend = getattr(wallets_module, backend_name)(unit=Unit.sat)
+
+    try:
+        invoice = await backend.create_invoice(
+            Amount(unit=Unit.sat, amount=10), memo="self-payment integration test"
+        )
+        assert invoice.ok
+        assert invoice.payment_request
+        assert invoice.checking_id
+
+        quote = MeltQuote(
+            quote="self-payment-integration-test",
+            method="bolt11",
+            request=invoice.payment_request,
+            checking_id=invoice.checking_id,
+            unit=Unit.sat.name,
+            amount=10,
+            fee_reserve=10,
+            state=MeltQuoteState.unpaid,
+        )
+        payment = await backend.pay_invoice(quote, fee_limit_msat=10_000)
+
+        assert payment.result == PaymentResult.SETTLED, payment.error_message
+        assert payment.checking_id == invoice.checking_id
+        assert payment.preimage
+
+        invoice_status = await backend.get_invoice_status(invoice.checking_id)
+        assert invoice_status.result == PaymentResult.SETTLED
+    finally:
+        client = getattr(backend, "client", None)
+        if client is not None:
+            await client.aclose()

--- a/tests/lightning/test_lnd_settings.py
+++ b/tests/lightning/test_lnd_settings.py
@@ -1,0 +1,16 @@
+from cashu.core.settings import LndRestFundingSource, LndRPCFundingSource
+
+
+def test_lnd_allow_self_payment_defaults_to_false():
+    rest = LndRestFundingSource(_env_file=None)
+    rpc = LndRPCFundingSource(_env_file=None)
+    assert rest.mint_lnd_allow_self_payment is False
+    assert rpc.mint_lnd_allow_self_payment is False
+
+
+def test_lnd_allow_self_payment_reads_env(monkeypatch):
+    monkeypatch.setenv("MINT_LND_ALLOW_SELF_PAYMENT", "true")
+    rest = LndRestFundingSource(_env_file=None)
+    rpc = LndRPCFundingSource(_env_file=None)
+    assert rest.mint_lnd_allow_self_payment is True
+    assert rpc.mint_lnd_allow_self_payment is True


### PR DESCRIPTION
Closes #1092 


## Summary
Adds a `MINT_LND_ALLOW_SELF_PAYMENT` setting (default `false`) that
forwards LND's `allow_self_payment` flag on outgoing payments, so a mint
can pay its own invoices (self-payments). Applied to both LND backends.

## Changes
- `cashu/core/settings.py`: new `mint_lnd_allow_self_payment` field on
  `LndRestFundingSource` and `LndRPCFundingSource`
- `cashu/lightning/lndrest.py`: send `allow_self_payment` in the
  `/v2/router/send` payload
- `cashu/lightning/lnd_grpc/lnd_grpc.py`: set `allow_self_payment` on
  `SendPaymentRequest`
- `.env.example`: document the new variable
- tests: REST payload, gRPC request, and settings parse (default + env)

## Testing
- `tests/lightning`: 43 passed (6 new)
- `tests/mint`: 401 passed; `tests/wallet`: 276 passed
- `make format` and `make check` both clean