### PR TITLE
fix(wallet): send blank change outputs with amount 0

### DIFF
--- a/cashu/wallet/wallet.py
+++ b/cashu/wallet/wallet.py
@@ -916,7 +916,7 @@ class Wallet(
             change_derivation_paths,
         ) = await self.generate_n_secrets(n_change_outputs)
         change_outputs, change_rs = self._construct_outputs(
-            n_change_outputs * [1], change_secrets, change_rs
+            n_change_outputs * [0], change_secrets, change_rs
         )
 
         await self.set_reserved_for_melt(proofs, reserved=True, quote_id=quote_id)

--- a/tests/mint/test_mint_melt.py
+++ b/tests/mint/test_mint_melt.py
@@ -191,8 +191,9 @@ async def test_settled_melt_quote_outputs_registration_regression(
         change_rs,
         change_derivation_paths,
     ) = await wallet.generate_n_secrets(n_change_outputs, skip_bump=True)
+    # amount 0 is what wallets send for blank outputs; the mint must accept it
     change_outputs, change_rs = wallet._construct_outputs(
-        n_change_outputs * [1], change_secrets, change_rs
+        n_change_outputs * [0], change_secrets, change_rs
     )
     await assert_err(
         ledger.melt(proofs=proofs1, quote=melt_quote1.quote, outputs=change_outputs),


### PR DESCRIPTION
The mint ignores blank output amounts (NUT-08), and cdk and cashu-ts already send 0. This aligns the nutshell wallet with that convention. Spec suggestion updated to match in cashubtc/nuts#426.