### PR TITLE
test: sync the shared nutroot vectors with the spec

### DIFF
--- a/tests/nutroot_v3_vectors.json
+++ b/tests/nutroot_v3_vectors.json
@@ -62,17 +62,13 @@
       "leaf": "00040200010104002102f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f90a002103acd484e2f0c7f65309ad178a9f559abde09796974c57e714c35f110dfc27ccbe",
       "control": {
         "K": "03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556",
-        "path": [
-          "80468218b6e329d4d80682883617af0acd1d4a9d5b1658fbc448cc4781b4f254"
-        ]
+        "path": ["80468218b6e329d4d80682883617af0acd1d4a9d5b1658fbc448cc4781b4f254"]
       },
       "signatures": [
         "27f53ffb8fe7bae5da0a754fd63aeb04fbfc7ee16c865fb5af3fb4411785b784df09a810c470386602fab69c450dc249efb465cff27f5322d1305e3eaec4d6fb"
       ]
     },
-    "after_witness_path": [
-      "fdb9a975d2d191fbfbe2ac40d70f49ffe73836f4bbb0f2bb2405f63e2cc029b2"
-    ]
+    "after_witness_path": ["fdb9a975d2d191fbfbe2ac40d70f49ffe73836f4bbb0f2bb2405f63e2cc029b2"]
   },
   "nut13_v3": {
     "comment": "NUT-13 v3 derivation (spec 2.4.2): HMAC(seed, message_v3) with message_v3 = \"Cashu_KDF_HMAC_SHA256\" || u32_be(len(keyset_id_bytes)) || keyset_id_bytes || u64_be(counter) || type || u32_be(attempt) || type_suffix. Every type rejection samples: 0x00 the internal private key k (secret is K = k*G compressed) and 0x02 the NUMS offset u against SECP256K1_N, 0x01 the blinding factor against BLS Fr, 0x03 a self-owned leaf key with suffix u32_be(i), 0x04 a mint quote lock key on its own quote counter, derived with an EMPTY keyset id field (a quote precedes any keyset), so quote_locks below do not depend on keyset_id. Types 0x00-0x03 share the proof counter. The framing is V3 only: the V2 message keeps its unframed form. Key derivation (0x00) accepts at attempts 0, 0, 0, 0 and blinding factors (0x01) at attempts 7, 1, 2, 2 for counters 0, 1, 2, 3, exercising the rejection loop. Counter 0 also carries Y = bls_hash_to_curve(raw 33 secret bytes) pinning the binary-secret hashing rule and DST across implementations.",
@@ -217,7 +213,7 @@
           {
             "amount": 8,
             "keyset_id": "02b7e077d020fabed456a6be138a8e20e9ef40b44d873fa12c005b656eb0cf99f6",
-            "secret": "0234df38671738d8e9ee205dc364fd4b45df8ed2ff91686e93d02ca1feb3b2f118",
+            "secret": "02e6e7cfa7b82d4b3b449fa6466c893469a727d0214d48db4956a6054b8022a29b",
             "C": "84d1b7291ae5737f3c851aa33cafe0f7afeb5ccb4da086c482bb85b7525e61547f1b5a6d1a01b1fed1f960d1a9d03327"
           }
         ],
@@ -240,8 +236,8 @@
           }
         ]
       },
-      "transcript": "01007f0100010802002102b7e077d020fabed456a6be138a8e20e9ef40b44d873fa12c005b656eb0cf99f60300210234df38671738d8e9ee205dc364fd4b45df8ed2ff91686e93d02ca1feb3b2f11804003084d1b7291ae5737f3c851aa33cafe0f7afeb5ccb4da086c482bb85b7525e61547f1b5a6d1a01b1fed1f960d1a9d0332703005a01000002002102b7e077d020fabed456a6be138a8e20e9ef40b44d873fa12c005b656eb0cf99f6030030b42a0bcc39598db1dca617aeea6bc367f2566636826dc961a54faae15b3b8d10afc1cb0206e70ab3b0e12c2b9478cd5503005a01000002002102b7e077d020fabed456a6be138a8e20e9ef40b44d873fa12c005b656eb0cf99f6030030b42a0bcc39598db1dca617aeea6bc367f2566636826dc961a54faae15b3b8d10afc1cb0206e70ab3b0e12c2b9478cd550400160100010802000f71756f74652d6d656c742d30303031",
-      "digest": "98bd694b8b67668d27a82a37a59261aacac3baec47959cb7a45de63ab9c7bfe0"
+      "transcript": "01007f0100010802002102b7e077d020fabed456a6be138a8e20e9ef40b44d873fa12c005b656eb0cf99f603002102e6e7cfa7b82d4b3b449fa6466c893469a727d0214d48db4956a6054b8022a29b04003084d1b7291ae5737f3c851aa33cafe0f7afeb5ccb4da086c482bb85b7525e61547f1b5a6d1a01b1fed1f960d1a9d0332703005a01000002002102b7e077d020fabed456a6be138a8e20e9ef40b44d873fa12c005b656eb0cf99f6030030b42a0bcc39598db1dca617aeea6bc367f2566636826dc961a54faae15b3b8d10afc1cb0206e70ab3b0e12c2b9478cd5503005a01000002002102b7e077d020fabed456a6be138a8e20e9ef40b44d873fa12c005b656eb0cf99f6030030b42a0bcc39598db1dca617aeea6bc367f2566636826dc961a54faae15b3b8d10afc1cb0206e70ab3b0e12c2b9478cd550400160100010802000f71756f74652d6d656c742d30303031",
+      "digest": "3b7a268b8c49e836d5235a4d4b89f1d5bfbe7bfa01d6427fa2a013f91b9d1a68"
     }
   },
   "tokens_v4": {
@@ -330,6 +326,15 @@
     "nums_key": "0250929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
     "blind_slot1_key": "02e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13",
     "blind_slot1_result": "039ca57991c48db95252bff61e02c31cf9b1e9ec2ef27d9dee33db6f0324e6ca81",
-    "blind_slot1_leaf": "000202000101040021039ca57991c48db95252bff61e02c31cf9b1e9ec2ef27d9dee33db6f0324e6ca8106000468a3be80"
+    "blind_slot1_leaf": "000202000101040021039ca57991c48db95252bff61e02c31cf9b1e9ec2ef27d9dee33db6f0324e6ca8106000468a3be80",
+    "duplicate_pair_tree": [
+      "00010200010104002102f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9",
+      "00010200010104002102f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9"
+    ],
+    "duplicate_pair_leaf_hash": "23e8ff1693496ecad495b7ed3cdd7f8595c52a3adc0b92475835b0fb839116cb",
+    "duplicate_pair_root": "1eaf291448e2f3c3a4fc00bfd591917bbb807e63af0fb905d054002bddd2cbc6",
+    "duplicate_pair_internal_key": "03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556",
+    "duplicate_pair_secret": "03dd2f11ab23b670222ada50325b5d49cd07e1d7a721d9b52fa2039df1f1b0dbfd",
+    "leaf_unknown_field": "00010200010104002102f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9090004deadbeef"
   }
 }


### PR DESCRIPTION
## Intended to merge into BLS Keyset v3 PR  #999

Test data only, no code changes.

The shared `nutroot_v3_vectors.json` `melt_with_change` transcript entry predates the NUT-13 reframing (cashubtc/nuts `f5353a0`): `swap`, `mint` and `melt` were regenerated for the new counter-0 secret but this entry kept the old one, so nutshell and cashu-ts agreed with each other while both disagreed with the spec document (`tests/10-tests.md` pins digest `3b7a268b...`; the JSON carried `98bd69...`).

This regenerates the entry from the spec and adds two vectors the spec carries but the shared JSON did not: the duplicate-pair fold (the fold commits the leaf multiset) and the unknown-leaf-field rejection. `test_nutroot.py` recomputes the transcript and digest from each vector's `tx`, so the suite now proves the encoder reproduces the spec values byte for byte. The cashu-ts copy is corrected in step on its `rnd/taproot-v3` branch.
