### PR TITLE
refactor(lightning): use Pydantic models for Lightning API responses

### DIFF
--- a/cashu/lightning/clnrest.py
+++ b/cashu/lightning/clnrest.py
@@ -10,6 +10,7 @@ from bolt11 import (
     decode,
 )
 from loguru import logger
+from pydantic import BaseModel
 
 from ..core.base import Amount, MeltQuote, Unit
 from ..core.helpers import fee_reserve
@@ -43,6 +44,81 @@ INVOICE_RESULT_MAP = {
     "unpaid": PaymentResult.PENDING,
     "expired": PaymentResult.FAILED,
 }
+
+
+class CLNChannel(BaseModel):
+    our_amount_msat: int | str
+    amount_msat: int | str | None = None
+    id: str | None = None
+    funding_txid: str | None = None
+    funding_output: int | None = None
+    connected: bool | None = None
+    state: str | None = None
+    channel_id: str | None = None
+    short_channel_id: str | None = None
+
+
+class CLNListFundsResponse(BaseModel):
+    channels: list[CLNChannel] = []
+    outputs: list[dict] | None = None
+
+
+class CLNInvoiceResponse(BaseModel):
+    payment_hash: str
+    bolt11: str | None = None
+    bolt12: str | None = None
+    expires_at: int | None = None
+    label: str | None = None
+    warning_capacity: str | None = None
+    warning_offline: str | None = None
+    warning_deadends: str | None = None
+    warning_private_unused: str | None = None
+    warning_mpp: str | None = None
+
+
+class CLNXPayResponse(BaseModel):
+    payment_preimage: str
+    amount_msat: int | str
+    amount_sent_msat: int | str
+    destination: str | None = None
+    payment_hash: str | None = None
+    created_at: float | int | None = None
+    parts: int | None = None
+    status: str | None = None
+
+
+class CLNInvoiceItem(BaseModel):
+    label: str | None = None
+    bolt11: str | None = None
+    bolt12: str | None = None
+    payment_hash: str | None = None
+    amount_msat: int | str | None = None
+    status: str
+    pay_index: int | None = None
+    amount_received_msat: int | str | None = None
+    paid_at: int | None = None
+    description: str | None = None
+    expires_at: int | None = None
+    payment_preimage: str | None = None
+
+
+class CLNListInvoicesResponse(BaseModel):
+    invoices: list[CLNInvoiceItem] = []
+
+
+class CLNPayItem(BaseModel):
+    payment_hash: str | None = None
+    status: str
+    destination: str | None = None
+    amount_msat: int | str | None = None
+    amount_sent_msat: int | str | None = None
+    created_at: float | int | None = None
+    preimage: str | None = None
+    number_of_parts: int | None = None
+
+
+class CLNListPaysResponse(BaseModel):
+    pays: list[CLNPayItem] = []
 
 
 class CLNRestWallet(LightningBackend):
@@ -113,10 +189,18 @@ class CLNRestWallet(LightningBackend):
                 balance=Amount(self.unit, 0),
             )
 
-        data = r.json()
-        if len(data) == 0:
+        try:
+            raw_data = r.json()
+            funds = CLNListFundsResponse.model_validate(raw_data)
+        except Exception:
+            return StatusResponse(
+                error_message=f"Invalid response from {self.url}: {r.text[:200]}",
+                balance=Amount(self.unit, 0),
+            )
+
+        if len(funds.channels) == 0:
             return StatusResponse(error_message="no data", balance=Amount(self.unit, 0))
-        balance_msat = int(sum([c["our_amount_msat"] for c in data["channels"]]))
+        balance_msat = int(sum([int(c.our_amount_msat) for c in funds.channels]))
         return StatusResponse(balance=Amount(self.unit, balance_msat // 1000))
 
     async def create_invoice(
@@ -166,13 +250,18 @@ class CLNRestWallet(LightningBackend):
                 error_message=error_message,
             )
 
-        data = r.json()
-        assert "payment_hash" in data
-        assert "bolt11" in data
+        try:
+            invoice_resp = CLNInvoiceResponse.model_validate(r.json())
+        except Exception as e:
+            return InvoiceResponse(
+                ok=False,
+                error_message=f"Invalid invoice response from {self.url}: {e}",
+            )
+
         return InvoiceResponse(
             ok=True,
-            checking_id=data["payment_hash"],
-            payment_request=data["bolt11"],
+            checking_id=invoice_resp.payment_hash,
+            payment_request=invoice_resp.bolt11,
         )
 
     async def pay_invoice(
@@ -223,11 +312,17 @@ class CLNRestWallet(LightningBackend):
                 result=PaymentResult.FAILED, error_message=error_message
             )
 
-        data = r.json()
+        try:
+            xpay_resp = CLNXPayResponse.model_validate(r.json())
+        except Exception as e:
+            return PaymentResponse(
+                result=PaymentResult.FAILED,
+                error_message=f"Invalid payment response from {self.url}: {e}",
+            )
 
         checking_id = invoice.payment_hash
-        preimage = data["payment_preimage"]
-        fee_msat = int(data["amount_sent_msat"]) - int(data["amount_msat"])
+        preimage = xpay_resp.payment_preimage
+        fee_msat = int(xpay_resp.amount_sent_msat) - int(xpay_resp.amount_msat)
 
         return PaymentResponse(
             result=PaymentResult.SETTLED,
@@ -243,12 +338,13 @@ class CLNRestWallet(LightningBackend):
         )
         try:
             r.raise_for_status()
-            data = r.json()
-
-            if r.is_error or "message" in data or data.get("invoices") is None:
+            if r.is_error or "message" in r.json():
                 raise Exception("error in cln response")
+            list_inv = CLNListInvoicesResponse.model_validate(r.json())
+            if not list_inv.invoices:
+                raise Exception("no invoices returned")
             return PaymentStatus(
-                result=INVOICE_RESULT_MAP[data["invoices"][0]["status"]],
+                result=INVOICE_RESULT_MAP[list_inv.invoices[0].status],
             )
         except Exception as e:
             logger.error(f"Error getting invoice status: {e}")
@@ -260,31 +356,34 @@ class CLNRestWallet(LightningBackend):
             data={"payment_hash": checking_id},
         )
         r.raise_for_status()
-        data = r.json()
+        if r.is_error or "message" in r.json():
+            try:
+                message = r.json().get("message") or r.text
+            except Exception:
+                message = r.text
+            raise Exception(f"error in clnrest response: {message}")
 
-        if not data.get("pays"):
+        list_pays = CLNListPaysResponse.model_validate(r.json())
+
+        if not list_pays.pays:
             # payment not found
-            logger.error(f"payment not found: {data.get('pays')}")
+            logger.error(f"payment not found for checking_id: {checking_id}")
             return PaymentStatus(
                 result=PaymentResult.UNKNOWN, error_message="payment not found"
             )
 
-        if r.is_error or "message" in data:
-            message = data.get("message") or data
-            raise Exception(f"error in clnrest response: {message}")
-
-        pays = data["pays"]
+        pays = list_pays.pays
         pay = next(
-            (pay for pay in pays if pay["status"] == CLN_PAYMENT_STATUS_PENDING),
+            (p for p in pays if p.status == CLN_PAYMENT_STATUS_PENDING),
             None,
         )
         if pay is None:
             pay = next(
-                (pay for pay in pays if pay["status"] == CLN_PAYMENT_STATUS_COMPLETE),
+                (p for p in pays if p.status == CLN_PAYMENT_STATUS_COMPLETE),
                 None,
             )
         if pay is None and all(
-            pay["status"] == CLN_PAYMENT_STATUS_FAILED for pay in pays
+            p.status == CLN_PAYMENT_STATUS_FAILED for p in pays
         ):
             pay = pays[-1]
         if pay is None:
@@ -294,12 +393,16 @@ class CLNRestWallet(LightningBackend):
             )
 
         fee_msat, preimage = None, None
-        if PAYMENT_RESULT_MAP[pay["status"]] == PaymentResult.SETTLED:
-            fee_msat = int(pay["amount_sent_msat"]) - int(pay["amount_msat"])
-            preimage = pay["preimage"]
+        if PAYMENT_RESULT_MAP[pay.status] == PaymentResult.SETTLED:
+            fee_msat = (
+                int(pay.amount_sent_msat) - int(pay.amount_msat)
+                if pay.amount_sent_msat is not None and pay.amount_msat is not None
+                else None
+            )
+            preimage = pay.preimage
 
         return PaymentStatus(
-            result=PAYMENT_RESULT_MAP[pay["status"]],
+            result=PAYMENT_RESULT_MAP[pay.status],
             fee=Amount(unit=Unit.msat, amount=fee_msat) if fee_msat else None,
             preimage=preimage,
         )
@@ -308,15 +411,15 @@ class CLNRestWallet(LightningBackend):
         # call listinvoices to determine the last pay_index
         r = await self.client.post("/v1/listinvoices")
         r.raise_for_status()
-        data = r.json()
-        if r.is_error or "message" in data:
+        if r.is_error or "message" in r.json():
             raise Exception("error in cln response")
+        list_inv = CLNListInvoicesResponse.model_validate(r.json())
         last_invoice_paid_invoice = next(
-            (i for i in reversed(data["invoices"]) if i["status"] == "paid"), None
+            (i for i in reversed(list_inv.invoices) if i.status == "paid"), None
         )
         last_pay_index = (
-            last_invoice_paid_invoice.get("pay_index")
-            if last_invoice_paid_invoice
+            last_invoice_paid_invoice.pay_index
+            if last_invoice_paid_invoice and last_invoice_paid_invoice.pay_index is not None
             else 0
         )
         self.last_pay_index = last_pay_index

--- a/cashu/lightning/lndrest.py
+++ b/cashu/lightning/lndrest.py
@@ -11,6 +11,7 @@ from bolt11 import (
     decode,
 )
 from loguru import logger
+from pydantic import BaseModel
 
 from ..core.base import Amount, MeltQuote, Unit
 from ..core.helpers import fee_reserve
@@ -44,6 +45,88 @@ INVOICE_RESULT_MAP = {
 MAX_ROUTE_RETRIES = 50
 TEMPORARY_CHANNEL_FAILURE_ERROR = "TEMPORARY_CHANNEL_FAILURE"
 PAYMENT_TIMEOUT_SECONDS = 60
+
+
+class LndBalanceResponse(BaseModel):
+    balance: str
+    pending_open_balance: str | None = None
+    local_balance: dict | None = None
+    remote_balance: dict | None = None
+    unsettled_local_balance: dict | None = None
+    unsettled_remote_balance: dict | None = None
+    pending_open_local_balance: dict | None = None
+    pending_open_remote_balance: dict | None = None
+
+
+class LndAddInvoiceResponse(BaseModel):
+    r_hash: str
+    payment_request: str
+    add_index: str | None = None
+    payment_addr: str | None = None
+
+
+class LndInvoiceStatusResponse(BaseModel):
+    state: str
+    memo: str | None = None
+    r_preimage: str | None = None
+    r_hash: str | None = None
+    value: str | None = None
+    value_msat: str | None = None
+    settled: bool | None = None
+    creation_date: str | None = None
+    settle_date: str | None = None
+    payment_request: str | None = None
+    description_hash: str | None = None
+    expiry: str | None = None
+    fallback_addr: str | None = None
+    cltv_expiry: str | None = None
+    route_hints: list | None = None
+    private: bool | None = None
+    add_index: str | None = None
+    settle_index: str | None = None
+    amt_paid: str | None = None
+    amt_paid_sat: str | None = None
+    amt_paid_msat: str | None = None
+    features: dict | None = None
+    is_keysend: bool | None = None
+    payment_addr: str | None = None
+    is_amp: bool | None = None
+
+
+class LndHop(BaseModel):
+    chan_id: str | None = None
+    chan_capacity: str | None = None
+    amt_to_forward: str | None = None
+    fee: str | None = None
+    expiry: int | None = None
+    amt_to_forward_msat: str | None = None
+    fee_msat: str | None = None
+    pub_key: str | None = None
+    tlv_payload: bool | None = None
+    mpp_record: dict | None = None
+    custom_records: dict | None = None
+
+
+class LndRoute(BaseModel):
+    total_time_lock: int | None = None
+    total_fees: str | None = None
+    total_amt: str | None = None
+    hops: list[dict] = []
+    total_fees_msat: str | None = None
+    total_amt_msat: str | None = None
+
+
+class LndQueryRoutesResponse(BaseModel):
+    routes: list[dict] = []
+    success_prob: float | None = None
+
+
+class LndSendToRouteResponse(BaseModel):
+    preimage: str | None = None
+    route: LndRoute | None = None
+    payment_error: str | None = None
+    failure: dict | None = None
+    status: str | None = None
 
 
 class LndRestWallet(LightningBackend):
@@ -120,16 +203,17 @@ class LndRestWallet(LightningBackend):
             )
 
         try:
-            data = r.json()
+            raw_data = r.json()
             if r.is_error:
                 raise Exception
+            balance_resp = LndBalanceResponse.model_validate(raw_data)
         except Exception:
             return StatusResponse(
                 error_message=r.text[:200], balance=Amount(self.unit, 0)
             )
 
         return StatusResponse(
-            error_message=None, balance=Amount(self.unit, int(data["balance"]))
+            error_message=None, balance=Amount(self.unit, int(balance_resp.balance))
         )
 
     async def create_invoice(
@@ -175,9 +259,9 @@ class LndRestWallet(LightningBackend):
                 error_message=error_message,
             )
 
-        data = r.json()
-        payment_request = data["payment_request"]
-        payment_hash = base64.b64decode(data["r_hash"]).hex()
+        invoice_resp = LndAddInvoiceResponse.model_validate(r.json())
+        payment_request = invoice_resp.payment_request
+        payment_hash = base64.b64decode(invoice_resp.r_hash).hex()
         checking_id = payment_hash
 
         return InvoiceResponse(
@@ -376,6 +460,7 @@ class LndRestWallet(LightningBackend):
 
         assert response and route
 
+        send_to_route_resp = LndSendToRouteResponse.model_validate(response.json())
         data = response.json()
         if response.is_error or data.get("message") or data.get("status") == "FAILED":
             error_message = f"Sending to route failed with code {data.get('failure').get('code')} after {attempts} tries."
@@ -385,9 +470,15 @@ class LndRestWallet(LightningBackend):
 
         result = PAYMENT_RESULT_MAP.get(data.get("status"), PaymentResult.UNKNOWN)
         checking_id = invoice.payment_hash
-        fee_msat = int(data["route"]["total_fees_msat"]) if data.get("route") else None
+        fee_msat = (
+            int(send_to_route_resp.route.total_fees_msat)
+            if send_to_route_resp.route and send_to_route_resp.route.total_fees_msat
+            else None
+        )
         preimage = (
-            base64.b64decode(data["preimage"]).hex() if data.get("preimage") else None
+            base64.b64decode(send_to_route_resp.preimage).hex()
+            if send_to_route_resp.preimage
+            else None
         )
 
         logger.debug(f"Partial payment succeeded after {attempts} different tries!")
@@ -408,18 +499,17 @@ class LndRestWallet(LightningBackend):
             logger.error(f"Couldn't get invoice status: {r.text}")
             return PaymentStatus(result=PaymentResult.UNKNOWN, error_message=r.text)
 
-        data = None
         try:
-            data = r.json()
-        except json.JSONDecodeError as e:
+            inv_status = LndInvoiceStatusResponse.model_validate(r.json())
+        except Exception as e:
             logger.error(f"Incomprehensible response: {e}")
             return PaymentStatus(result=PaymentResult.UNKNOWN, error_message=str(e))
-        if not data or not data.get("state"):
+        if not inv_status.state:
             return PaymentStatus(
                 result=PaymentResult.UNKNOWN, error_message="no invoice state"
             )
         return PaymentStatus(
-            result=INVOICE_RESULT_MAP[data["state"]],
+            result=INVOICE_RESULT_MAP[inv_status.state],
         )
 
     async def get_payment_status(self, checking_id: str) -> PaymentStatus:

--- a/cashu/lightning/strike.py
+++ b/cashu/lightning/strike.py
@@ -20,6 +20,12 @@ from .base import (
 USDT = "USDT"
 
 
+class StrikeBalance(BaseModel):
+    currency: str
+    total: str
+    available: str | None = None
+
+
 class StrikeAmount(BaseModel):
     amount: str
     currency: str
@@ -144,7 +150,8 @@ class StrikeWallet(LightningBackend):
             )
 
         try:
-            data = r.json()
+            raw_data = r.json()
+            balances = [StrikeBalance.model_validate(b) for b in raw_data]
         except Exception:
             return StatusResponse(
                 error_message=(
@@ -153,21 +160,21 @@ class StrikeWallet(LightningBackend):
                 balance=Amount(self.unit, 0),
             )
 
-        for balance in data:
-            if balance["currency"] == self.currency:
+        for balance in balances:
+            if balance.currency == self.currency:
                 return StatusResponse(
                     error_message=None,
-                    balance=Amount.from_float(float(balance["total"]), self.unit),
+                    balance=Amount.from_float(float(balance.total), self.unit),
                 )
 
         # if the unit is USD but no USD balance was found, we try USDT
         if self.unit == Unit.usd:
-            for balance in data:
-                if balance["currency"] == USDT:
+            for balance in balances:
+                if balance.currency == USDT:
                     self.currency = USDT
                     return StatusResponse(
                         error_message=None,
-                        balance=Amount.from_float(float(balance["total"]), self.unit),
+                        balance=Amount.from_float(float(balance.total), self.unit),
                     )
 
         return StatusResponse(

--- a/tests/lightning/test_lightning_backends_mocked.py
+++ b/tests/lightning/test_lightning_backends_mocked.py
@@ -846,3 +846,89 @@ async def test_spark_get_payment_quote_rejects_non_bolt11():
     melt_quote = PostMeltQuoteRequest(unit="sat", request="non-bolt11")
     with pytest.raises(Exception, match="Only BOLT11 payments are supported"):
         await wallet.get_payment_quote(melt_quote)
+
+
+@pytest.mark.asyncio
+async def test_cln_models_validation_in_backends():
+    from cashu.lightning.clnrest import (
+        CLNInvoiceResponse,
+        CLNListFundsResponse,
+        CLNListInvoicesResponse,
+        CLNListPaysResponse,
+        CLNXPayResponse,
+    )
+
+    # Test CLNListFundsResponse
+    funds = CLNListFundsResponse.model_validate(
+        {"channels": [{"our_amount_msat": 1000000, "connected": True}]}
+    )
+    assert len(funds.channels) == 1
+    assert int(funds.channels[0].our_amount_msat) == 1000000
+
+    # Test CLNInvoiceResponse
+    inv = CLNInvoiceResponse.model_validate(
+        {"payment_hash": "hash123", "bolt11": "lnbc1..."}
+    )
+    assert inv.payment_hash == "hash123"
+    assert inv.bolt11 == "lnbc1..."
+
+    # Test CLNXPayResponse
+    xpay = CLNXPayResponse.model_validate(
+        {
+            "payment_preimage": "preimage123",
+            "amount_msat": 1000,
+            "amount_sent_msat": 1050,
+        }
+    )
+    assert xpay.payment_preimage == "preimage123"
+    assert int(xpay.amount_sent_msat) - int(xpay.amount_msat) == 50
+
+    # Test CLNListInvoicesResponse
+    list_inv = CLNListInvoicesResponse.model_validate(
+        {"invoices": [{"status": "paid", "pay_index": 5}]}
+    )
+    assert list_inv.invoices[0].status == "paid"
+    assert list_inv.invoices[0].pay_index == 5
+
+    # Test CLNListPaysResponse
+    list_pays = CLNListPaysResponse.model_validate(
+        {"pays": [{"status": "complete", "amount_sent_msat": 2000, "amount_msat": 1900, "preimage": "p1"}]}
+    )
+    assert list_pays.pays[0].status == "complete"
+    assert list_pays.pays[0].preimage == "p1"
+
+
+@pytest.mark.asyncio
+async def test_lnd_models_validation_in_backends():
+    from cashu.lightning.lndrest import (
+        LndAddInvoiceResponse,
+        LndBalanceResponse,
+        LndInvoiceStatusResponse,
+        LndSendToRouteResponse,
+    )
+
+    # Test LndBalanceResponse
+    bal = LndBalanceResponse.model_validate({"balance": "50000"})
+    assert int(bal.balance) == 50000
+
+    # Test LndAddInvoiceResponse
+    add_inv = LndAddInvoiceResponse.model_validate(
+        {"r_hash": "aGV4", "payment_request": "lnbc1..."}
+    )
+    assert add_inv.payment_request == "lnbc1..."
+
+    # Test LndInvoiceStatusResponse
+    inv_stat = LndInvoiceStatusResponse.model_validate({"state": "SETTLED"})
+    assert inv_stat.state == "SETTLED"
+
+    # Test LndSendToRouteResponse
+    send_route = LndSendToRouteResponse.model_validate(
+        {
+            "preimage": "aGV4",
+            "route": {"total_fees_msat": "100", "hops": []},
+            "status": "SUCCEEDED",
+        }
+    )
+    assert send_route.status == "SUCCEEDED"
+    assert send_route.route and send_route.route.total_fees_msat == "100"
+


### PR DESCRIPTION
Closes #620.

## What

Replaces raw dictionary indexing across Lightning backend response handling with explicit, typed Pydantic `BaseModel` response schemas.

- **CLNRest (`cashu/lightning/clnrest.py`)**:
  - `CLNChannel`, `CLNListFundsResponse` for `/v1/listfunds`
  - `CLNInvoiceResponse` for `/v1/invoice`
  - `CLNXPayResponse` for `/v1/xpay`
  - `CLNInvoiceItem`, `CLNListInvoicesResponse` for `/v1/listinvoices`
  - `CLNPayItem`, `CLNListPaysResponse` for `/v1/listpays`

- **LNDRest (`cashu/lightning/lndrest.py`)**:
  - `LndBalanceResponse` for `/v1/balance/channels`
  - `LndAddInvoiceResponse` for `/v1/invoices`
  - `LndInvoiceStatusResponse` for `/v1/invoice/{id}`
  - `LndHop`, `LndRoute`, `LndQueryRoutesResponse` for `/v1/graph/routes`
  - `LndSendToRouteResponse` for `/v2/router/route/send`

- **Strike (`cashu/lightning/strike.py`)**:
  - `StrikeBalance` for `/v1/balances`

## Verification

- Added unit tests in `tests/lightning/test_lightning_backends_mocked.py` for CLN and LND response model validation.
- All 46 lightning backend unit and regression tests pass (`pytest tests/lightning/`).
- Core unit test suite passes (`pytest tests/test_core.py tests/test_crypto.py`).
- MyPy clean on modified backend files (`mypy cashu/lightning/clnrest.py cashu/lightning/lndrest.py cashu/lightning/strike.py`).