### PR TITLE
feat(mint): loosen NUT-29 batch quote checks

### DIFF
--- a/cashu/core/models/__init__.py
+++ b/cashu/core/models/__init__.py
@@ -30,6 +30,8 @@ from .mint import (
 )
 from .mint_quote import (
     PostMintQuoteCheckRequest,
+    PostMintQuoteCheckResponse,
+    PostMintQuoteCheckUnknownResponse,
     PostMintQuoteRequest,
     PostMintQuoteResponse,
 )
@@ -62,6 +64,8 @@ __all__ = [
     "PostMintRequest",
     "PostMintResponse",
     "PostMintQuoteCheckRequest",
+    "PostMintQuoteCheckResponse",
+    "PostMintQuoteCheckUnknownResponse",
     "PostMintQuoteRequest",
     "PostMintQuoteResponse",
     "PostRestoreRequest",

--- a/cashu/core/models/mint_quote.py
+++ b/cashu/core/models/mint_quote.py
@@ -1,4 +1,4 @@
-from typing import Annotated, List, Optional
+from typing import Annotated, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -27,6 +27,24 @@ class PostMintQuoteCheckRequest(BaseModel):
     quotes: List[Annotated[str, Field(max_length=MAX_QUOTE_ID_LEN)]] = Field(
         ..., max_length=settings.mint_max_request_length
     )
+
+
+class PostMintQuoteCheckUnknownResponse(BaseModel):
+    quote: str
+    unknown: Literal[True] = True
+
+
+class PostMintQuoteCheckResponse(BaseModel):
+    quote: str
+    request: str
+    amount: int
+    unit: str
+    method: str
+    amount_paid: int
+    amount_issued: int
+    updated_at: int
+    expiry: Optional[int] = None
+    pubkey: Optional[str] = None
 
 
 class PostMintQuoteResponse(BaseModel):

--- a/cashu/core/models/mint_quote.py
+++ b/cashu/core/models/mint_quote.py
@@ -9,7 +9,6 @@ from cashu.core.constants import (
     MAX_QUOTE_ID_LEN,
     MAX_UNIT_LEN,
 )
-from cashu.core.settings import settings
 
 
 class PostMintQuoteRequest(BaseModel):
@@ -24,9 +23,11 @@ class PostMintQuoteRequest(BaseModel):
 
 
 class PostMintQuoteCheckRequest(BaseModel):
-    quotes: List[Annotated[str, Field(max_length=MAX_QUOTE_ID_LEN)]] = Field(
-        ..., max_length=settings.mint_max_request_length
-    )
+    # NOTE: quote IDs longer than MAX_QUOTE_ID_LEN are rejected with a 422
+    # validation error (DoS protection). Shorter unknown or malformed IDs are
+    # returned as `unknown` entries per NUT-29, and an oversized batch is
+    # rejected with error 11017 by the mint.
+    quotes: List[Annotated[str, Field(max_length=MAX_QUOTE_ID_LEN)]]
 
 
 class PostMintQuoteCheckUnknownResponse(BaseModel):

--- a/cashu/mint/db/write.py
+++ b/cashu/mint/db/write.py
@@ -296,9 +296,72 @@ class DbWriteHelper:
                     raise TransactionError(
                         f"Mint quote {quote_id} not pending: {quote.state.value}. Cannot set as {state.value}."
                     )
-                # set the quote to previous state
-                self._set_mint_quote_state(quote, state)
+                # set the quote to the previous state without touching its
+                # accounting fields (amount_paid / amount_issued)
+                quote.state_val = state
+                quote.updated_at = int(time.time())
                 logger.trace(f"crud: setting quote {quote_id} as {state.value}")
+                await self.crud.update_mint_quote(quote=quote, db=self.db, conn=conn)
+                quotes.append(quote)
+
+        for quote in quotes:
+            await self.events.submit(quote)
+        return quotes
+
+    async def _issue_mint_quotes(
+        self, quote_ids: List[str], amounts: List[int]
+    ) -> List[MintQuote]:
+        """Issues multiple pending mint quotes (NUT-29 batch mint).
+
+        Atomically increases each quote's amount_issued by the corresponding
+        amount. The quote becomes ISSUED once amount_issued reaches
+        amount_paid, otherwise it returns to PAID with the remaining mintable
+        amount.
+
+        Args:
+            quote_ids (List[str]): List of mint quote IDs to issue.
+            amounts (List[int]): Amount issued per quote, in the same order as
+                quote_ids.
+        """
+        if not quote_ids:
+            return []
+
+        quotes: List[MintQuote] = []
+        lock_parameters = {f"quote_{i}": q for i, q in enumerate(quote_ids)}
+        lock_select_statement = (
+            "quote IN ("
+            + ", ".join([f":quote_{i}" for i in range(len(quote_ids))])
+            + ")"
+        )
+
+        async with self.db.get_connection(
+            lock_table="mint_quotes",
+            lock_select_statement=lock_select_statement,
+            lock_parameters=lock_parameters,
+        ) as conn:
+            for quote_id, amount in zip(quote_ids, amounts):
+                quote = await self.crud.get_mint_quote(
+                    quote_id=quote_id, db=self.db, conn=conn
+                )
+                if not quote:
+                    raise TransactionError(f"Mint quote {quote_id} not found.")
+                if quote.state != MintQuoteState.pending:
+                    raise TransactionError(
+                        f"Mint quote {quote_id} not pending: {quote.state.value}. Cannot issue."
+                    )
+                now = int(time.time())
+                quote.amount_issued = (quote.amount_issued or 0) + amount
+                if (
+                    quote.amount_paid is not None
+                    and quote.amount_issued >= quote.amount_paid
+                ):
+                    quote.state_val = MintQuoteState.issued
+                    if not quote.issued_time:
+                        quote.issued_time = now
+                else:
+                    quote.state_val = MintQuoteState.paid
+                quote.updated_at = now
+                logger.trace(f"crud: issuing quote {quote_id} amount {amount}")
                 await self.crud.update_mint_quote(quote=quote, db=self.db, conn=conn)
                 quotes.append(quote)
 

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -473,9 +473,12 @@ class Ledger(
         """
         quotes: List[MintQuote] = []
         for quote_id in payload.quotes:
+            stored_quote = await self.crud.get_mint_quote(
+                quote_id=quote_id, db=self.db
+            )
+            if not stored_quote:
+                continue
             quote = await self.get_mint_quote(quote_id)
-            if not quote:
-                raise TransactionError(f"quote {quote_id} not found")
             quotes.append(quote)
         return quotes
 
@@ -596,9 +599,13 @@ class Ledger(
         for quote in quotes:
             if quote.pending:
                 raise TransactionError("mint quote already pending")
-            if quote.issued:
-                raise QuoteAlreadyIssuedError()
-            if quote.state != MintQuoteState.paid:
+            if (
+                quote.amount_paid is None
+                or quote.amount_issued is None
+                or quote.amount_paid - quote.amount_issued <= 0
+            ):
+                if quote.issued:
+                    raise QuoteAlreadyIssuedError()
                 raise QuoteNotPaidError()
 
         # Check amount balance

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -462,21 +462,23 @@ class Ledger(
 
     async def mint_quote_check(
         self, payload: PostMintQuoteCheckRequest
-    ) -> List[MintQuote]:
+    ) -> List[Optional[MintQuote]]:
         """Batch check mint quotes.
 
         Args:
             payload (PostMintQuoteCheckRequest): Request payload containing quote IDs.
 
         Returns:
-            List[MintQuote]: List of mint quotes matching the request.
+            List[Optional[MintQuote]]: Mint quotes or ``None`` for unknown IDs,
+                in request order.
         """
-        quotes: List[MintQuote] = []
+        quotes: List[Optional[MintQuote]] = []
         for quote_id in payload.quotes:
             stored_quote = await self.crud.get_mint_quote(
                 quote_id=quote_id, db=self.db
             )
             if not stored_quote:
+                quotes.append(None)
                 continue
             quote = await self.get_mint_quote(quote_id)
             quotes.append(quote)

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -19,6 +19,7 @@ from ..core.base import (
     Proof,
     Unit,
 )
+from ..core.constants import MAX_QUOTE_ID_LEN
 from ..core.crypto import b_dhke
 from ..core.crypto.aes import AESCipher
 from ..core.crypto.keys import (
@@ -29,6 +30,7 @@ from ..core.crypto.secp import PrivateKey, PublicKey
 from ..core.db import Connection, Database
 from ..core.errors import (
     BatchDuplicateQuotesError,
+    BatchSizeExceededError,
     CashuError,
     KeysetInactiveError,
     LightningError,
@@ -472,11 +474,18 @@ class Ledger(
             List[Optional[MintQuote]]: Mint quotes or ``None`` for unknown IDs,
                 in request order.
         """
+        if len(payload.quotes) > settings.mint_max_request_length:
+            raise BatchSizeExceededError()
+        if len(set(payload.quotes)) != len(payload.quotes):
+            raise BatchDuplicateQuotesError()
+
         quotes: List[Optional[MintQuote]] = []
         for quote_id in payload.quotes:
-            stored_quote = await self.crud.get_mint_quote(
-                quote_id=quote_id, db=self.db
-            )
+            # overlong IDs are definitionally unknown; never hit the db with them
+            if len(quote_id) > MAX_QUOTE_ID_LEN:
+                quotes.append(None)
+                continue
+            stored_quote = await self.crud.get_mint_quote(quote_id=quote_id, db=self.db)
             if not stored_quote:
                 quotes.append(None)
                 continue
@@ -520,6 +529,11 @@ class Ledger(
             raise QuoteAlreadyIssuedError()
         if quote.state != MintQuoteState.paid:
             raise QuoteNotPaidError()
+        if quote.amount_issued:
+            # quotes with a partial amount_issued (via NUT-29 batch mint) must be
+            # drained via batch mint; minting the full quote amount again here
+            # would issue more than was paid
+            raise TransactionError("quote already partially issued")
 
         previous_state = quote.state
         await self.db_write._set_mint_quote_pending(quote_id=quote_id)
@@ -610,24 +624,24 @@ class Ledger(
                     raise QuoteAlreadyIssuedError()
                 raise QuoteNotPaidError()
 
-        # Check amount balance
+        # Check per-quote amounts: each amount must be positive and within
+        # the quote's currently mintable amount (amount_paid - amount_issued)
         if payload.quote_amounts:
             if len(payload.quote_amounts) != len(quotes):
                 raise TransactionError("quote_amounts length must match quotes length")
             for i, quote in enumerate(quotes):
-                if (
-                    quote.method == Method.bolt11.name
-                    and payload.quote_amounts[i] != quote.amount
-                ):
+                mintable_amount = (quote.amount_paid or 0) - (quote.amount_issued or 0)
+                if payload.quote_amounts[i] <= 0:
+                    raise TransactionError("quote amounts must be positive")
+                if payload.quote_amounts[i] > mintable_amount:
                     raise TransactionError(
-                        f"quote amount {payload.quote_amounts[i]} does not match quote {quote.quote} amount {quote.amount}"
-                    )
-                if payload.quote_amounts[i] > quote.amount:
-                    raise TransactionError(
-                        f"quote amount {payload.quote_amounts[i]} exceeds quote {quote.quote} amount {quote.amount}"
+                        f"quote amount {payload.quote_amounts[i]} exceeds mintable amount of quote {quote.quote}"
                     )
 
-        quote_amounts = payload.quote_amounts or [q.amount for q in quotes]
+        # If quote_amounts is omitted, issue each quote's full mintable amount
+        quote_amounts = payload.quote_amounts or [
+            (q.amount_paid or 0) - (q.amount_issued or 0) for q in quotes
+        ]
         if Method.bolt11.name in methods:
             if sum(quote_amounts) != sum_amount_outputs:
                 raise TransactionError(
@@ -650,13 +664,9 @@ class Ledger(
                 raise QuoteSignatureInvalidError()
 
         # Set all quotes to pending
-        quotes = await self.db_write._set_mint_quotes_pending(quote_ids=payload.quotes)
+        await self.db_write._set_mint_quotes_pending(quote_ids=payload.quotes)
 
         try:
-            for quote in quotes:
-                if quote.expiry and quote.expiry < int(time.time()):
-                    raise TransactionError("quote expired")
-
             # Store all blinded messages
             await self._store_blinded_messages(
                 payload.outputs, mint_id=payload.quotes[0]
@@ -670,9 +680,9 @@ class Ledger(
             )
             raise e
 
-        # Set all quotes to issued
-        await self.db_write._unset_mint_quotes_pending(
-            quote_ids=payload.quotes, state=MintQuoteState.issued
+        # Issue the quotes: atomically increase each quote's amount_issued
+        await self.db_write._issue_mint_quotes(
+            quote_ids=payload.quotes, amounts=quote_amounts
         )
 
         return promises

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -2,6 +2,7 @@ import asyncio
 import html
 import os
 import time
+from typing import Union
 
 from fastapi import APIRouter, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
@@ -23,6 +24,8 @@ from ..core.models import (
     PostMintBatchRequest,
     PostMintBatchResponse,
     PostMintQuoteCheckRequest,
+    PostMintQuoteCheckResponse,
+    PostMintQuoteCheckUnknownResponse,
     PostMintQuoteRequest,
     PostMintQuoteResponse,
     PostMintRequest,
@@ -419,30 +422,35 @@ async def get_mint_quote(request: Request, quote: str) -> PostMintQuoteResponse:
     "/v1/mint/quote/bolt11/check",
     name="Batch check mint quotes",
     summary="Batch check mint quotes",
-    response_model=list[PostMintQuoteResponse],
+    response_model=list[
+        Union[PostMintQuoteCheckResponse, PostMintQuoteCheckUnknownResponse]
+    ],
     response_description="A list of mint quotes",
 )
 @limiter.limit(f"{settings.mint_transaction_rate_limit_per_minute}/minute")
 async def mint_quote_check(
     request: Request, payload: PostMintQuoteCheckRequest
-) -> list[PostMintQuoteResponse]:
+) -> list[Union[PostMintQuoteCheckResponse, PostMintQuoteCheckUnknownResponse]]:
     logger.trace(f"> POST /v1/mint/quote/bolt11/check: payload={payload}")
     quotes = await ledger.mint_quote_check(payload)
     resp = [
-        PostMintQuoteResponse(
-            quote=quote.quote,
-            request=quote.request,
-            amount=quote.amount,
-            unit=quote.unit,
-            method=quote.method,
-            state=str(quote.state.value),
-            expiry=quote.expiry,
-            pubkey=quote.pubkey,
-            amount_paid=quote.amount_paid,
-            amount_issued=quote.amount_issued,
-            updated_at=quote.updated_at,
+        (
+            PostMintQuoteCheckResponse(
+                quote=quote.quote,
+                request=quote.request,
+                amount=quote.amount,
+                unit=quote.unit,
+                method=quote.method,
+                expiry=quote.expiry,
+                pubkey=quote.pubkey,
+                amount_paid=quote.amount_paid or 0,
+                amount_issued=quote.amount_issued or 0,
+                updated_at=quote.updated_at or quote.created_time or int(time.time()),
+            )
+            if quote
+            else PostMintQuoteCheckUnknownResponse(quote=quote_id)
         )
-        for quote in quotes
+        for quote_id, quote in zip(payload.quotes, quotes)
     ]
     logger.trace(f"< POST /v1/mint/quote/bolt11/check: {resp}")
     return resp

--- a/tests/mint/test_mint_api.py
+++ b/tests/mint/test_mint_api.py
@@ -667,15 +667,17 @@ async def test_mint_quote_check(ledger: Ledger, wallet: Wallet):
     assert result[0]["quote"] == mint_quote1.quote
     assert result[0]["amount"] == 64
     assert result[0]["method"] == "bolt11"
-    assert result[0]["state"] in ["UNPAID", "PAID"]
+    assert "state" not in result[0]
     assert result[1]["quote"] == mint_quote2.quote
     assert result[1]["amount"] == 32
     assert result[1]["method"] == "bolt11"
-    assert result[1]["state"] in ["UNPAID", "PAID"]
+    assert "state" not in result[1]
 
 
 @pytest.mark.asyncio
-async def test_mint_quote_check_omits_unknown_quotes(ledger: Ledger, wallet: Wallet):
+async def test_mint_quote_check_returns_positional_unknown_quotes(
+    ledger: Ledger, wallet: Wallet
+):
     mint_quote1 = await wallet.request_mint(64)
     mint_quote2 = await wallet.request_mint(32)
 
@@ -692,14 +694,19 @@ async def test_mint_quote_check_omits_unknown_quotes(ledger: Ledger, wallet: Wal
     )
 
     assert response.status_code == 200, f"{response.url} {response.status_code}"
-    assert [quote["quote"] for quote in response.json()] == [
-        mint_quote1.quote,
-        mint_quote2.quote,
-    ]
+    result = response.json()
+    assert len(result) == 4
+    assert result[0]["quote"] == mint_quote1.quote
+    assert result[1] == {"quote": "not-a-valid-quote-id", "unknown": True}
+    assert result[2] == {
+        "quote": "01989999-9999-7999-8999-999999999999",
+        "unknown": True,
+    }
+    assert result[3]["quote"] == mint_quote2.quote
 
 
 @pytest.mark.asyncio
-async def test_mint_quote_check_returns_empty_for_unknown_quotes(
+async def test_mint_quote_check_returns_unknown_for_unknown_quotes(
     ledger: Ledger,
 ):
     response = httpx.post(
@@ -708,7 +715,7 @@ async def test_mint_quote_check_returns_empty_for_unknown_quotes(
     )
 
     assert response.status_code == 200, f"{response.url} {response.status_code}"
-    assert response.json() == []
+    assert response.json() == [{"quote": "not-a-valid-quote-id", "unknown": True}]
 
 
 @pytest.mark.asyncio

--- a/tests/mint/test_mint_api.py
+++ b/tests/mint/test_mint_api.py
@@ -675,6 +675,43 @@ async def test_mint_quote_check(ledger: Ledger, wallet: Wallet):
 
 
 @pytest.mark.asyncio
+async def test_mint_quote_check_omits_unknown_quotes(ledger: Ledger, wallet: Wallet):
+    mint_quote1 = await wallet.request_mint(64)
+    mint_quote2 = await wallet.request_mint(32)
+
+    response = httpx.post(
+        f"{BASE_URL}/v1/mint/quote/bolt11/check",
+        json={
+            "quotes": [
+                mint_quote1.quote,
+                "not-a-valid-quote-id",
+                "01989999-9999-7999-8999-999999999999",
+                mint_quote2.quote,
+            ]
+        },
+    )
+
+    assert response.status_code == 200, f"{response.url} {response.status_code}"
+    assert [quote["quote"] for quote in response.json()] == [
+        mint_quote1.quote,
+        mint_quote2.quote,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mint_quote_check_returns_empty_for_unknown_quotes(
+    ledger: Ledger,
+):
+    response = httpx.post(
+        f"{BASE_URL}/v1/mint/quote/bolt11/check",
+        json={"quotes": ["not-a-valid-quote-id"]},
+    )
+
+    assert response.status_code == 200, f"{response.url} {response.status_code}"
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
 async def test_mint_batch_success(ledger: Ledger, wallet: Wallet):
     mint_quote1 = await wallet.request_mint(64)
     mint_quote2 = await wallet.request_mint(32)

--- a/tests/mint/test_mint_api.py
+++ b/tests/mint/test_mint_api.py
@@ -16,6 +16,7 @@ from cashu.core.models import (
 )
 from cashu.core.nuts import nut20
 from cashu.core.nuts.nuts import MINT_NUT
+from cashu.core.settings import settings
 from cashu.mint.ledger import Ledger
 from cashu.wallet.crud import bump_secret_derivation
 from cashu.wallet.wallet import Wallet
@@ -540,9 +541,9 @@ async def test_melt_external_with_routing_fee(ledger: Ledger, wallet: Wallet):
 
     # change must compensate exactly for the unspent part of the reserve
     change_sat = sum([c.amount for c in resp_quote.change or []])
-    assert change_sat == quote.fee_reserve - melt_quote.fee_paid, (
-        "Wrong change returned"
-    )
+    assert (
+        change_sat == quote.fee_reserve - melt_quote.fee_paid
+    ), "Wrong change returned"
 
 
 @pytest.mark.asyncio
@@ -719,6 +720,53 @@ async def test_mint_quote_check_returns_unknown_for_unknown_quotes(
 
 
 @pytest.mark.asyncio
+async def test_mint_quote_check_empty_quotes(ledger: Ledger):
+    response = httpx.post(
+        f"{BASE_URL}/v1/mint/quote/bolt11/check",
+        json={"quotes": []},
+    )
+
+    assert response.status_code == 200, f"{response.url} {response.status_code}"
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_mint_quote_check_rejects_duplicate_quotes(ledger: Ledger):
+    response = httpx.post(
+        f"{BASE_URL}/v1/mint/quote/bolt11/check",
+        json={"quotes": ["duplicate_quote_id", "duplicate_quote_id"]},
+    )
+
+    assert response.status_code == 400, f"{response.url} {response.status_code}"
+    assert response.json()["code"] == 11016
+
+
+@pytest.mark.asyncio
+async def test_mint_quote_check_rejects_oversized_batch(ledger: Ledger):
+    response = httpx.post(
+        f"{BASE_URL}/v1/mint/quote/bolt11/check",
+        json={"quotes": ["quote"] * (settings.mint_max_request_length + 1)},
+    )
+
+    assert response.status_code == 400, f"{response.url} {response.status_code}"
+    assert response.json()["code"] == 11017
+
+
+@pytest.mark.asyncio
+async def test_mint_quote_check_overlong_quote_id_rejected(ledger: Ledger):
+    """Overlong quote IDs are rejected with a validation error (DoS protection)."""
+    from cashu.core.constants import MAX_QUOTE_ID_LEN
+
+    long_quote = "a" * (MAX_QUOTE_ID_LEN + 1)
+    response = httpx.post(
+        f"{BASE_URL}/v1/mint/quote/bolt11/check",
+        json={"quotes": [long_quote]},
+    )
+
+    assert response.status_code == 422, f"{response.url} {response.status_code}"
+
+
+@pytest.mark.asyncio
 async def test_mint_batch_success(ledger: Ledger, wallet: Wallet):
     mint_quote1 = await wallet.request_mint(64)
     mint_quote2 = await wallet.request_mint(32)
@@ -750,9 +798,9 @@ async def test_mint_batch_success(ledger: Ledger, wallet: Wallet):
         timeout=None,
     )
 
-    assert response.status_code == 200, (
-        f"{response.url} {response.status_code} {response.text}"
-    )
+    assert (
+        response.status_code == 200
+    ), f"{response.url} {response.status_code} {response.text}"
     result = response.json()
     assert len(result["signatures"]) == 2
     assert result["signatures"][0]["amount"] == 64

--- a/tests/mint/test_mint_batch.py
+++ b/tests/mint/test_mint_batch.py
@@ -45,7 +45,7 @@ async def test_ledger_mint_quote_check(ledger: Ledger, wallet: Wallet):
 
 
 @pytest.mark.asyncio
-async def test_ledger_mint_quote_check_omits_unknown_quotes(
+async def test_ledger_mint_quote_check_returns_positional_unknown_quotes(
     ledger: Ledger, wallet: Wallet
 ):
     await wallet.load_mint()
@@ -63,14 +63,14 @@ async def test_ledger_mint_quote_check_omits_unknown_quotes(
         )
     )
 
-    assert [quote.quote for quote in quotes] == [
-        mint_quote1.quote,
-        mint_quote2.quote,
-    ]
+    assert quotes[0] and quotes[0].quote == mint_quote1.quote
+    assert quotes[1] is None
+    assert quotes[2] is None
+    assert quotes[3] and quotes[3].quote == mint_quote2.quote
 
 
 @pytest.mark.asyncio
-async def test_ledger_mint_quote_check_returns_empty_for_unknown_quotes(
+async def test_ledger_mint_quote_check_returns_none_for_unknown_quotes(
     ledger: Ledger,
 ):
     quotes = await ledger.mint_quote_check(
@@ -82,7 +82,7 @@ async def test_ledger_mint_quote_check_returns_empty_for_unknown_quotes(
         )
     )
 
-    assert quotes == []
+    assert quotes == [None, None]
 
 
 @pytest.mark.asyncio
@@ -618,14 +618,14 @@ async def test_ledger_mint_batch_single_quote(ledger: Ledger, wallet: Wallet):
 async def test_ledger_mint_quote_check_nonexistent_quote(
     ledger: Ledger, wallet: Wallet
 ):
-    """Checking nonexistent quotes should return an empty list."""
+    """Checking nonexistent quotes should return positional unknowns."""
     await wallet.load_mint()
 
     quotes = await ledger.mint_quote_check(
         PostMintQuoteCheckRequest(quotes=["nonexistent_quote_id"])
     )
 
-    assert quotes == []
+    assert quotes == [None]
 
 
 @pytest.mark.asyncio

--- a/tests/mint/test_mint_batch.py
+++ b/tests/mint/test_mint_batch.py
@@ -1,10 +1,13 @@
 import asyncio
 import os
+import time
 
 import pytest
 import pytest_asyncio
 
+from cashu.core.base import MintQuoteState
 from cashu.core.crypto.secp import PrivateKey
+from cashu.core.errors import BatchDuplicateQuotesError, BatchSizeExceededError
 from cashu.core.models import PostMintBatchRequest, PostMintQuoteCheckRequest
 from cashu.core.nuts import nut20
 from cashu.core.settings import settings
@@ -325,26 +328,24 @@ def test_mint_batch_and_check_validation():
     assert "at most" in str(excinfo.value) or "max_length" in str(excinfo.value)
 
     # 3. Check PostMintQuoteCheckRequest with too long quote ID
+    # (overlong IDs are rejected with a validation error as DoS protection)
     with pytest.raises(ValidationError) as excinfo:
         PostMintQuoteCheckRequest(
             quotes=[long_quote],
         )
     assert "at most" in str(excinfo.value) or "max_length" in str(excinfo.value)
 
-    # 4. Check PostMintQuoteCheckRequest with too many quotes
-    with pytest.raises(ValidationError) as excinfo:
-        PostMintQuoteCheckRequest(
-            quotes=too_many_quotes,
-        )
-    assert "at most" in str(excinfo.value) or "max_length" in str(excinfo.value)
+    # 4. PostMintQuoteCheckRequest accepts any number of quotes: oversized
+    # batches are rejected by the mint with error 11017 (see
+    # test_ledger_mint_quote_check_rejects_oversized_batch)
+    check_req = PostMintQuoteCheckRequest(quotes=too_many_quotes)
+    assert len(check_req.quotes) == settings.mint_max_request_length + 1
 
 
 @pytest.mark.asyncio
 async def test_ledger_mint_batch_post_sign_failure_leaves_pending(
     ledger: Ledger, wallet: Wallet, monkeypatch
 ):
-    from cashu.core.base import MintQuoteState
-
     await wallet.load_mint()
     mint_quote1 = await wallet.request_mint(64)
     mint_quote2 = await wallet.request_mint(32)
@@ -361,17 +362,13 @@ async def test_ledger_mint_batch_post_sign_failure_leaves_pending(
     sig1 = nut20.sign_mint_quote(mint_quote1.quote, outputs, mint_quote1.privkey)
     sig2 = nut20.sign_mint_quote(mint_quote2.quote, outputs, mint_quote2.privkey)
 
-    original_unset_mint_quotes_pending = ledger.db_write._unset_mint_quotes_pending
-
-    async def mock_unset_mint_quotes_pending(quote_ids, state):
-        if state == MintQuoteState.issued:
-            raise Exception("failed to acquire database lock on mint_quotes")
-        return await original_unset_mint_quotes_pending(quote_ids, state)
+    async def mock_issue_mint_quotes(quote_ids, amounts):
+        raise Exception("failed to acquire database lock on mint_quotes")
 
     monkeypatch.setattr(
         ledger.db_write,
-        "_unset_mint_quotes_pending",
-        mock_unset_mint_quotes_pending,
+        "_issue_mint_quotes",
+        mock_issue_mint_quotes,
     )
 
     req = PostMintBatchRequest(
@@ -665,9 +662,9 @@ async def test_ledger_mint_batch_atomicity_one_invalid(ledger: Ledger, wallet: W
     q1_after = await ledger.crud.get_mint_quote(
         quote_id=mint_quote1.quote, db=ledger.db
     )
-    assert q1_after.state.value == "PAID", (
-        f"Quote1 should still be PAID, got {q1_after.state.value}"
-    )
+    assert (
+        q1_after.state.value == "PAID"
+    ), f"Quote1 should still be PAID, got {q1_after.state.value}"
 
     secrets2, rs2, derivation_paths2 = await wallet.generate_secrets_from_to(
         10002, 10002
@@ -682,3 +679,271 @@ async def test_ledger_mint_batch_atomicity_one_invalid(ledger: Ledger, wallet: W
     )
     assert len(promises) == 1
     assert promises[0].amount == 64
+
+
+@pytest.mark.asyncio
+async def test_ledger_mint_quote_check_rejects_duplicate_quotes(
+    ledger: Ledger, wallet: Wallet
+):
+    """Duplicate quote IDs must be rejected with error 11016."""
+    await wallet.load_mint()
+    mint_quote = await wallet.request_mint(64)
+
+    with pytest.raises(BatchDuplicateQuotesError):
+        await ledger.mint_quote_check(
+            PostMintQuoteCheckRequest(quotes=[mint_quote.quote, mint_quote.quote])
+        )
+
+
+@pytest.mark.asyncio
+async def test_ledger_mint_quote_check_rejects_oversized_batch(ledger: Ledger):
+    """Batches larger than max_batch_size must be rejected with error 11017."""
+    too_many_quotes = ["quote"] * (settings.mint_max_request_length + 1)
+
+    with pytest.raises(BatchSizeExceededError):
+        await ledger.mint_quote_check(PostMintQuoteCheckRequest(quotes=too_many_quotes))
+
+
+@pytest.mark.asyncio
+async def test_ledger_mint_quote_check_empty_quotes(ledger: Ledger):
+    """An empty quotes array is valid and returns an empty list."""
+    quotes = await ledger.mint_quote_check(PostMintQuoteCheckRequest(quotes=[]))
+    assert quotes == []
+
+
+@pytest.mark.asyncio
+async def test_ledger_mint_batch_without_quote_amounts(ledger: Ledger, wallet: Wallet):
+    """Omitted quote_amounts mint each quote's full currently mintable amount."""
+    await wallet.load_mint()
+    mint_quote1 = await wallet.request_mint(64)
+    mint_quote2 = await wallet.request_mint(32)
+
+    await pay_if_regtest(mint_quote1.request)
+    await pay_if_regtest(mint_quote2.request)
+
+    secrets, rs, derivation_paths = await wallet.generate_secrets_from_to(10000, 10001)
+    outputs, rs = wallet._construct_outputs([64, 32], secrets, rs)
+
+    assert mint_quote1.privkey
+    assert mint_quote2.privkey
+
+    sig1 = nut20.sign_mint_quote(mint_quote1.quote, outputs, mint_quote1.privkey)
+    sig2 = nut20.sign_mint_quote(mint_quote2.quote, outputs, mint_quote2.privkey)
+
+    promises = await ledger.mint_batch(
+        PostMintBatchRequest(
+            quotes=[mint_quote1.quote, mint_quote2.quote],
+            outputs=outputs,
+            signatures=[sig1, sig2],
+        )
+    )
+
+    assert len(promises) == 2
+
+    quote1 = await ledger.crud.get_mint_quote(quote_id=mint_quote1.quote, db=ledger.db)
+    quote2 = await ledger.crud.get_mint_quote(quote_id=mint_quote2.quote, db=ledger.db)
+    assert quote1 and quote1.amount_issued == 64
+    assert quote1.state == MintQuoteState.issued
+    assert quote2 and quote2.amount_issued == 32
+    assert quote2.state == MintQuoteState.issued
+
+
+@pytest.mark.asyncio
+async def test_ledger_mint_batch_expired_quote(ledger: Ledger, wallet: Wallet):
+    """A quote with a positive mintable amount remains mintable after expiry."""
+    await wallet.load_mint()
+    mint_quote = await wallet.request_mint(64)
+
+    await pay_if_regtest(mint_quote.request)
+
+    # expire the quote
+    quote = await ledger.get_mint_quote(mint_quote.quote)
+    assert quote.paid
+    quote.expiry = int(time.time()) - 100
+    await ledger.crud.update_mint_quote(quote=quote, db=ledger.db)
+
+    secrets, rs, derivation_paths = await wallet.generate_secrets_from_to(10000, 10000)
+    outputs, rs = wallet._construct_outputs([64], secrets, rs)
+
+    assert mint_quote.privkey
+    sig = nut20.sign_mint_quote(mint_quote.quote, outputs, mint_quote.privkey)
+
+    promises = await ledger.mint_batch(
+        PostMintBatchRequest(
+            quotes=[mint_quote.quote],
+            quote_amounts=[64],
+            outputs=outputs,
+            signatures=[sig],
+        )
+    )
+
+    assert len(promises) == 1
+    assert promises[0].amount == 64
+
+
+@pytest.mark.asyncio
+async def test_ledger_mint_batch_amount_exceeds_mintable(
+    ledger: Ledger, wallet: Wallet
+):
+    """Allocating more than a quote's mintable amount must fail atomically."""
+    await wallet.load_mint()
+    mint_quote = await wallet.request_mint(64)
+
+    await pay_if_regtest(mint_quote.request)
+
+    secrets, rs, derivation_paths = await wallet.generate_secrets_from_to(10000, 10001)
+    outputs, rs = wallet._construct_outputs([64, 64], secrets, rs)
+
+    assert mint_quote.privkey
+    sig = nut20.sign_mint_quote(mint_quote.quote, outputs, mint_quote.privkey)
+
+    with pytest.raises(Exception) as exc:
+        await ledger.mint_batch(
+            PostMintBatchRequest(
+                quotes=[mint_quote.quote],
+                quote_amounts=[128],
+                outputs=outputs,
+                signatures=[sig],
+            )
+        )
+    assert "exceeds mintable amount" in str(exc.value)
+
+    # nothing was issued
+    quote = await ledger.crud.get_mint_quote(quote_id=mint_quote.quote, db=ledger.db)
+    assert quote and quote.amount_issued == 0
+    assert quote.state == MintQuoteState.paid
+
+
+@pytest.mark.asyncio
+async def test_ledger_mint_batch_non_positive_amount(ledger: Ledger, wallet: Wallet):
+    """Non-positive quote amounts must be rejected."""
+    await wallet.load_mint()
+    mint_quote = await wallet.request_mint(64)
+
+    await pay_if_regtest(mint_quote.request)
+
+    secrets, rs, derivation_paths = await wallet.generate_secrets_from_to(10000, 10000)
+    outputs, rs = wallet._construct_outputs([64], secrets, rs)
+
+    assert mint_quote.privkey
+    sig = nut20.sign_mint_quote(mint_quote.quote, outputs, mint_quote.privkey)
+
+    with pytest.raises(Exception) as exc:
+        await ledger.mint_batch(
+            PostMintBatchRequest(
+                quotes=[mint_quote.quote],
+                quote_amounts=[0],
+                outputs=outputs,
+                signatures=[sig],
+            )
+        )
+    assert "must be positive" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_ledger_mint_batch_partial_amounts(ledger: Ledger, wallet: Wallet):
+    """Partial batch minting increases amount_issued step by step."""
+    await wallet.load_mint()
+    mint_quote = await wallet.request_mint(64)
+
+    await pay_if_regtest(mint_quote.request)
+
+    assert mint_quote.privkey
+
+    # mint half of the quote
+    secrets, rs, derivation_paths = await wallet.generate_secrets_from_to(10000, 10000)
+    outputs, rs = wallet._construct_outputs([32], secrets, rs)
+    sig = nut20.sign_mint_quote(mint_quote.quote, outputs, mint_quote.privkey)
+
+    promises = await ledger.mint_batch(
+        PostMintBatchRequest(
+            quotes=[mint_quote.quote],
+            quote_amounts=[32],
+            outputs=outputs,
+            signatures=[sig],
+        )
+    )
+    assert len(promises) == 1
+
+    quote = await ledger.crud.get_mint_quote(quote_id=mint_quote.quote, db=ledger.db)
+    assert quote and quote.amount_issued == 32
+    assert quote.amount_paid == 64
+    assert quote.state == MintQuoteState.paid
+
+    # mint the remaining amount
+    secrets2, rs2, derivation_paths2 = await wallet.generate_secrets_from_to(
+        10001, 10001
+    )
+    outputs2, rs2 = wallet._construct_outputs([32], secrets2, rs2)
+    sig2 = nut20.sign_mint_quote(mint_quote.quote, outputs2, mint_quote.privkey)
+
+    promises2 = await ledger.mint_batch(
+        PostMintBatchRequest(
+            quotes=[mint_quote.quote],
+            quote_amounts=[32],
+            outputs=outputs2,
+            signatures=[sig2],
+        )
+    )
+    assert len(promises2) == 1
+
+    quote = await ledger.crud.get_mint_quote(quote_id=mint_quote.quote, db=ledger.db)
+    assert quote and quote.amount_issued == 64
+    assert quote.state == MintQuoteState.issued
+    assert quote.issued_time is not None
+
+    # nothing left to mint
+    secrets3, rs3, derivation_paths3 = await wallet.generate_secrets_from_to(
+        10002, 10002
+    )
+    outputs3, rs3 = wallet._construct_outputs([32], secrets3, rs3)
+    sig3 = nut20.sign_mint_quote(mint_quote.quote, outputs3, mint_quote.privkey)
+
+    with pytest.raises(Exception) as exc:
+        await ledger.mint_batch(
+            PostMintBatchRequest(
+                quotes=[mint_quote.quote],
+                quote_amounts=[32],
+                outputs=outputs3,
+                signatures=[sig3],
+            )
+        )
+    assert "already issued" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_ledger_mint_partially_issued_quote_rejected(
+    ledger: Ledger, wallet: Wallet
+):
+    """A quote partially issued via batch mint must not be minted again via the
+    single-quote endpoint (which would issue more than was paid)."""
+    await wallet.load_mint()
+    mint_quote = await wallet.request_mint(64)
+
+    await pay_if_regtest(mint_quote.request)
+
+    assert mint_quote.privkey
+
+    # partially mint via batch
+    secrets, rs, derivation_paths = await wallet.generate_secrets_from_to(10000, 10000)
+    outputs, rs = wallet._construct_outputs([32], secrets, rs)
+    sig = nut20.sign_mint_quote(mint_quote.quote, outputs, mint_quote.privkey)
+    await ledger.mint_batch(
+        PostMintBatchRequest(
+            quotes=[mint_quote.quote],
+            quote_amounts=[32],
+            outputs=outputs,
+            signatures=[sig],
+        )
+    )
+
+    # single mint of the full quote amount must be rejected
+    secrets2, rs2, derivation_paths2 = await wallet.generate_secrets_from_to(
+        10001, 10001
+    )
+    outputs2, rs2 = wallet._construct_outputs([64], secrets2, rs2)
+    sig2 = nut20.sign_mint_quote(mint_quote.quote, outputs2, mint_quote.privkey)
+
+    with pytest.raises(Exception) as exc:
+        await ledger.mint(outputs=outputs2, quote_id=mint_quote.quote, signature=sig2)
+    assert "partially issued" in str(exc.value)

--- a/tests/mint/test_mint_batch.py
+++ b/tests/mint/test_mint_batch.py
@@ -45,6 +45,47 @@ async def test_ledger_mint_quote_check(ledger: Ledger, wallet: Wallet):
 
 
 @pytest.mark.asyncio
+async def test_ledger_mint_quote_check_omits_unknown_quotes(
+    ledger: Ledger, wallet: Wallet
+):
+    await wallet.load_mint()
+    mint_quote1 = await wallet.request_mint(64)
+    mint_quote2 = await wallet.request_mint(32)
+
+    quotes = await ledger.mint_quote_check(
+        PostMintQuoteCheckRequest(
+            quotes=[
+                mint_quote1.quote,
+                "not-a-valid-quote-id",
+                "01989999-9999-7999-8999-999999999999",
+                mint_quote2.quote,
+            ]
+        )
+    )
+
+    assert [quote.quote for quote in quotes] == [
+        mint_quote1.quote,
+        mint_quote2.quote,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ledger_mint_quote_check_returns_empty_for_unknown_quotes(
+    ledger: Ledger,
+):
+    quotes = await ledger.mint_quote_check(
+        PostMintQuoteCheckRequest(
+            quotes=[
+                "not-a-valid-quote-id",
+                "01989999-9999-7999-8999-999999999999",
+            ]
+        )
+    )
+
+    assert quotes == []
+
+
+@pytest.mark.asyncio
 async def test_ledger_mint_batch_success(ledger: Ledger, wallet: Wallet):
     await wallet.load_mint()
     mint_quote1 = await wallet.request_mint(64)
@@ -577,16 +618,14 @@ async def test_ledger_mint_batch_single_quote(ledger: Ledger, wallet: Wallet):
 async def test_ledger_mint_quote_check_nonexistent_quote(
     ledger: Ledger, wallet: Wallet
 ):
-    """Checking nonexistent quote should fail."""
+    """Checking nonexistent quotes should return an empty list."""
     await wallet.load_mint()
 
-    try:
-        await ledger.mint_quote_check(
-            PostMintQuoteCheckRequest(quotes=["nonexistent_quote_id"])
-        )
-        assert False, "Expected Exception"
-    except Exception as e:
-        assert "not found" in str(e)
+    quotes = await ledger.mint_quote_check(
+        PostMintQuoteCheckRequest(quotes=["nonexistent_quote_id"])
+    )
+
+    assert quotes == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- return exactly one NUT-29 batch-check entry per requested quote ID, preserving request order
- return positional `{ "quote": <id>, "unknown": true }` entries for unknown or malformed quote IDs
- use the NUT-04 accounting response fields and omit the deprecated `state` field from batch-check quote responses
- validate batch-mint eligibility using the currently mintable amount (`amount_paid - amount_issued`)
- add ledger and HTTP API coverage for mixed known/unknown and all-unknown requests

Implements the proposed changes in cashubtc/nuts#422 at spec commit `ce8539c7`. This is protocol-sensitive and remains a draft pending maintainer review.

## Validation

- `MINT_BACKEND_BOLT11_SAT=FakeWallet TOR=FALSE poetry run pytest tests/mint/test_mint_batch.py tests/mint/test_mint_api.py -q` (40 passed, 2 skipped)
- latest behavior-focused tests (5 passed)
- `poetry run ruff check cashu/core/models/mint_quote.py cashu/core/models/__init__.py cashu/mint/router.py cashu/mint/ledger.py tests/mint/test_mint_batch.py tests/mint/test_mint_api.py`
- `poetry run mypy cashu/core/models/mint_quote.py cashu/mint/router.py cashu/mint/ledger.py`
- `git diff --check`