### PR TITLE
Allow minting paid quotes after expiry

### DIFF
--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -496,7 +496,6 @@ class Ledger(
             Exception: Validation of outputs failed.
             Exception: Quote not paid.
             Exception: Quote already issued.
-            Exception: Quote expired.
             Exception: Amount to mint does not match quote amount.
 
         Returns:
@@ -515,6 +514,9 @@ class Ledger(
         if quote.state != MintQuoteState.paid:
             raise QuoteNotPaidError()
 
+        # Quote expiry limits when the payment request can be paid. Once payment is
+        # confirmed, the quote remains mintable until its value has been issued.
+
         previous_state = quote.state
         await self.db_write._set_mint_quote_pending(quote_id=quote_id)
         try:
@@ -522,8 +524,6 @@ class Ledger(
                 raise TransactionError("quote unit does not match output unit")
             if not quote.amount == sum_amount_outputs:
                 raise TransactionError("amount to mint does not match quote amount")
-            if quote.expiry and quote.expiry < int(time.time()):
-                raise TransactionError("quote expired")
             if not self._verify_mint_quote_witness(quote, outputs, signature):
                 raise QuoteSignatureInvalidError()
             await self._store_blinded_messages(outputs, mint_id=quote_id)
@@ -600,6 +600,8 @@ class Ledger(
             if quote.state != MintQuoteState.paid:
                 raise QuoteNotPaidError()
 
+        # Quote expiry limits payment, not issuance of already-paid value.
+
         # Check amount balance
         if payload.quote_amounts:
             if len(payload.quote_amounts) != len(quotes):
@@ -643,10 +645,6 @@ class Ledger(
         quotes = await self.db_write._set_mint_quotes_pending(quote_ids=payload.quotes)
 
         try:
-            for quote in quotes:
-                if quote.expiry and quote.expiry < int(time.time()):
-                    raise TransactionError("quote expired")
-
             # Store all blinded messages
             await self._store_blinded_messages(
                 payload.outputs, mint_id=payload.quotes[0]

--- a/tests/mint/test_mint.py
+++ b/tests/mint/test_mint.py
@@ -88,6 +88,32 @@ async def test_mint(ledger: Ledger):
 
 
 @pytest.mark.asyncio
+async def test_mint_paid_quote_after_expiry(ledger: Ledger):
+    quote = await ledger.mint_quote(PostMintQuoteRequest(amount=8, unit="sat"))
+    await pay_if_regtest(quote.request)
+    quote = await ledger.get_mint_quote(quote.quote)
+    assert quote.paid
+
+    quote.expiry = int(time.time()) - 1
+    await ledger.crud.update_mint_quote(quote=quote, db=ledger.db)
+
+    blinded_message, _ = step1_alice("paid_quote_after_expiry")
+    promises = await ledger.mint(
+        outputs=[
+            BlindedMessage(
+                amount=8,
+                B_=blinded_message.format().hex(),
+                id=ledger.keyset.id,
+            )
+        ],
+        quote_id=quote.quote,
+    )
+
+    assert len(promises) == 1
+    assert promises[0].amount == 8
+
+
+@pytest.mark.asyncio
 async def test_mint_invalid_quote(ledger: Ledger):
     await assert_err(
         ledger.get_mint_quote(quote_id="invalid_quote_id"),

--- a/tests/mint/test_mint_batch.py
+++ b/tests/mint/test_mint_batch.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import time
 
 import pytest
 import pytest_asyncio
@@ -79,6 +80,47 @@ async def test_ledger_mint_batch_success(ledger: Ledger, wallet: Wallet):
     quote2 = await ledger.get_mint_quote(mint_quote2.quote)
     assert quote1.issued_time is not None
     assert quote2.issued_time is not None
+
+
+@pytest.mark.asyncio
+async def test_ledger_mint_batch_paid_quotes_after_expiry(
+    ledger: Ledger, wallet: Wallet
+):
+    await wallet.load_mint()
+    mint_quote1 = await wallet.request_mint(64)
+    mint_quote2 = await wallet.request_mint(32)
+
+    await pay_if_regtest(mint_quote1.request)
+    await pay_if_regtest(mint_quote2.request)
+
+    quote1 = await ledger.get_mint_quote(mint_quote1.quote)
+    quote2 = await ledger.get_mint_quote(mint_quote2.quote)
+    assert quote1.paid
+    assert quote2.paid
+
+    quote1.expiry = int(time.time()) - 1
+    quote2.expiry = int(time.time()) - 1
+    await ledger.crud.update_mint_quote(quote=quote1, db=ledger.db)
+    await ledger.crud.update_mint_quote(quote=quote2, db=ledger.db)
+
+    secrets, rs, _ = await wallet.generate_secrets_from_to(10002, 10003)
+    outputs, _ = wallet._construct_outputs([64, 32], secrets, rs)
+
+    assert mint_quote1.privkey
+    assert mint_quote2.privkey
+    sig1 = nut20.sign_mint_quote(mint_quote1.quote, outputs, mint_quote1.privkey)
+    sig2 = nut20.sign_mint_quote(mint_quote2.quote, outputs, mint_quote2.privkey)
+
+    promises = await ledger.mint_batch(
+        PostMintBatchRequest(
+            quotes=[mint_quote1.quote, mint_quote2.quote],
+            quote_amounts=[64, 32],
+            outputs=outputs,
+            signatures=[sig1, sig2],
+        )
+    )
+
+    assert [promise.amount for promise in promises] == [64, 32]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- remove the issuance-time expiry rejection from single and batch minting
- keep payment-state, amount, witness, pending, and issued checks unchanged
- add regression coverage for minting paid quotes after their expiry timestamp

## Root cause

Nutshell records a mint quote as paid when its Lightning backend reports the invoice settled, but `mint` and `mint_batch` independently rejected that paid quote once its expiry timestamp passed. This could leave a successfully paid quote permanently unmintable if the wallet did not request signatures before expiry.

Quote expiry limits when the payment request can be paid. Once payment is confirmed, the paid value should remain mintable until it has been issued.

## Impact

Wallets can recover ecash from paid quotes after expiry, including through the batch endpoint. Unpaid quotes remain unmintable, and the existing state transitions continue to prevent duplicate issuance.

## Validation

- `pytest tests/mint/test_mint.py tests/mint/test_mint_batch.py -q` — 37 passed
- `ruff check cashu/mint/ledger.py tests/mint/test_mint.py tests/mint/test_mint_batch.py`
