### PR TITLE
fix(mint): return stored signatures on idempotent POST /mint retry

### DIFF
--- a/cashu/mint/crud.py
+++ b/cashu/mint/crud.py
@@ -402,6 +402,41 @@ class LedgerCrudSqlite(LedgerCrud):
         )
         return [BlindedSignature.from_row(r) for r in rows] if rows else []  # type: ignore
 
+    async def get_blind_signatures_mint_id(
+        self,
+        *,
+        db: Database,
+        mint_id: str,
+        conn: Optional[Connection] = None,
+    ) -> List[BlindedSignature]:
+        rows = await (conn or db).fetchall(
+            f"""
+                SELECT * from {db.table_with_schema("promises")}
+                WHERE mint_quote = :mint_id AND c_ IS NOT NULL
+                ORDER BY order_index ASC
+                """,
+            {"mint_id": mint_id},
+        )
+        return [BlindedSignature.from_row(r) for r in rows] if rows else []  # type: ignore
+
+    async def get_blinded_Bs_mint_id(
+        self,
+        *,
+        db: Database,
+        mint_id: str,
+        conn: Optional[Connection] = None,
+    ) -> List[str]:
+        """Return the stored B_ values for a given mint quote, in order."""
+        rows = await (conn or db).fetchall(
+            f"""
+                SELECT b_ from {db.table_with_schema("promises")}
+                WHERE mint_quote = :mint_id AND c_ IS NOT NULL
+                ORDER BY order_index ASC
+                """,
+            {"mint_id": mint_id},
+        )
+        return [r["b_"] for r in rows] if rows else []
+
     async def delete_blinded_messages_melt_id(
         self,
         *,

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -509,18 +509,32 @@ class Ledger(
         Returns:
             List[BlindedSignature]: Signatures on the outputs.
         """
+        quote = await self.get_mint_quote(quote_id)
+
+        # Idempotency: if this quote was already issued or is stuck pending,
+        # return previously stored signatures for matching outputs.
+        if quote.issued or quote.pending:
+            stored = await self.crud.get_blind_signatures_mint_id(
+                db=self.db, mint_id=quote_id
+            )
+            stored_Bs = await self.crud.get_blinded_Bs_mint_id(
+                db=self.db, mint_id=quote_id
+            )
+            if len(stored) == len(outputs) and stored_Bs == [
+                o.B_ for o in outputs
+            ]:
+                return stored
+            if quote.issued:
+                raise QuoteAlreadyIssuedError()
+            raise QuotePendingError("Mint quote already pending.")
+
+        if quote.state != MintQuoteState.paid:
+            raise QuoteNotPaidError()
+
         await self._verify_outputs(outputs)
         sum_amount_outputs = sum([b.amount for b in outputs])
         # we already know from _verify_outputs that all outputs have the same unit because they have the same keyset
         output_unit = self.keysets[outputs[0].id].unit
-
-        quote = await self.get_mint_quote(quote_id)
-        if quote.pending:
-            raise QuotePendingError("Mint quote already pending.")
-        if quote.issued:
-            raise QuoteAlreadyIssuedError()
-        if quote.state != MintQuoteState.paid:
-            raise QuoteNotPaidError()
 
         previous_state = quote.state
         await self.db_write._set_mint_quote_pending(quote_id=quote_id)

--- a/tests/mint/test_mint_operations.py
+++ b/tests/mint/test_mint_operations.py
@@ -154,16 +154,21 @@ async def test_mint_internal(wallet1: Wallet, ledger: Ledger):
     signature = nut20.sign_mint_quote(
         mint_quote.quote, outputs, wallet_mint_quote.privkey
     )
-    await ledger.mint(outputs=outputs, quote_id=mint_quote.quote, signature=signature)
-
-    await assert_err(
-        ledger.mint(outputs=outputs, quote_id=mint_quote.quote),
-        OutputsAlreadySignedError.detail,
+    signatures = await ledger.mint(
+        outputs=outputs, quote_id=mint_quote.quote, signature=signature
     )
 
     mint_quote_after_payment = await ledger.get_mint_quote(mint_quote.quote)
     assert mint_quote_after_payment.issued, "mint quote should be issued"
-    assert mint_quote_after_payment.issued
+
+    # Idempotent retry with same outputs should return stored signatures
+    retry_signatures = await ledger.mint(
+        outputs=outputs, quote_id=mint_quote.quote
+    )
+    assert len(retry_signatures) == len(signatures)
+    for orig, retry in zip(signatures, retry_signatures):
+        assert orig.C_ == retry.C_
+        assert orig.amount == retry.amount
 
 
 @pytest.mark.asyncio
@@ -363,6 +368,64 @@ async def test_mint_with_same_outputs_twice(wallet1: Wallet, ledger: Ledger):
     await assert_err(
         ledger.mint(outputs=outputs, quote_id=mint_quote_2.quote, signature=signature),
         OutputsAlreadySignedError.detail,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(is_regtest, reason="only works with FakeWallet")
+async def test_mint_idempotent_retry_same_outputs(wallet1: Wallet, ledger: Ledger):
+    """Retry with the same outputs and same quote returns stored signatures."""
+    mint_quote = await wallet1.request_mint(64)
+    output_amounts = [64]
+    secrets, rs, derivation_paths = await wallet1.generate_n_secrets(
+        len(output_amounts)
+    )
+    outputs, rs = wallet1._construct_outputs(output_amounts, secrets, rs)
+    assert mint_quote.privkey
+    signature = nut20.sign_mint_quote(
+        mint_quote.quote, outputs, mint_quote.privkey
+    )
+    signatures = await ledger.mint(
+        outputs=outputs, quote_id=mint_quote.quote, signature=signature
+    )
+
+    retry_signatures = await ledger.mint(
+        outputs=outputs, quote_id=mint_quote.quote
+    )
+    assert len(retry_signatures) == len(signatures)
+    for orig, retry in zip(signatures, retry_signatures):
+        assert orig.C_ == retry.C_
+        assert orig.amount == retry.amount
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(is_regtest, reason="only works with FakeWallet")
+async def test_mint_retry_different_outputs_same_count_rejected(
+    wallet1: Wallet, ledger: Ledger
+):
+    """Retry with different outputs (same count) for an issued quote is rejected."""
+    mint_quote = await wallet1.request_mint(128)
+    output_amounts = [128]
+    secrets, rs, derivation_paths = await wallet1.generate_n_secrets(
+        len(output_amounts)
+    )
+    outputs1, rs1 = wallet1._construct_outputs(output_amounts, secrets, rs)
+    assert mint_quote.privkey
+    signature = nut20.sign_mint_quote(
+        mint_quote.quote, outputs1, mint_quote.privkey
+    )
+    await ledger.mint(
+        outputs=outputs1, quote_id=mint_quote.quote, signature=signature
+    )
+
+    # Different outputs, same count, same quote
+    secrets2, rs2, derivation_paths2 = await wallet1.generate_n_secrets(
+        len(output_amounts)
+    )
+    outputs2, rs2 = wallet1._construct_outputs(output_amounts, secrets2, rs2)
+    await assert_err(
+        ledger.mint(outputs=outputs2, quote_id=mint_quote.quote),
+        "quote already issued",
     )
 
 


### PR DESCRIPTION
When a wallet retries `POST /mint` with the same outputs after a connection drop, the mint now returns the previously stored signatures instead of raising `OutputsAlreadySignedError`. This prevents token loss when the connection is lost during the minting process.

- Add `get_blind_signatures_mint_id()` and `get_blinded_Bs_mint_id()` to `crud.py`
- Add idempotency block in `ledger.mint()` that checks quote state first
- Verify `B_` values match (not just output count) to prevent mismatched returns
- Update `test_mint_internal` to expect success on retry
- Add tests for idempotent retry and different-output rejection

Closes #257
