### PR TITLE
fix(mint): return error 12002 for inactive output keysets

### DIFF
--- a/cashu/core/errors.py
+++ b/cashu/core/errors.py
@@ -176,6 +176,14 @@ class KeysetNotFoundError(KeysetError):
         super().__init__(self.detail, code=self.code)
 
 
+class KeysetInactiveError(KeysetError):
+    detail = "keyset is inactive, cannot sign messages"
+    code = 12002
+
+    def __init__(self):
+        super().__init__(self.detail, code=self.code)
+
+
 class LightningError(CashuError):
     detail = "Lightning error"
     code = 20000

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -30,6 +30,7 @@ from ..core.db import Connection, Database
 from ..core.errors import (
     BatchDuplicateQuotesError,
     CashuError,
+    KeysetInactiveError,
     LightningError,
     LightningPaymentFailedError,
     NotAllowedError,
@@ -1430,7 +1431,7 @@ class Ledger(
                 if output.id != keyset.id:
                     raise TransactionError("keyset id does not match output id")
                 if not keyset.active:
-                    raise TransactionError("keyset is not active")
+                    raise KeysetInactiveError()
                 logger.trace(f"Storing blinded message with keyset {keyset.id}.")
                 await self.crud.store_blinded_message(
                     id=keyset.id,
@@ -1476,7 +1477,7 @@ class Ledger(
             if output.id != keyset.id:
                 raise TransactionError("keyset id does not match output id")
             if not keyset.active:
-                raise TransactionError("keyset is not active")
+                raise KeysetInactiveError()
             keyset_id = output.id
             logger.trace(f"Generating promise with keyset {keyset_id}.")
             private_key_amount = keyset.private_keys[output.amount]

--- a/cashu/mint/verification.py
+++ b/cashu/mint/verification.py
@@ -15,6 +15,7 @@ from ..core.crypto.secp import PublicKey
 from ..core.db import Connection
 from ..core.errors import (
     InvalidProofsError,
+    KeysetInactiveError,
     NoSecretInProofsError,
     NotAllowedError,
     OutputsAlreadySignedError,
@@ -178,7 +179,7 @@ class LedgerVerification(
         if outputs[0].id not in self.keysets:
             raise TransactionError("keyset id unknown.")
         if not self.keysets[outputs[0].id].active:
-            raise TransactionError("keyset id inactive.")
+            raise KeysetInactiveError()
         if expected_unit and self.keysets[outputs[0].id].unit != expected_unit:
             raise TransactionError(
                 f"output unit {self.keysets[outputs[0].id].unit.name} does not match quote unit {expected_unit.name}"

--- a/tests/mint/test_mint_verification.py
+++ b/tests/mint/test_mint_verification.py
@@ -18,6 +18,7 @@ from cashu.core.crypto.b_dhke import hash_to_curve, step1_alice
 from cashu.core.crypto.secp import PrivateKey
 from cashu.core.errors import (
     InvalidProofsError,
+    KeysetInactiveError,
     NoSecretInProofsError,
     NotAllowedError,
     OutputsAlreadySignedError,
@@ -535,10 +536,31 @@ async def test_verify_outputs_rejects_inactive_keyset(ledger: Ledger):
     prev = ks.active
     try:
         ks.active = False
-        with pytest.raises(TransactionError, match="keyset id inactive"):
+        with pytest.raises(KeysetInactiveError) as exc_info:
             await ledger._verify_outputs([o])
+        assert exc_info.value.code == 12002
     finally:
         ks.active = prev
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "operation_name", ["_store_blinded_messages", "_sign_blinded_messages"]
+)
+async def test_blinded_message_operations_reject_inactive_keyset(
+    ledger: Ledger, operation_name: str
+):
+    output = _blinded_output(ledger, label=operation_name)
+    keyset = ledger.keysets[output.id]
+    previous_active = keyset.active
+    try:
+        keyset.active = False
+        operation = getattr(ledger, operation_name)
+        with pytest.raises(KeysetInactiveError) as exc_info:
+            await operation([output])
+        assert exc_info.value.code == 12002
+    finally:
+        keyset.active = previous_active
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add a dedicated KeysetInactiveError with protocol code 12002
- return it from shared output verification and defensive storage/signing checks
- add regression coverage for all inactive output-keyset rejection layers

Closes #1119

## Testing

- pytest tests/mint/test_mint_verification.py -q (94 passed)
- ruff check .
- mypy cashu --check-untyped-defs