### PR TITLE
fix(auth): align auth promises schema with the mint CRUD

### DIFF
--- a/cashu/mint/auth/migrations.py
+++ b/cashu/mint/auth/migrations.py
@@ -138,3 +138,59 @@ async def m004_remove_dleq_from_promises(db: Database):
         await conn.execute(
             f"ALTER TABLE {db.table_with_schema('promises')} DROP COLUMN dleq_s"
         )
+
+
+async def m005_align_promises_with_mint_schema(db: Database):
+    """
+    Align the auth promises table with the columns the shared LedgerCrudSqlite writes.
+    """
+    async with db.connect() as conn:
+        if conn.type == "SQLITE":
+            await conn.execute("PRAGMA foreign_keys=OFF;")
+            await conn.execute(
+                f"""
+                    CREATE TABLE IF NOT EXISTS {db.table_with_schema("promises_new")} (
+                        id TEXT NOT NULL,
+                        amount {db.big_int} NOT NULL,
+                        b_ TEXT NOT NULL,
+                        c_ TEXT,
+                        created TIMESTAMP,
+                        signed_at TIMESTAMP,
+                        mint_quote TEXT,
+                        melt_quote TEXT,
+                        swap_id TEXT,
+                        order_index INTEGER DEFAULT 0,
+
+                        UNIQUE (b_)
+
+                    );
+                """
+            )
+            await conn.execute(
+                f"INSERT INTO {db.table_with_schema('promises_new')} (id, amount, b_, c_, created) "
+                f"SELECT id, amount, b_, c_, created FROM {db.table_with_schema('promises')}"
+            )
+            await conn.execute(f"DROP TABLE {db.table_with_schema('promises')}")
+            await conn.execute(
+                f"ALTER TABLE {db.table_with_schema('promises_new')} RENAME TO {db.table_with_schema('promises')}"
+            )
+            await conn.execute("PRAGMA foreign_keys=ON;")
+        else:
+            await conn.execute(
+                f"ALTER TABLE {db.table_with_schema('promises')} ADD COLUMN IF NOT EXISTS mint_quote TEXT"
+            )
+            await conn.execute(
+                f"ALTER TABLE {db.table_with_schema('promises')} ADD COLUMN IF NOT EXISTS melt_quote TEXT"
+            )
+            await conn.execute(
+                f"ALTER TABLE {db.table_with_schema('promises')} ADD COLUMN IF NOT EXISTS swap_id TEXT"
+            )
+            await conn.execute(
+                f"ALTER TABLE {db.table_with_schema('promises')} ADD COLUMN IF NOT EXISTS signed_at TIMESTAMP"
+            )
+            await conn.execute(
+                f"ALTER TABLE {db.table_with_schema('promises')} ADD COLUMN IF NOT EXISTS order_index INTEGER DEFAULT 0"
+            )
+            await conn.execute(
+                f"ALTER TABLE {db.table_with_schema('promises')} ALTER COLUMN c_ DROP NOT NULL"
+            )

--- a/cashu/mint/auth/migrations.py
+++ b/cashu/mint/auth/migrations.py
@@ -146,7 +146,6 @@ async def m005_align_promises_with_mint_schema(db: Database):
     """
     async with db.connect() as conn:
         if conn.type == "SQLITE":
-            await conn.execute("PRAGMA foreign_keys=OFF;")
             await conn.execute(
                 f"""
                     CREATE TABLE IF NOT EXISTS {db.table_with_schema("promises_new")} (
@@ -174,7 +173,6 @@ async def m005_align_promises_with_mint_schema(db: Database):
             await conn.execute(
                 f"ALTER TABLE {db.table_with_schema('promises_new')} RENAME TO {db.table_with_schema('promises')}"
             )
-            await conn.execute("PRAGMA foreign_keys=ON;")
         else:
             await conn.execute(
                 f"ALTER TABLE {db.table_with_schema('promises')} ADD COLUMN IF NOT EXISTS mint_quote TEXT"

--- a/tests/mint/test_mint_migrations.py
+++ b/tests/mint/test_mint_migrations.py
@@ -6,6 +6,7 @@ from cashu.core.base import MeltQuote, MeltQuoteState, MintQuote, MintQuoteState
 from cashu.core.db import Database
 from cashu.core.migrations import migrate_databases
 from cashu.mint import migrations as mint_migrations
+from cashu.mint.auth import migrations as auth_migrations
 from cashu.mint.crud import LedgerCrudSqlite
 
 
@@ -230,3 +231,89 @@ async def test_auth_m003_migration():
     # Clean up
     if os.path.exists(db_path):
         shutil.rmtree(db_path)
+
+
+@pytest.mark.asyncio
+async def test_auth_promises_schema_supports_blinded_message_crud(tmp_path):
+    """The auth ledger reuses LedgerCrudSqlite, so the auth promises table must carry
+    the same columns the mint CRUD writes.
+    """
+    db = Database("auth", str(tmp_path / "auth_promises_schema"))
+    await migrate_databases(db, auth_migrations)
+    crud = LedgerCrudSqlite()
+
+    async with db.connect() as conn:
+        columns = {
+            row["name"]: row
+            for row in await conn.fetchall(
+                f"PRAGMA table_info({db.table_with_schema('promises')})"
+            )
+        }
+
+    assert {
+        "mint_quote",
+        "melt_quote",
+        "swap_id",
+        "signed_at",
+        "order_index",
+    } <= columns.keys()
+    # blinded messages are stored before they are signed
+    assert not columns["c_"]["notnull"]
+
+    b_ = "02" + "aa" * 32
+    c_ = "03" + "bb" * 32
+
+    # this is the call AuthLedger.mint_blind_auth makes via Ledger._store_blinded_messages
+    await crud.store_blinded_message(db=db, amount=1, b_=b_, id="keyset_id")
+    assert await crud.get_blind_signature(db=db, b_=b_) is None
+
+    await crud.update_blinded_message_signature(db=db, amount=1, b_=b_, c_=c_)
+    signature = await crud.get_blind_signature(db=db, b_=b_)
+    assert signature is not None
+    assert signature.C_ == c_
+    assert signature.amount == 1
+    assert signature.id == "keyset_id"
+
+
+@pytest.mark.asyncio
+async def test_auth_m005_migration_preserves_existing_promises(tmp_path):
+    """m005 rebuilds the SQLite promises table, so already-issued auth promises must
+    survive the upgrade.
+    """
+    db = Database("auth", str(tmp_path / "auth_promises_upgrade"))
+
+    # bring the database up to the pre-m005 state
+    async with db.connect() as conn:
+        await auth_migrations.m000_create_migrations_table(conn)
+    for migration in (
+        auth_migrations.m001_initial,
+        auth_migrations.m002_add_balance_to_keysets_and_log_table,
+        auth_migrations.m003_add_final_expiry_to_keysets,
+        auth_migrations.m004_remove_dleq_from_promises,
+    ):
+        await migration(db)
+
+    b_ = "02" + "cc" * 32
+    c_ = "03" + "dd" * 32
+    async with db.connect() as conn:
+        await conn.execute(
+            f"""
+            INSERT INTO {db.table_with_schema('promises')} (id, amount, b_, c_, created)
+            VALUES (:id, :amount, :b_, :c_, :created)
+            """,
+            {
+                "id": "keyset_id",
+                "amount": 1,
+                "b_": b_,
+                "c_": c_,
+                "created": db.to_timestamp(db.timestamp_now_str()),
+            },
+        )
+
+    await auth_migrations.m005_align_promises_with_mint_schema(db)
+
+    signature = await LedgerCrudSqlite().get_blind_signature(db=db, b_=b_)
+    assert signature is not None
+    assert signature.C_ == c_
+    assert signature.amount == 1
+    assert signature.id == "keyset_id"


### PR DESCRIPTION
## Fixes #1143 

## Summary
The auth ledger uses the shared LedgerCrudSqlite, which writes mint_quote, melt_quote, swap_id, order_index and signed_at, and stores blinded messages before signing them. The auth migration chain never grew those columns and still declares c_ NOT NULL, so blind auth minting fails on a freshly migrated auth database with:
```
    table promises has no column named mint_quote
```
Add m005 to add the missing columns and make c_ nullable.

