### PR TITLE
Align route and payment state handling

### DIFF
--- a/cashu/mint/app.py
+++ b/cashu/mint/app.py
@@ -117,12 +117,21 @@ async def catch_exceptions(request: Request, call_next):
 # Add exception handlers
 app.add_exception_handler(RequestValidationError, request_validation_exception_handler)  # type: ignore
 
+def include_mint_routers(app: FastAPI) -> None:
+    if settings.debug_mint_only_deprecated and not settings.mint_require_auth:
+        app.include_router(
+            router=router_deprecated, tags=["Deprecated"], deprecated=True
+        )
+    else:
+        app.include_router(router=router, tags=["Mint"])
+        if not settings.mint_require_auth:
+            app.include_router(
+                router=router_deprecated, tags=["Deprecated"], deprecated=True
+            )
+
+
 # Add routers
-if settings.debug_mint_only_deprecated:
-    app.include_router(router=router_deprecated, tags=["Deprecated"], deprecated=True)
-else:
-    app.include_router(router=router, tags=["Mint"])
-    app.include_router(router=router_deprecated, tags=["Deprecated"], deprecated=True)
+include_mint_routers(app)
 
 if settings.mint_require_auth:
     app.include_router(auth_router, tags=["Auth"])

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -1234,8 +1234,9 @@ class Ledger(
                         return PostMeltQuoteResponse.from_melt_quote(melt_quote)
 
                     match status.result:
-                        case PaymentResult.FAILED | PaymentResult.UNKNOWN:
-                            # Everything as expected. Payment AND a status check both agree on a failure. We roll back the transaction.
+                        case PaymentResult.FAILED:
+                            # Only an explicit terminal failure makes it safe to
+                            # release the proofs back to the caller.
                             await self.db_write.unset_melt_quote_pending_and_proofs(
                                 quote=melt_quote,
                                 proofs=proofs,
@@ -1249,6 +1250,12 @@ class Ledger(
                             raise LightningPaymentFailedError(
                                 f"Lightning payment failed{': ' + payment.error_message if payment.error_message else ''}."
                             )
+                        case PaymentResult.UNKNOWN:
+                            logger.error(
+                                f"Payment state for melt quote {melt_quote.quote} remains UNKNOWN. Proofs remain PENDING."
+                            )
+                            self.disable_melt = True
+                            return PostMeltQuoteResponse.from_melt_quote(melt_quote)
                         case _:
                             # Something went wrong with our implementation or the backend. Status check returned different result than payment. Keep transaction pending and return.
                             logger.error(

--- a/tests/mint/test_mint_app.py
+++ b/tests/mint/test_mint_app.py
@@ -1,0 +1,22 @@
+from fastapi import FastAPI
+
+from cashu.core.settings import settings
+from cashu.mint.app import include_mint_routers
+
+
+def test_auth_enabled_does_not_mount_deprecated_transaction_routes(monkeypatch):
+    monkeypatch.setattr(settings, "mint_require_auth", True)
+    monkeypatch.setattr(settings, "debug_mint_only_deprecated", False)
+    test_app = FastAPI()
+
+    include_mint_routers(test_app)
+
+    mounted_routes = {
+        (method, route.path)
+        for route in test_app.routes
+        for method in getattr(route, "methods", set())
+    }
+    assert ("POST", "/v1/swap") in mounted_routes
+    assert ("POST", "/mint") not in mounted_routes
+    assert ("POST", "/melt") not in mounted_routes
+    assert ("POST", "/split") not in mounted_routes

--- a/tests/mint/test_mint_melt.py
+++ b/tests/mint/test_mint_melt.py
@@ -407,29 +407,26 @@ async def test_melt_lightning_pay_invoice_failed_failed(ledger: Ledger, wallet: 
     except LightningPaymentFailedError:
         pass
 
-    settings.fakewallet_payment_state = PaymentResult.UNKNOWN.name
-    settings.fakewallet_pay_invoice_state = PaymentResult.FAILED.name
-    try:
-        await ledger.melt(proofs=wallet.proofs, quote=quote_id)
-        raise AssertionError("Expected LightningPaymentFailedError")
-    except LightningPaymentFailedError:
-        pass
-
-    settings.fakewallet_payment_state = PaymentResult.FAILED.name
-    settings.fakewallet_pay_invoice_state = PaymentResult.UNKNOWN.name
-    try:
-        await ledger.melt(proofs=wallet.proofs, quote=quote_id)
-        raise AssertionError("Expected LightningPaymentFailedError")
-    except LightningPaymentFailedError:
-        pass
+@pytest.mark.asyncio
+@pytest.mark.skipif(is_regtest, reason="only fake wallet")
+async def test_melt_lightning_unknown_status_keeps_proofs_pending(
+    ledger: Ledger, wallet: Wallet
+):
+    mint_quote = await wallet.request_mint(64)
+    await ledger.get_mint_quote(mint_quote.quote)
+    await wallet.mint(64, quote_id=mint_quote.quote)
+    invoice = "lnbcrt620n1pn0r3vepp5zljn7g09fsyeahl4rnhuy0xax2puhua5r3gspt7ttlfrley6valqdqqcqzzsxqyz5vqsp577h763sel3q06tfnfe75kvwn5pxn344sd5vnays65f9wfgx4fpzq9qxpqysgqg3re9afz9rwwalytec04pdhf9mvh3e2k4r877tw7dr4g0fvzf9sny5nlfggdy6nduy2dytn06w50ls34qfldgsj37x0ymxam0a687mspp0ytr8"
+    quote_id = (
+        await ledger.melt_quote(PostMeltQuoteRequest(unit="sat", request=invoice))
+    ).quote
 
     settings.fakewallet_payment_state = PaymentResult.UNKNOWN.name
     settings.fakewallet_pay_invoice_state = PaymentResult.UNKNOWN.name
-    try:
-        await ledger.melt(proofs=wallet.proofs, quote=quote_id)
-        raise AssertionError("Expected LightningPaymentFailedError")
-    except LightningPaymentFailedError:
-        pass
+    response = await ledger.melt(proofs=wallet.proofs, quote=quote_id)
+
+    assert response.state == MeltQuoteState.pending.value
+    states = await ledger.db_read.get_proofs_states([p.Y for p in wallet.proofs])
+    assert all(state.pending for state in states)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- omit deprecated transaction routes when access controls are enabled
- retain pending proofs while a payment backend remains indeterminate
- add focused regression coverage for both state transitions

## Validation

- `poetry run ruff check` on changed Python modules
- `tests/mint/test_mint_app.py tests/mint/test_mint_melt.py`: 24 passed, 1 skipped