### PR TITLE
feat(mint): add quote lookup by pubkey

### DIFF
--- a/cashu/core/mint_info.py
+++ b/cashu/core/mint_info.py
@@ -6,7 +6,13 @@ from pydantic import BaseModel
 from .base import Method, Unit
 from .json_rpc.base import JSONRPCSubscriptionKinds
 from .models import MintInfoContact, MintInfoProtectedEndpoint, Nut15MppSupport
-from .nuts.nuts import BLIND_AUTH_NUT, CLEAR_AUTH_NUT, MPP_NUT, WEBSOCKETS_NUT
+from .nuts.nuts import (
+    BLIND_AUTH_NUT,
+    CLEAR_AUTH_NUT,
+    MPP_NUT,
+    WEBSOCKETS_NUT,
+    NutKey,
+)
 
 
 def _match_protected_endpoint(endpoint_path: str, request_path: str) -> bool:
@@ -40,7 +46,7 @@ class MintInfo(BaseModel):
     urls: Optional[List[str]]
     tos_url: Optional[str]
     time: Optional[int]
-    nuts: Dict[int, Any]
+    nuts: Dict[NutKey, Any]
 
     def __str__(self):
         return f"{self.name} ({self.description})"
@@ -49,7 +55,7 @@ class MintInfo(BaseModel):
     def from_json_str(cls, json_str: str):
         return cls.model_validate(json.loads(json_str))
 
-    def supports_nut(self, nut: int) -> bool:
+    def supports_nut(self, nut: NutKey) -> bool:
         if self.nuts is None:
             return False
         return nut in self.nuts

--- a/cashu/core/models/__init__.py
+++ b/cashu/core/models/__init__.py
@@ -32,6 +32,8 @@ from .mint_quote import (
     PostMintQuoteCheckRequest,
     PostMintQuoteRequest,
     PostMintQuoteResponse,
+    PostMintQuotesByPubkeyRequest,
+    PostMintQuotesByPubkeyResponse,
 )
 from .restore import PostRestoreRequest, PostRestoreResponse
 from .swap import PostSwapRequest, PostSwapResponse
@@ -64,6 +66,8 @@ __all__ = [
     "PostMintQuoteCheckRequest",
     "PostMintQuoteRequest",
     "PostMintQuoteResponse",
+    "PostMintQuotesByPubkeyRequest",
+    "PostMintQuotesByPubkeyResponse",
     "PostRestoreRequest",
     "PostRestoreResponse",
     "PostSwapRequest",

--- a/cashu/core/models/info.py
+++ b/cashu/core/models/info.py
@@ -2,6 +2,8 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 
+from cashu.core.nuts.nuts import NutKey
+
 
 class MintMethodBolt11OptionSetting(BaseModel):
     description: Optional[bool] = None
@@ -46,9 +48,9 @@ class GetInfoResponse(BaseModel):
     tos_url: Optional[str] = None
     urls: Optional[List[str]] = None
     time: Optional[int] = None
-    nuts: Optional[Dict[int, Any]] = None
+    nuts: Optional[Dict[NutKey, Any]] = None
 
-    def supports(self, nut: int) -> Optional[bool]:
+    def supports(self, nut: NutKey) -> Optional[bool]:
         return nut in self.nuts if self.nuts else None
 
 

--- a/cashu/core/models/mint_quote.py
+++ b/cashu/core/models/mint_quote.py
@@ -9,6 +9,10 @@ from cashu.core.constants import (
     MAX_QUOTE_ID_LEN,
     MAX_UNIT_LEN,
 )
+from cashu.core.nuts.nutxx import (
+    MAX_LOOKUP_PUBKEYS,
+    SCHNORR_SIGNATURE_HEX_LENGTH,
+)
 from cashu.core.settings import settings
 
 
@@ -27,6 +31,24 @@ class PostMintQuoteCheckRequest(BaseModel):
     quotes: List[Annotated[str, Field(max_length=MAX_QUOTE_ID_LEN)]] = Field(
         ..., max_length=settings.mint_max_request_length
     )
+
+
+class PostMintQuotesByPubkeyRequest(BaseModel):
+    pubkeys: List[
+        Annotated[
+            str,
+            Field(min_length=MAX_PUBKEY_LEN, max_length=MAX_PUBKEY_LEN),
+        ]
+    ] = Field(..., max_length=MAX_LOOKUP_PUBKEYS)
+    pubkey_signatures: List[
+        Annotated[
+            str,
+            Field(
+                min_length=SCHNORR_SIGNATURE_HEX_LENGTH,
+                max_length=SCHNORR_SIGNATURE_HEX_LENGTH,
+            ),
+        ]
+    ] = Field(..., max_length=MAX_LOOKUP_PUBKEYS)
 
 
 class PostMintQuoteResponse(BaseModel):
@@ -51,3 +73,7 @@ class PostMintQuoteResponse(BaseModel):
         to_dict["amount_issued"] = mint_quote.amount_issued
         to_dict["updated_at"] = mint_quote.updated_at
         return cls.model_validate(to_dict)
+
+
+class PostMintQuotesByPubkeyResponse(BaseModel):
+    quotes: List[PostMintQuoteResponse]

--- a/cashu/core/nuts/nuts.py
+++ b/cashu/core/nuts/nuts.py
@@ -1,3 +1,7 @@
+from typing import Literal, Union
+
+NutKey = Union[int, Literal["XX"]]
+
 SWAP_NUT = 3
 MINT_NUT = 4
 MELT_NUT = 5
@@ -18,3 +22,4 @@ CLEAR_AUTH_NUT = 21
 BLIND_AUTH_NUT = 22
 METHOD_BOLT11_NUT = 23
 BATCH_MINT_NUT = 29
+MINT_QUOTE_LOOKUP_NUT: Literal["XX"] = "XX"

--- a/cashu/core/nuts/nutxx.py
+++ b/cashu/core/nuts/nutxx.py
@@ -1,0 +1,25 @@
+"""NUT-XX: mint quote lookup by public key."""
+
+from hashlib import sha256
+
+from coincurve import PublicKeyXOnly
+
+from ..crypto.secp import PublicKey
+
+MINT_QUOTE_LOOKUP_DOMAIN = b"Cashu_MintQuoteLookup_v1"
+
+# Bound the signature-verification work an unauthenticated request can trigger.
+MAX_LOOKUP_PUBKEYS = 50
+SCHNORR_SIGNATURE_HEX_LENGTH = 128
+
+
+def construct_message(mint_pubkey: str, pubkey: str) -> bytes:
+    """Return the UTF-8 preimage whose SHA-256 digest is signed."""
+    return MINT_QUOTE_LOOKUP_DOMAIN + mint_pubkey.encode() + pubkey.encode()
+
+
+def verify_signature(mint_pubkey: str, pubkey: PublicKey, signature: bytes) -> bool:
+    """Verify a NUT-XX quote-lookup signature for ``pubkey``."""
+    message = construct_message(mint_pubkey, pubkey.format().hex())
+    xonly_pubkey = PublicKeyXOnly(pubkey.format()[1:])
+    return xonly_pubkey.verify(signature, sha256(message).digest())

--- a/cashu/mint/crud.py
+++ b/cashu/mint/crud.py
@@ -244,6 +244,16 @@ class LedgerCrud(ABC):
     ) -> Optional[MintQuote]: ...
 
     @abstractmethod
+    async def get_mint_quotes_by_pubkeys(
+        self,
+        *,
+        pubkeys: List[str],
+        method: str,
+        db: Database,
+        conn: Optional[Connection] = None,
+    ) -> List[MintQuote]: ...
+
+    @abstractmethod
     async def get_mint_quote_by_request(
         self,
         *,
@@ -378,7 +388,7 @@ class LedgerCrudSqlite(LedgerCrud):
             f"""
             SELECT * from {db.table_with_schema("promises")}
             WHERE melt_quote = :melt_id
-                AND c_ IS {'NOT NULL' if signed else 'NULL'}
+                AND c_ IS {"NOT NULL" if signed else "NULL"}
             ORDER BY order_index ASC
             """,
             {"melt_id": melt_id},
@@ -680,6 +690,30 @@ class LedgerCrudSqlite(LedgerCrud):
         if row is None:
             return None
         return MintQuote.from_row(row) if row else None  # type: ignore
+
+    async def get_mint_quotes_by_pubkeys(
+        self,
+        *,
+        pubkeys: List[str],
+        method: str,
+        db: Database,
+        conn: Optional[Connection] = None,
+    ) -> List[MintQuote]:
+        if not pubkeys:
+            return []
+
+        placeholders = ",".join(f":pubkey_{i}" for i in range(len(pubkeys)))
+        rows = await (conn or db).fetchall(
+            f"""
+            SELECT * from {db.table_with_schema("mint_quotes")}
+            WHERE method = :method AND pubkey IN ({placeholders})
+            """,
+            {
+                "method": method,
+                **{f"pubkey_{i}": pubkey for i, pubkey in enumerate(pubkeys)},
+            },
+        )
+        return [MintQuote.from_row(row) for row in rows] if rows else []
 
     async def get_mint_quote_by_request(
         self,

--- a/cashu/mint/features.py
+++ b/cashu/mint/features.py
@@ -20,6 +20,7 @@ from ..core.nuts.nuts import (
     HTLC_NUT,
     MELT_NUT,
     MINT_NUT,
+    MINT_QUOTE_LOOKUP_NUT,
     MINT_QUOTE_SIGNATURE_NUT,
     MPP_NUT,
     P2PK_NUT,
@@ -27,6 +28,7 @@ from ..core.nuts.nuts import (
     SCRIPT_NUT,
     STATE_NUT,
     WEBSOCKETS_NUT,
+    NutKey,
 )
 from ..core.settings import settings
 from ..mint.protocols import SupportsBackends, SupportsPubkey
@@ -66,7 +68,9 @@ class LedgerFeatures(SupportsBackends, SupportsPubkey):
         )
 
     @property
-    def mint_features(self) -> Dict[int, Union[List[Any], Dict[str, Any]]]:
+    def mint_features(
+        self,
+    ) -> Dict[NutKey, Union[List[Any], Dict[str, Any]]]:
         mint_features = self.create_mint_features()
         mint_features = self.add_supported_features(mint_features)
         mint_features = self.add_mpp_features(mint_features)
@@ -76,7 +80,9 @@ class LedgerFeatures(SupportsBackends, SupportsPubkey):
 
         return mint_features
 
-    def create_mint_features(self) -> Dict[int, Union[List[Any], Dict[str, Any]]]:
+    def create_mint_features(
+        self,
+    ) -> Dict[NutKey, Union[List[Any], Dict[str, Any]]]:
         mint_method_settings: List[MintMethodSetting] = []
         for method, unit_dict in self.backends.items():
             for unit in unit_dict.keys():
@@ -101,7 +107,7 @@ class LedgerFeatures(SupportsBackends, SupportsPubkey):
                     melt_setting.min_amount = 0
                 melt_method_settings.append(melt_setting)
 
-        mint_features: Dict[int, Union[List[Any], Dict[str, Any]]] = {
+        mint_features: Dict[NutKey, Union[List[Any], Dict[str, Any]]] = {
             MINT_NUT: dict(
                 methods=mint_method_settings,
                 disabled=settings.mint_bolt11_disable_mint,
@@ -114,7 +120,8 @@ class LedgerFeatures(SupportsBackends, SupportsPubkey):
         return mint_features
 
     def add_supported_features(
-        self, mint_features: Dict[int, Union[List[Any], Dict[str, Any]]]
+        self,
+        mint_features: Dict[NutKey, Union[List[Any], Dict[str, Any]]],
     ):
         supported_dict = dict(supported=True)
         mint_features[STATE_NUT] = supported_dict
@@ -125,10 +132,12 @@ class LedgerFeatures(SupportsBackends, SupportsPubkey):
         mint_features[DLEQ_NUT] = supported_dict
         mint_features[HTLC_NUT] = supported_dict
         mint_features[MINT_QUOTE_SIGNATURE_NUT] = supported_dict
+        mint_features[MINT_QUOTE_LOOKUP_NUT] = supported_dict
         return mint_features
 
     def add_batch_features(
-        self, mint_features: Dict[int, Union[List[Any], Dict[str, Any]]]
+        self,
+        mint_features: Dict[NutKey, Union[List[Any], Dict[str, Any]]],
     ):
         mint_features[BATCH_MINT_NUT] = {
             "supported": True,
@@ -138,7 +147,8 @@ class LedgerFeatures(SupportsBackends, SupportsPubkey):
         return mint_features
 
     def add_mpp_features(
-        self, mint_features: Dict[int, Union[List[Any], Dict[str, Any]]]
+        self,
+        mint_features: Dict[NutKey, Union[List[Any], Dict[str, Any]]],
     ):
         # signal which method-unit pairs support MPP
         mpp_features = []
@@ -153,7 +163,8 @@ class LedgerFeatures(SupportsBackends, SupportsPubkey):
         return mint_features
 
     def add_websocket_features(
-        self, mint_features: Dict[int, Union[List[Any], Dict[str, Any]]]
+        self,
+        mint_features: Dict[NutKey, Union[List[Any], Dict[str, Any]]],
     ):
         # specify which websocket features are supported
         # these two are supported by default
@@ -221,7 +232,8 @@ class LedgerFeatures(SupportsBackends, SupportsPubkey):
         return mint_features
 
     def add_cache_features(
-        self, mint_features: Dict[int, Union[List[Any], Dict[str, Any]]]
+        self,
+        mint_features: Dict[NutKey, Union[List[Any], Dict[str, Any]]],
     ):
         if settings.mint_redis_cache_enabled:
             cache_features: dict[str, list[dict[str, str]] | int] = {

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -29,6 +29,7 @@ from ..core.crypto.secp import PrivateKey, PublicKey
 from ..core.db import Connection, Database
 from ..core.errors import (
     BatchDuplicateQuotesError,
+    BatchSizeExceededError,
     CashuError,
     KeysetInactiveError,
     LightningError,
@@ -47,7 +48,9 @@ from ..core.models import (
     PostMintBatchRequest,
     PostMintQuoteCheckRequest,
     PostMintQuoteRequest,
+    PostMintQuotesByPubkeyRequest,
 )
+from ..core.nuts import nutxx
 from ..core.settings import settings
 from ..core.split import amount_split
 from ..lightning.base import (
@@ -459,6 +462,41 @@ class Ledger(
                         await self.events.submit(quote)
 
         return quote
+
+    async def mint_quotes_by_pubkey(
+        self, payload: PostMintQuotesByPubkeyRequest
+    ) -> List[MintQuote]:
+        """Return NUT-20 mint quotes after proving control of every pubkey."""
+        if len(payload.pubkeys) > nutxx.MAX_LOOKUP_PUBKEYS:
+            raise BatchSizeExceededError(
+                f"Maximum number of pubkeys is {nutxx.MAX_LOOKUP_PUBKEYS}."
+            )
+        if len(payload.pubkeys) != len(payload.pubkey_signatures):
+            raise CashuError("Mint quote lookup signature missing or invalid.")
+        if not self.pubkey:
+            raise CashuError("Mint public key is not available.")
+
+        mint_pubkey = self.pubkey.format().hex()
+        verified_pubkeys: List[str] = []
+        for pubkey_hex, signature_hex in zip(
+            payload.pubkeys, payload.pubkey_signatures
+        ):
+            try:
+                pubkey = PublicKey(bytes.fromhex(pubkey_hex))
+                signature = bytes.fromhex(signature_hex)
+                if not nutxx.verify_signature(mint_pubkey, pubkey, signature):
+                    raise ValueError("invalid signature")
+            except Exception as exc:
+                raise CashuError(
+                    "Mint quote lookup signature missing or invalid."
+                ) from exc
+            verified_pubkeys.append(pubkey.format().hex())
+
+        return await self.crud.get_mint_quotes_by_pubkeys(
+            pubkeys=verified_pubkeys,
+            method=Method.bolt11.name,
+            db=self.db,
+        )
 
     async def mint_quote_check(
         self, payload: PostMintQuoteCheckRequest

--- a/cashu/mint/migrations.py
+++ b/cashu/mint/migrations.py
@@ -1338,3 +1338,12 @@ async def m038_remove_dleq_from_promises(db: Database):
         await conn.execute(
             f"ALTER TABLE {db.table_with_schema('promises')} DROP COLUMN dleq_s"
         )
+
+
+async def m039_add_mint_quote_pubkey_index(db: Database):
+    """Index NUT-20 mint quote ownership lookups."""
+    async with db.connect() as conn:
+        await conn.execute(
+            f"CREATE INDEX IF NOT EXISTS idx_mint_quotes_pubkey "
+            f"ON {db.table_with_schema('mint_quotes')} (pubkey)"
+        )

--- a/cashu/mint/router.py
+++ b/cashu/mint/router.py
@@ -25,6 +25,8 @@ from ..core.models import (
     PostMintQuoteCheckRequest,
     PostMintQuoteRequest,
     PostMintQuoteResponse,
+    PostMintQuotesByPubkeyRequest,
+    PostMintQuotesByPubkeyResponse,
     PostMintRequest,
     PostMintResponse,
     PostRestoreRequest,
@@ -40,6 +42,7 @@ from ..core.nuts.nuts import (
     DLEQ_NUT,
     FEE_RETURN_NUT,
     HTLC_NUT,
+    MINT_QUOTE_LOOKUP_NUT,
     MINT_QUOTE_SIGNATURE_NUT,
     MPP_NUT,
     P2PK_NUT,
@@ -47,6 +50,7 @@ from ..core.nuts.nuts import (
     SCRIPT_NUT,
     STATE_NUT,
     WEBSOCKETS_NUT,
+    NutKey,
 )
 from ..core.settings import settings
 from ..mint.startup import ledger
@@ -108,9 +112,7 @@ async def index(request: Request) -> HTMLResponse:
     # Methods (Minting / Melting)
     mint_methods = []
     melt_methods = []
-    backends_methods = sorted(
-        list(set(m.name.upper() for m in ledger.backends.keys()))
-    )
+    backends_methods = sorted(list(set(m.name.upper() for m in ledger.backends.keys())))
     if not settings.mint_bolt11_disable_mint:
         mint_methods = backends_methods
     if not settings.mint_bolt11_disable_melt:
@@ -126,10 +128,10 @@ async def index(request: Request) -> HTMLResponse:
         melt_limits.append(format_limit(settings.mint_max_melt_bolt11_sat, "sat"))
 
     # Features (NUTs)
-    supported_features = []
+    supported_features: list[tuple[NutKey, str]] = []
     nuts = mint_info.nuts or {}
 
-    def is_nut_supported(nut_num: int) -> bool:
+    def is_nut_supported(nut_num: NutKey) -> bool:
         if nut_num not in nuts:
             return False
         nut_val = nuts[nut_num]
@@ -161,6 +163,10 @@ async def index(request: Request) -> HTMLResponse:
         supported_features.append((CACHE_NUT, "Cached responses"))
     if is_nut_supported(MINT_QUOTE_SIGNATURE_NUT):
         supported_features.append((MINT_QUOTE_SIGNATURE_NUT, "Signed mint quotes"))
+    if is_nut_supported(MINT_QUOTE_LOOKUP_NUT):
+        supported_features.append(
+            (MINT_QUOTE_LOOKUP_NUT, "Mint quote lookup by public key")
+        )
     if is_nut_supported(CLEAR_AUTH_NUT):
         supported_features.append((CLEAR_AUTH_NUT, "Clear auth"))
     if is_nut_supported(BLIND_AUTH_NUT):
@@ -383,6 +389,26 @@ async def mint_quote(
     )
     logger.trace(f"< POST /v1/mint/quote/bolt11: {resp}")
     return resp
+
+
+@router.post(
+    "/v1/mint/quote/bolt11/pubkey",
+    name="Get mint quotes by public key",
+    summary="Get NUT-20 locked mint quotes by public key",
+    response_model=PostMintQuotesByPubkeyResponse,
+    response_description="Mint quotes locked to the authenticated public keys",
+)
+@limiter.limit(f"{settings.mint_transaction_rate_limit_per_minute}/minute")
+async def mint_quotes_by_pubkey(
+    request: Request, payload: PostMintQuotesByPubkeyRequest
+) -> PostMintQuotesByPubkeyResponse:
+    logger.trace("> POST /v1/mint/quote/bolt11/pubkey")
+    quotes = await ledger.mint_quotes_by_pubkey(payload)
+    response = PostMintQuotesByPubkeyResponse(
+        quotes=[PostMintQuoteResponse.from_mint_quote(quote) for quote in quotes]
+    )
+    logger.trace(f"< POST /v1/mint/quote/bolt11/pubkey: {len(response.quotes)} quotes")
+    return response
 
 
 @router.get(

--- a/tests/mint/test_mint_migrations.py
+++ b/tests/mint/test_mint_migrations.py
@@ -120,6 +120,19 @@ async def test_m038_remove_dleq_from_promises(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_m039_add_mint_quote_pubkey_index(tmp_path):
+    db = Database("mint", str(tmp_path / "mint"))
+    await migrate_databases(db, mint_migrations)
+
+    async with db.connect() as conn:
+        indexes = await conn.fetchall(
+            f"PRAGMA index_list({db.table_with_schema('mint_quotes')})"
+        )
+
+    assert "idx_mint_quotes_pubkey" in {index["name"] for index in indexes}
+
+
+@pytest.mark.asyncio
 async def test_m029_witness_cleanup():
     db = Database("mint", "./test_data/mig_witness_cleanup")
 

--- a/tests/mint/test_mint_quote_lookup.py
+++ b/tests/mint/test_mint_quote_lookup.py
@@ -1,0 +1,225 @@
+from hashlib import sha256
+from time import time
+from uuid import uuid4
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from cashu.core.base import MintQuote, MintQuoteState
+from cashu.core.crypto.secp import PrivateKey
+from cashu.core.errors import BatchSizeExceededError, CashuError
+from cashu.core.models import (
+    GetInfoResponse,
+    PostMintQuotesByPubkeyRequest,
+)
+from cashu.core.nuts import nutxx
+from cashu.core.nuts.nuts import MINT_QUOTE_LOOKUP_NUT
+from cashu.mint import app as app_module
+from cashu.mint import router as router_module
+from cashu.mint.ledger import Ledger
+
+
+def lookup_payload(
+    mint_pubkey: str, owners: list[PrivateKey]
+) -> PostMintQuotesByPubkeyRequest:
+    pubkeys = [owner.public_key.format().hex() for owner in owners]
+    signatures = [
+        owner.sign_schnorr(
+            sha256(nutxx.construct_message(mint_pubkey, pubkey)).digest()
+        ).hex()
+        for owner, pubkey in zip(owners, pubkeys)
+    ]
+    return PostMintQuotesByPubkeyRequest(pubkeys=pubkeys, pubkey_signatures=signatures)
+
+
+def test_mint_quote_lookup_message_vector():
+    mint = PrivateKey(bytes.fromhex("00" * 31 + "01"))
+    owner = PrivateKey(bytes.fromhex("00" * 31 + "02"))
+
+    message = nutxx.construct_message(
+        mint.public_key.format().hex(), owner.public_key.format().hex()
+    )
+    assert message.decode() == (
+        "Cashu_MintQuoteLookup_v1"
+        "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+        "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
+    )
+
+
+def test_mint_info_accepts_provisional_nut_key_without_changing_numeric_keys():
+    info = GetInfoResponse(nuts={"4": {"disabled": False}, "XX": {"supported": True}})
+
+    assert info.nuts is not None
+    assert 4 in info.nuts
+    assert info.nuts[MINT_QUOTE_LOOKUP_NUT] == {"supported": True}
+
+
+async def store_quote(
+    ledger: Ledger,
+    *,
+    amount: int,
+    pubkey: str | None,
+    method: str = "bolt11",
+) -> MintQuote:
+    quote_id = uuid4().hex
+    quote = MintQuote(
+        quote=quote_id,
+        method=method,
+        request=f"lnbc-{quote_id}",
+        checking_id=quote_id,
+        unit="sat",
+        amount=amount,
+        state=MintQuoteState.unpaid,
+        created_time=int(time()),
+        pubkey=pubkey,
+    )
+    await ledger.crud.store_mint_quote(quote=quote, db=ledger.db)
+    return quote
+
+
+def lookup_app(monkeypatch: pytest.MonkeyPatch, ledger: Ledger) -> FastAPI:
+    monkeypatch.setattr(router_module, "ledger", ledger)
+    app = FastAPI()
+    app.middleware("http")(app_module.catch_exceptions)
+    app.include_router(router_module.router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_mint_quotes_by_pubkey_returns_only_owned_quotes(ledger: Ledger):
+    owner_1 = PrivateKey()
+    owner_2 = PrivateKey()
+    other_owner = PrivateKey()
+
+    own_quote_1 = await store_quote(
+        ledger, amount=10, pubkey=owner_1.public_key.format().hex()
+    )
+    own_quote_2 = await store_quote(
+        ledger, amount=20, pubkey=owner_2.public_key.format().hex()
+    )
+    await store_quote(ledger, amount=30, pubkey=other_owner.public_key.format().hex())
+    await store_quote(ledger, amount=40, pubkey=None)
+    await store_quote(
+        ledger,
+        amount=50,
+        pubkey=owner_1.public_key.format().hex(),
+        method="custom",
+    )
+
+    payload = lookup_payload(ledger.pubkey.format().hex(), [owner_1, owner_2])
+    quotes = await ledger.mint_quotes_by_pubkey(payload)
+
+    assert {quote.quote for quote in quotes} == {
+        own_quote_1.quote,
+        own_quote_2.quote,
+    }
+
+
+@pytest.mark.asyncio
+async def test_mint_quotes_by_pubkey_accepts_empty_request(ledger: Ledger):
+    quotes = await ledger.mint_quotes_by_pubkey(
+        PostMintQuotesByPubkeyRequest(pubkeys=[], pubkey_signatures=[])
+    )
+    assert quotes == []
+
+
+@pytest.mark.asyncio
+async def test_mint_quotes_by_pubkey_rejects_missing_signature(ledger: Ledger):
+    owner = PrivateKey()
+    payload = PostMintQuotesByPubkeyRequest(
+        pubkeys=[owner.public_key.format().hex()], pubkey_signatures=[]
+    )
+
+    with pytest.raises(CashuError, match="signature missing or invalid"):
+        await ledger.mint_quotes_by_pubkey(payload)
+
+
+@pytest.mark.asyncio
+async def test_mint_quotes_by_pubkey_rejects_wrong_owner(ledger: Ledger):
+    owner = PrivateKey()
+    attacker = PrivateKey()
+    owner_pubkey = owner.public_key.format().hex()
+    attacker_signature = attacker.sign_schnorr(
+        sha256(
+            nutxx.construct_message(ledger.pubkey.format().hex(), owner_pubkey)
+        ).digest()
+    ).hex()
+    payload = PostMintQuotesByPubkeyRequest(
+        pubkeys=[owner_pubkey], pubkey_signatures=[attacker_signature]
+    )
+
+    with pytest.raises(CashuError, match="signature missing or invalid"):
+        await ledger.mint_quotes_by_pubkey(payload)
+
+
+@pytest.mark.asyncio
+async def test_mint_quotes_by_pubkey_rejects_other_mint_signature(ledger: Ledger):
+    owner = PrivateKey()
+    other_mint = PrivateKey()
+    payload = lookup_payload(other_mint.public_key.format().hex(), [owner])
+
+    with pytest.raises(CashuError, match="signature missing or invalid"):
+        await ledger.mint_quotes_by_pubkey(payload)
+
+
+@pytest.mark.asyncio
+async def test_mint_quotes_by_pubkey_rejects_oversized_request(ledger: Ledger):
+    owner = PrivateKey()
+    pubkey = owner.public_key.format().hex()
+    payload = PostMintQuotesByPubkeyRequest.model_construct(
+        pubkeys=[pubkey] * (nutxx.MAX_LOOKUP_PUBKEYS + 1),
+        pubkey_signatures=[],
+    )
+
+    with pytest.raises(BatchSizeExceededError):
+        await ledger.mint_quotes_by_pubkey(payload)
+
+
+def test_mint_info_advertises_mint_quote_lookup(ledger: Ledger):
+    assert ledger.mint_info.nuts[MINT_QUOTE_LOOKUP_NUT] == {"supported": True}
+
+
+@pytest.mark.asyncio
+async def test_mint_quote_lookup_api_response_shape(
+    ledger: Ledger, monkeypatch: pytest.MonkeyPatch
+):
+    owner = PrivateKey()
+    pubkey = owner.public_key.format().hex()
+    quote = await store_quote(ledger, amount=50, pubkey=pubkey)
+
+    payload = lookup_payload(ledger.pubkey.format().hex(), [owner])
+    transport = httpx.ASGITransport(app=lookup_app(monkeypatch, ledger))
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        info_response = await client.get("/v1/info")
+        response = await client.post(
+            "/v1/mint/quote/bolt11/pubkey", json=payload.model_dump()
+        )
+
+    assert info_response.status_code == 200
+    assert info_response.json()["nuts"][MINT_QUOTE_LOOKUP_NUT] == {"supported": True}
+    assert response.status_code == 200, response.text
+    quotes = response.json()["quotes"]
+    assert len(quotes) == 1
+    assert quotes[0]["quote"] == quote.quote
+    assert quotes[0]["method"] == "bolt11"
+    assert quotes[0]["pubkey"] == pubkey
+
+
+@pytest.mark.asyncio
+async def test_mint_quote_lookup_api_rejects_unsigned_request(
+    ledger: Ledger, monkeypatch: pytest.MonkeyPatch
+):
+    owner = PrivateKey()
+    transport = httpx.ASGITransport(app=lookup_app(monkeypatch, ledger))
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/mint/quote/bolt11/pubkey",
+            json={
+                "pubkeys": [owner.public_key.format().hex()],
+                "pubkey_signatures": [],
+            },
+        )
+
+    assert response.status_code == 400
+    assert "signature missing or invalid" in response.json()["detail"]


### PR DESCRIPTION
## Summary

- implement the mint-side quote lookup from cashubtc/nuts#341 at POST /v1/mint/quote/bolt11/pubkey
- verify every mint-bound, domain-separated Schnorr signature before querying quotes
- return method-scoped NUT-04 quote responses and advertise provisional NUT-XX support
- cap lookup requests at 50 pubkeys and add an indexed pubkey lookup
- add focused signature, authorization, routing, response, mint-info, and migration coverage

## Scope and compatibility

- mint only; no wallet lookup client is included
- follows the current method-scoped NUT route; cashubtc/cdk#1834 currently uses a method-agnostic route
- includes migration m039 to index mint_quotes.pubkey

## Testing

- make check
- poetry run pytest tests/mint/test_mint_quote_lookup.py tests/mint/test_mint_migrations.py tests/mint/test_mint_app_router.py -q (30 passed)