### PR TITLE
fix: the six regtest-mint failures on the v3 keysets branch

### DIFF
--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -28,6 +28,7 @@ from ..core.db import Connection, Database
 from ..core.errors import (
     BatchDuplicateQuotesError,
     CashuError,
+    KeysetInactiveError,
     LightningError,
     LightningPaymentFailedError,
     NotAllowedError,
@@ -1446,7 +1447,7 @@ class Ledger(
                 if output.id != keyset.id:
                     raise TransactionError("keyset id does not match output id")
                 if not keyset.active:
-                    raise TransactionError("keyset is not active")
+                    raise KeysetInactiveError()
                 logger.trace(f"Storing blinded message with keyset {keyset.id}.")
                 await self.crud.store_blinded_message(
                     id=keyset.id,
@@ -1504,7 +1505,7 @@ class Ledger(
             if output.id != keyset.id:
                 raise TransactionError("keyset id does not match output id")
             if not keyset.active:
-                raise TransactionError("keyset is not active")
+                raise KeysetInactiveError()
             keyset_id = output.id
             logger.trace(f"Generating promise with keyset {keyset_id}.")
             private_key_amount = keyset.private_keys[output.amount]

--- a/tests/mint/test_mint_api.py
+++ b/tests/mint/test_mint_api.py
@@ -488,6 +488,8 @@ async def test_melt_external(ledger: Ledger, wallet: Wallet):
     reason="only works on regtest",
 )
 async def test_melt_external_with_routing_fee(ledger: Ledger, wallet: Wallet):
+    # Raw melt payload without a v3 witness, so mint on the pre-v3 keyset.
+    await use_v2_keyset(wallet)
     mint_quote = await wallet.request_mint(64)
     await pay_if_regtest(mint_quote.request)
     await wallet.mint(64, quote_id=mint_quote.quote)
@@ -546,6 +548,8 @@ async def test_melt_external_with_routing_fee(ledger: Ledger, wallet: Wallet):
     reason="CLN pathfinding is randomized, the exact fee is not deterministic",
 )
 async def test_melt_external_routing_fee_rounding(ledger: Ledger, wallet: Wallet):
+    # Raw melt payload without a v3 witness, so mint on the pre-v3 keyset.
+    await use_v2_keyset(wallet)
     mint_quote = await wallet.request_mint(1024)
     await pay_if_regtest(mint_quote.request)
     await wallet.mint(1024, quote_id=mint_quote.quote)

--- a/tests/mint/test_mint_melt.py
+++ b/tests/mint/test_mint_melt.py
@@ -813,7 +813,7 @@ async def test_mint_pay_with_duplicate_checking_id(wallet):
     )
     assert response1.state == "PAID"
 
-    assert_err(
+    await assert_err(
         wallet.melt(
             proofs=proofs2,
             invoice=invoice,

--- a/tests/mint/test_mint_melt.py
+++ b/tests/mint/test_mint_melt.py
@@ -820,7 +820,8 @@ async def test_mint_pay_with_duplicate_checking_id(wallet):
             fee_reserve_sat=melt_quote2.fee_reserve,
             quote_id=melt_quote2.quote,
         ),
-        "Melt quote already paid or pending.",
+        # wallet.melt wraps the mint's 11000 detail
+        "could not pay invoice: Mint Error: Melt quote already paid or pending. (Code: 11000)",
     )
 
 


### PR DESCRIPTION
## Intended to merge into BLS Keyset v3 PR  #999 

Fixes the failing CI run's four unique failures, all with one-line causes.

**test_blinded_message_operations_reject_inactive_keyset (both params):** `_store_blinded_messages` and `_sign_blinded_messages` in ledger.py still raised plain `TransactionError("keyset is not active")` where the test and `verification.py` use `KeysetInactiveError`. Both sites now raise the specific class.

**test_melt_external_with_routing_fee / _rounding:** these hand-roll a raw `/v1/melt/bolt11` payload with no v3 transaction witness, but the wallet fixture now mints on the v3 keyset by default, so the mint answers 400 "missing nutroot transaction witness". They now bind to the pre-v3 keyset via `use_v2_keyset`, like the other raw-payload tests in the same file.

**Drive-by:** an `assert_err` at test_mint_melt.py:816 was never awaited, so its assertion was silently skipped.

Gates run locally: ruff, mypy, full pytest (1015 passed; the melt tests are regtest-only and are verified by construction plus the mint's logged 400 reason).