### PR TITLE
feat(mint): advertise the maximum request array length

### DIFF
--- a/cashu/core/mint_info.py
+++ b/cashu/core/mint_info.py
@@ -40,6 +40,7 @@ class MintInfo(BaseModel):
     urls: Optional[List[str]]
     tos_url: Optional[str]
     time: Optional[int]
+    max_request_length: Optional[int] = None
     nuts: Dict[int, Any]
 
     def __str__(self):

--- a/cashu/core/mint_info.py
+++ b/cashu/core/mint_info.py
@@ -40,7 +40,7 @@ class MintInfo(BaseModel):
     urls: Optional[List[str]]
     tos_url: Optional[str]
     time: Optional[int]
-    max_request_length: Optional[int] = None
+    max_array_length: Optional[int] = None
     nuts: Dict[int, Any]
 
     def __str__(self):

--- a/cashu/core/models/info.py
+++ b/cashu/core/models/info.py
@@ -46,6 +46,7 @@ class GetInfoResponse(BaseModel):
     tos_url: Optional[str] = None
     urls: Optional[List[str]] = None
     time: Optional[int] = None
+    max_request_length: Optional[int] = None
     nuts: Optional[Dict[int, Any]] = None
 
     def supports(self, nut: int) -> Optional[bool]:

--- a/cashu/core/models/info.py
+++ b/cashu/core/models/info.py
@@ -46,7 +46,7 @@ class GetInfoResponse(BaseModel):
     tos_url: Optional[str] = None
     urls: Optional[List[str]] = None
     time: Optional[int] = None
-    max_request_length: Optional[int] = None
+    max_array_length: Optional[int] = None
     nuts: Optional[Dict[int, Any]] = None
 
     def supports(self, nut: int) -> Optional[bool]:

--- a/cashu/mint/features.py
+++ b/cashu/mint/features.py
@@ -63,7 +63,7 @@ class LedgerFeatures(SupportsBackends, SupportsPubkey):
             tos_url=settings.mint_info_tos_url,
             motd=settings.mint_info_motd,
             time=None,
-            max_request_length=settings.mint_max_request_length,
+            max_array_length=settings.mint_max_request_length,
         )
 
     @property

--- a/cashu/mint/features.py
+++ b/cashu/mint/features.py
@@ -63,6 +63,7 @@ class LedgerFeatures(SupportsBackends, SupportsPubkey):
             tos_url=settings.mint_info_tos_url,
             motd=settings.mint_info_motd,
             time=None,
+            max_request_length=settings.mint_max_request_length,
         )
 
     @property

--- a/cashu/mint/management_rpc/management_rpc.py
+++ b/cashu/mint/management_rpc/management_rpc.py
@@ -26,6 +26,8 @@ class MintManagementRPC(management_pb2_grpc.MintServicer):
         logger.debug("gRPC GetInfo has been called")
         mint_info_dict = self.ledger.mint_info.dict()
         del mint_info_dict["nuts"]
+        # not in the management proto; operators set it in the mint config
+        del mint_info_dict["max_request_length"]
         mint_info_dict["long_description"] = mint_info_dict["description_long"]
         del mint_info_dict["description_long"]
         response = management_pb2.GetInfoResponse(**mint_info_dict)

--- a/cashu/mint/management_rpc/management_rpc.py
+++ b/cashu/mint/management_rpc/management_rpc.py
@@ -27,7 +27,7 @@ class MintManagementRPC(management_pb2_grpc.MintServicer):
         mint_info_dict = self.ledger.mint_info.dict()
         del mint_info_dict["nuts"]
         # not in the management proto; operators set it in the mint config
-        del mint_info_dict["max_request_length"]
+        del mint_info_dict["max_array_length"]
         mint_info_dict["long_description"] = mint_info_dict["description_long"]
         del mint_info_dict["description_long"]
         response = management_pb2.GetInfoResponse(**mint_info_dict)

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -255,6 +255,7 @@ async def info() -> GetInfoResponse:
         urls=settings.mint_info_urls,
         motd=mint_info.motd,
         time=int(time.time()),
+        max_request_length=mint_info.max_request_length,
     )
 
 

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -255,7 +255,7 @@ async def info() -> GetInfoResponse:
         urls=settings.mint_info_urls,
         motd=mint_info.motd,
         time=int(time.time()),
-        max_request_length=mint_info.max_request_length,
+        max_array_length=mint_info.max_array_length,
     )
 
 

--- a/tests/mint/test_mint_app_router.py
+++ b/tests/mint/test_mint_app_router.py
@@ -58,7 +58,7 @@ def _dummy_ledger():
         icon_url="https://mint.test/icon.png",
         tos_url="https://mint.test/tos",
         motd="Hello",
-        max_request_length=1000,
+        max_array_length=1000,
     )
 
     async def mint_quote(payload):

--- a/tests/mint/test_mint_app_router.py
+++ b/tests/mint/test_mint_app_router.py
@@ -58,6 +58,7 @@ def _dummy_ledger():
         icon_url="https://mint.test/icon.png",
         tos_url="https://mint.test/tos",
         motd="Hello",
+        max_request_length=1000,
     )
 
     async def mint_quote(payload):


### PR DESCRIPTION
Implements cashubtc/nuts#425.

Adds the optional [NUT-06](https://github.com/cashubtc/nuts/blob/main/06.md) `max_array_length` to `/v1/info` so wallets can size their batches up front instead of discovering the cap by getting an error partway through a request.

The value is the existing `mint_max_request_length` setting, which already bounds every request array, so this only surfaces what the mint enforces today.

