### PR TITLE
test(spark): run shared mint and wallet regtests

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -1,4 +1,5 @@
 name: prepare
+description: Install Python, Poetry, and project dependencies.
 
 inputs:
   python-version:

--- a/.github/actions/setup-regtest/action.yml
+++ b/.github/actions/setup-regtest/action.yml
@@ -1,0 +1,31 @@
+name: Setup regtest
+description: Start the pinned Lightning environment, including Spark when selected.
+
+inputs:
+  backend-wallet-class:
+    description: Lightning backend under test
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout regtest
+      uses: actions/checkout@v6
+      with:
+        repository: callebtc/cashu-regtest
+        ref: 23d5c160e0b5fade7e4a245b7385f9116bf2fc5c
+        path: regtest
+        persist-credentials: false
+
+    - name: Start regtest
+      shell: bash
+      working-directory: regtest
+      env:
+        BACKEND: ${{ inputs.backend-wallet-class }}
+      run: |
+        chmod -R 777 .
+        if [ "$BACKEND" = "SparkL2Wallet" ]; then
+          bash ./start.sh --spark
+        else
+          bash ./start.sh
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,12 @@ jobs:
         python-version: ["3.12"]
         poetry-version: ["2.3.2"]
         backend-wallet-class:
-          ["LndRPCWallet", "LndRestWallet", "CLNRestWallet"]
+          ["LndRPCWallet", "LndRestWallet", "CLNRestWallet", "SparkL2Wallet"]
         mint-database: ["./test_data/test_mint", "postgres://cashu:cashu@localhost:5432/cashu"]
         # mint-database: ["./test_data/test_mint"]
     with:
       python-version: ${{ matrix.python-version }}
+      poetry-version: ${{ matrix.poetry-version }}
       backend-wallet-class: ${{ matrix.backend-wallet-class }}
       mint-database: ${{ matrix.mint-database }}
 
@@ -82,10 +83,11 @@ jobs:
         python-version: ["3.12"]
         poetry-version: ["2.3.2"]
         backend-wallet-class:
-          ["LndRPCWallet", "LndRestWallet", "CLNRestWallet"]
+          ["LndRPCWallet", "LndRestWallet", "CLNRestWallet", "SparkL2Wallet"]
         mint-database: ["./test_data/test_mint", "postgres://cashu:cashu@localhost:5432/cashu"]
         # mint-database: ["./test_data/test_mint"]
     with:
       python-version: ${{ matrix.python-version }}
+      poetry-version: ${{ matrix.poetry-version }}
       backend-wallet-class: ${{ matrix.backend-wallet-class }}
       mint-database: ${{ matrix.mint-database }}

--- a/.github/workflows/regtest-mint.yml
+++ b/.github/workflows/regtest-mint.yml
@@ -26,7 +26,7 @@ jobs:
   regtest-mint:
     runs-on: ${{ inputs.os-version }}
     # Spark's cold source build can take 90 minutes before the suite starts.
-    timeout-minutes: ${{ inputs.backend-wallet-class == 'SparkL2Wallet' && 150 || 30 }}
+    timeout-minutes: ${{ inputs.backend-wallet-class == 'SparkL2Wallet' && 150 || 45 }}
     env:
       CASHU_REGTEST_DIR: ${{ github.workspace }}/regtest
     steps:
@@ -55,7 +55,7 @@ jobs:
         run: make test-spark-backend-regtest
 
       - name: Run Tests
-        timeout-minutes: ${{ inputs.backend-wallet-class == 'SparkL2Wallet' && 45 || 10 }}
+        timeout-minutes: ${{ inputs.backend-wallet-class == 'SparkL2Wallet' && 45 || 20 }}
         env:
           WALLET_NAME: test_wallet
           MINT_HOST: localhost

--- a/.github/workflows/regtest-mint.yml
+++ b/.github/workflows/regtest-mint.yml
@@ -25,7 +25,10 @@ permissions:
 jobs:
   regtest-mint:
     runs-on: ${{ inputs.os-version }}
-    timeout-minutes: 10
+    # Spark's cold source build can take 90 minutes before the suite starts.
+    timeout-minutes: ${{ inputs.backend-wallet-class == 'SparkL2Wallet' && 150 || 30 }}
+    env:
+      CASHU_REGTEST_DIR: ${{ github.workspace }}/regtest
     steps:
       - name: Start PostgreSQL service
         if: contains(inputs.mint-database, 'postgres')
@@ -41,13 +44,18 @@ jobs:
           poetry-version: ${{ inputs.poetry-version }}
 
       - name: Setup Regtest
-        run: |
-          git clone https://github.com/callebtc/cashu-regtest-enviroment.git regtest
-          cd regtest
-          chmod -R 777 .
-          bash ./start.sh
+        timeout-minutes: ${{ inputs.backend-wallet-class == 'SparkL2Wallet' && 90 || 20 }}
+        uses: ./.github/actions/setup-regtest
+        with:
+          backend-wallet-class: ${{ inputs.backend-wallet-class }}
+
+      - name: Run direct Spark backend tests
+        if: inputs.backend-wallet-class == 'SparkL2Wallet'
+        timeout-minutes: 10
+        run: make test-spark-backend-regtest
 
       - name: Run Tests
+        timeout-minutes: ${{ inputs.backend-wallet-class == 'SparkL2Wallet' && 45 || 10 }}
         env:
           WALLET_NAME: test_wallet
           MINT_HOST: localhost
@@ -69,7 +77,20 @@ jobs:
           MINT_CLNREST_CERT: ./regtest/data/clightning-2/regtest/ca.pem
         run: |
           sudo chmod -R 777 .
-          make test-mint
+          if [ "$MINT_BACKEND_BOLT11_SAT" = "SparkL2Wallet" ]; then
+            make test-spark-mint
+          else
+            make test-mint
+          fi
+
+      - name: Regtest failure diagnostics
+        if: failure()
+        working-directory: regtest
+        env:
+          COMPOSE_PROJECT_NAME: cashu
+        run: |
+          docker compose --profile "*" ps -a
+          docker compose --profile "*" logs --tail=100
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/regtest-wallet.yml
+++ b/.github/workflows/regtest-wallet.yml
@@ -25,7 +25,10 @@ permissions:
 jobs:
   regtest-wallet:
     runs-on: ${{ inputs.os-version }}
-    timeout-minutes: 10
+    # Spark's cold source build can take 90 minutes before the suite starts.
+    timeout-minutes: ${{ inputs.backend-wallet-class == 'SparkL2Wallet' && 150 || 30 }}
+    env:
+      CASHU_REGTEST_DIR: ${{ github.workspace }}/regtest
     steps:
       - name: Start PostgreSQL service
         if: contains(inputs.mint-database, 'postgres')
@@ -41,13 +44,13 @@ jobs:
           poetry-version: ${{ inputs.poetry-version }}
 
       - name: Setup Regtest
-        run: |
-          git clone https://github.com/callebtc/cashu-regtest-enviroment.git regtest
-          cd regtest
-          chmod -R 777 .
-          bash ./start.sh
+        timeout-minutes: ${{ inputs.backend-wallet-class == 'SparkL2Wallet' && 90 || 20 }}
+        uses: ./.github/actions/setup-regtest
+        with:
+          backend-wallet-class: ${{ inputs.backend-wallet-class }}
 
       - name: Run Tests
+        timeout-minutes: ${{ inputs.backend-wallet-class == 'SparkL2Wallet' && 45 || 10 }}
         env:
           WALLET_NAME: test_wallet
           MINT_HOST: localhost
@@ -69,7 +72,20 @@ jobs:
           MINT_CLNREST_CERT: ./regtest/data/clightning-2/regtest/ca.pem
         run: |
           sudo chmod -R 777 .
-          make test-wallet
+          if [ "$MINT_BACKEND_BOLT11_SAT" = "SparkL2Wallet" ]; then
+            make test-spark-wallet
+          else
+            make test-wallet
+          fi
+
+      - name: Regtest failure diagnostics
+        if: failure()
+        working-directory: regtest
+        env:
+          COMPOSE_PROJECT_NAME: cashu
+        run: |
+          docker compose --profile "*" ps -a
+          docker compose --profile "*" logs --tail=100
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,6 +168,12 @@ it. If the checkout is elsewhere, run
 | `make test-spark-mint` | The existing `make test-mint` suite with `SparkL2Wallet`, including held payments that settle or fail and pending Cashu proofs. |
 | `make test-spark-wallet` | The existing `make test-wallet` suite with `SparkL2Wallet`, including recovery after an interrupted melt succeeds or fails. |
 
+GitHub CI runs the shared Spark mint and wallet suites with both SQLite and
+PostgreSQL. The Spark mint jobs also run the four direct backend cases. All
+regtest jobs use the revision pinned in `.github/actions/setup-regtest/action.yml`;
+Spark jobs start it with `--spark` and allow up to 90 minutes for setup and
+45 minutes for the shared suite.
+
 The shared suites start the real HTTP mint. An opt-in pytest fixture configures
 the installed Breez SDK to use local endpoints and generated operator
 certificates. The HTTP mint and in-process test ledger use separate temporary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,51 @@ MINT_CLNREST_CERT="../cashu-regtest-enviroment/data/clightning-2/regtest/ca.pem"
 
 ```
 
+### Spark backend regtest
+
+The Spark tests use the real Breez SDK installed by Poetry with the local Spark
+operators, SSP, Esplora, LND, and CLN from
+[cashu-regtest](https://github.com/callebtc/cashu-regtest). Set up the environment:
+
+```sh
+cd ~/cashu-regtest
+git switch main
+git pull --ff-only
+./start.sh --spark
+
+cd ~/nutshell
+make test-spark-regtest
+```
+
+The first Spark stack build can take 30–90 minutes and needs disk space for its
+Rust and Go builds. `start.sh` resets the regtest's existing containers, volumes,
+and Lightning data. The tests themselves use the running stack without restarting
+it. If the checkout is elsewhere, run
+`CASHU_REGTEST_DIR=/path/to/cashu-regtest make test-spark-regtest`.
+
+The four cases cover both `sat` and `msat` units against LND and CLN: invoice
+amounts and descriptions, msat rounding, incoming payment events, settlement,
+outgoing quotes and payments, matching preimages, fee and balance accounting,
+and status persistence after reconnecting. Each case generates a temporary seed
+and SDK storage directory and funds its wallet through a real Lightning payment.
+No Breez API key or configured mint mnemonic is needed.
+
+Only the SDK connection configuration is overridden to use the fixture's local
+endpoints and operator certificates; backend methods and SDK payment operations
+run normally. This suite tests the Lightning backend contract without starting
+the HTTP mint server. The tests leave their regtest payment history and wallet
+balances until the next stack reset.
+
+Normal test runs skip these cases. To invoke them directly:
+
+```sh
+CASHU_SPARK_REGTEST=true MINT_BACKEND_BOLT11_SAT=FakeWallet \
+  MINT_BACKEND_BOLT11_USD=FakeWallet TOR=FALSE \
+  poetry run pytest tests/lightning/test_spark_regtest.py -v
+```
+
+An explicitly enabled run fails if the local services are unavailable.
+
 ### Profiling
 
 If you'd like to profile your code (measure how long steps take to execute), run the mint using `DEBUG_PROFILING=TRUE`. Make sure to turn this off again, as your application will be significantly slower with profiling enabled.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,26 +160,58 @@ and Lightning data. The tests themselves use the running stack without restartin
 it. If the checkout is elsewhere, run
 `CASHU_REGTEST_DIR=/path/to/cashu-regtest make test-spark-regtest`.
 
-The four cases cover both `sat` and `msat` units against LND and CLN: invoice
-amounts and descriptions, msat rounding, incoming payment events, settlement,
-outgoing quotes and payments, matching preimages, fee and balance accounting,
-and status persistence after reconnecting. Each case generates a temporary seed
-and SDK storage directory and funds its wallet through a real Lightning payment.
-No Breez API key or configured mint mnemonic is needed.
+`make test-spark-regtest` runs three commands sequentially:
 
-Only the SDK connection configuration is overridden to use the fixture's local
-endpoints and operator certificates; backend methods and SDK payment operations
-run normally. This suite tests the Lightning backend contract without starting
-the HTTP mint server. The tests leave their regtest payment history and wallet
-balances until the next stack reset.
+| Command | Coverage |
+| --- | --- |
+| `make test-spark-backend-regtest` | Four direct backend round trips: LND and CLN, in sat and msat, including events, preimages, fee/balance accounting, and reconnecting. |
+| `make test-spark-mint` | The existing `make test-mint` suite with `SparkL2Wallet`, including held payments that settle or fail and pending Cashu proofs. |
+| `make test-spark-wallet` | The existing `make test-wallet` suite with `SparkL2Wallet`, including recovery after an interrupted melt succeeds or fails. |
 
-Normal test runs skip these cases. To invoke them directly:
+The shared suites start the real HTTP mint. An opt-in pytest fixture configures
+the installed Breez SDK to use local endpoints and generated operator
+certificates. The HTTP mint and in-process test ledger use separate temporary
+seeds and caches; backend instances within each process share one SDK. The test
+ledger receives 10,000 regtest sats before the suite starts. Startup-recovery
+tests submit a real backend payment without recording its result in the mint,
+then reconcile its pending proofs using the persisted quote and payment history.
+No Breez API key or configured mint mnemonic is used. The fixture does not mock
+backend or SDK payment operations. Funding helpers wait until the receiving
+backend or HTTP mint can see the payment before continuing. The fixture records
+which process created each invoice so these checks query the correct wallet.
+USD retains the existing `FakeWallet` backend for mixed-unit tests.
+
+For direct pytest invocation of the shared suites, set:
 
 ```sh
-CASHU_SPARK_REGTEST=true MINT_BACKEND_BOLT11_SAT=FakeWallet \
+CASHU_SPARK_REGTEST=true MINT_BACKEND_BOLT11_SAT=SparkL2Wallet \
   MINT_BACKEND_BOLT11_USD=FakeWallet TOR=FALSE \
-  poetry run pytest tests/lightning/test_spark_regtest.py -v
+  poetry run pytest tests/mint/test_mint_regtest.py tests/wallet/test_wallet_regtest.py -v
 ```
+
+The direct backend cases use their own isolated wallets and remain skipped in
+normal runs. Spark reports an unpaid receive request as `UNKNOWN` until it
+appears in payment history; the shared tests check that distinction explicitly.
+MPP cases use the existing capability checks because Spark does not support MPP.
+The three tests tied to nonzero LND/CLN routing fees are skipped for Spark.
+This version of `open-ssp` requires `SSP_SWAP_FEE_SATS=0` and rejects nonzero
+fees because fee-bearing Swap V3 fills are unsupported. Nonzero Spark fee
+conversion remains covered by the mocked backend tests; live nonzero-fee parity
+requires upstream SSP support.
+
+The tests leave payment history and wallet balances until the next stack reset.
+Repeated runs can consume the SSP's initial 500,000-sat liquidity. Replenish it
+without resetting the running stack using the regtest repository's helper:
+
+```sh
+cd ~/cashu-regtest
+source ./docker-scripts.sh
+cashu-spark-fund-ssp
+```
+
+After many runs, SSP leaf splitting can also exhaust the operators' unused
+deposit-address quota, preventing this helper from creating a funding address.
+Reset the regtest stack before rerunning in that case.
 
 An explicitly enabled run fails if the local services are unavailable.
 

--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,32 @@ test-mint:
 	DEBUG=true \
 	poetry run pytest tests/mint --cov-report xml --cov cashu
 
-.PHONY: test-spark-regtest
+.PHONY: test-spark-regtest test-spark-backend-regtest test-spark-mint test-spark-wallet
 test-spark-regtest:
+	$(MAKE) test-spark-backend-regtest
+	$(MAKE) test-spark-mint
+	$(MAKE) test-spark-wallet
+
+test-spark-backend-regtest:
 	CASHU_SPARK_REGTEST=true \
 	MINT_BACKEND_BOLT11_SAT=FakeWallet \
 	MINT_BACKEND_BOLT11_USD=FakeWallet \
 	TOR=FALSE \
 	poetry run pytest tests/lightning/test_spark_regtest.py -v
+
+test-spark-mint:
+	CASHU_SPARK_REGTEST=true \
+	MINT_BACKEND_BOLT11_SAT=SparkL2Wallet \
+	MINT_BACKEND_BOLT11_USD=FakeWallet \
+	TOR=FALSE \
+	$(MAKE) test-mint
+
+test-spark-wallet:
+	CASHU_SPARK_REGTEST=true \
+	MINT_BACKEND_BOLT11_SAT=SparkL2Wallet \
+	MINT_BACKEND_BOLT11_USD=FakeWallet \
+	TOR=FALSE \
+	$(MAKE) test-wallet
 
 install:
 	make clean

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,14 @@ test-mint:
 	DEBUG=true \
 	poetry run pytest tests/mint --cov-report xml --cov cashu
 
+.PHONY: test-spark-regtest
+test-spark-regtest:
+	CASHU_SPARK_REGTEST=true \
+	MINT_BACKEND_BOLT11_SAT=FakeWallet \
+	MINT_BACKEND_BOLT11_USD=FakeWallet \
+	TOR=FALSE \
+	poetry run pytest tests/lightning/test_spark_regtest.py -v
+
 install:
 	make clean
 	python setup.py sdist bdist_wheel

--- a/cashu/lightning/sparkl2.py
+++ b/cashu/lightning/sparkl2.py
@@ -193,7 +193,7 @@ class SparkL2Wallet(LightningBackend):
         try:
             # The Spark SDK has prepare_send_payment -> send_payment flow.
             prepare_req = breez_sdk_spark.PrepareSendPaymentRequest(
-                payment_request=quote.request,
+                payment_request=breez_sdk_spark.PaymentRequest.INPUT(quote.request),
                 amount=None,  # Already in invoice
                 fee_policy=None,  # Can pass fee limits here if supported
             )
@@ -380,7 +380,11 @@ class SparkL2Wallet(LightningBackend):
 
         try:
             prepare_req = breez_sdk_spark.PrepareSendPaymentRequest(
-                payment_request=melt_quote.request, amount=None, fee_policy=None
+                payment_request=breez_sdk_spark.PaymentRequest.INPUT(
+                    melt_quote.request
+                ),
+                amount=None,
+                fee_policy=None,
             )
 
             prepare_res = await self.sdk.prepare_send_payment(prepare_req)

--- a/cashu/lightning/sparkl2.py
+++ b/cashu/lightning/sparkl2.py
@@ -260,6 +260,19 @@ class SparkL2Wallet(LightningBackend):
                 )
 
             checking_id = payment.id or checking_id
+            if (
+                payment.status == breez_sdk_spark.PaymentStatus.COMPLETED
+                and payment.details
+                and payment.details.is_lightning()
+                and not payment.details.htlc_details.preimage
+            ):
+                # The send response can precede the cached Lightning preimage.
+                # Refresh once before returning a still-pending melt to callers.
+                await self.sdk.sync_wallet(breez_sdk_spark.SyncWalletRequest())
+                refreshed = await self.sdk.get_payment(
+                    breez_sdk_spark.GetPaymentRequest(payment_id=checking_id)
+                )
+                payment = refreshed.payment
             fee_amount = None
             if payment.fees is not None:
                 if self.unit == Unit.msat:
@@ -274,7 +287,16 @@ class SparkL2Wallet(LightningBackend):
                     preimage = htlc.preimage
 
             if payment.status == breez_sdk_spark.PaymentStatus.COMPLETED:
-                result = PaymentResult.SETTLED
+                # The transfer can complete before the SDK caches the Lightning
+                # preimage. Keep the melt pending until its proof is available.
+                awaiting_preimage = (
+                    payment.details and payment.details.is_lightning() and not preimage
+                )
+                result = (
+                    PaymentResult.PENDING
+                    if awaiting_preimage
+                    else PaymentResult.SETTLED
+                )
             elif payment.status == breez_sdk_spark.PaymentStatus.FAILED:
                 result = PaymentResult.FAILED
             else:
@@ -285,6 +307,9 @@ class SparkL2Wallet(LightningBackend):
                 checking_id=checking_id,
                 fee=fee_amount,
                 preimage=preimage,
+                error_message=(
+                    "Spark payment failed" if result == PaymentResult.FAILED else None
+                ),
             )
         except Exception as e:
             return PaymentResponse(
@@ -337,15 +362,42 @@ class SparkL2Wallet(LightningBackend):
             raise Exception("SDK not initialized")
 
         try:
-            req = breez_sdk_spark.GetPaymentRequest(payment_id=checking_id)
-            res = await self.sdk.get_payment(req)
+            if len(checking_id) == 64:
+                # Quotes use the BOLT11 hash, while the SDK assigns a UUID to
+                # the send. Resolve the hash even before send_payment returns,
+                # including after reconnecting to the persisted SDK storage.
+                res = await self.sdk.list_payments(
+                    breez_sdk_spark.ListPaymentsRequest(
+                        type_filter=[breez_sdk_spark.PaymentType.SEND],
+                        asset_filter=breez_sdk_spark.AssetFilter.BITCOIN(),
+                        payment_details_filter=[
+                            breez_sdk_spark.PaymentDetailsFilter.LIGHTNING(None)
+                        ],
+                        sort_ascending=False,
+                    )
+                )
+                payment = next(
+                    (
+                        p
+                        for p in res.payments
+                        if p.details
+                        and p.details.is_lightning()
+                        and p.details.htlc_details
+                        and p.details.htlc_details.payment_hash == checking_id
+                    ),
+                    None,
+                )
+            else:
+                res = await self.sdk.get_payment(
+                    breez_sdk_spark.GetPaymentRequest(payment_id=checking_id)
+                )
+                payment = res.payment if res else None
 
-            if not res or not res.payment:
+            if not payment:
                 return PaymentStatus(
                     result=PaymentResult.UNKNOWN, error_message="Payment not found"
                 )
 
-            payment = res.payment
             fee_sats = payment.fees
             fee_amount = None
             if fee_sats is not None:
@@ -360,8 +412,17 @@ class SparkL2Wallet(LightningBackend):
                     preimage = htlc.preimage
 
             if payment.status == breez_sdk_spark.PaymentStatus.COMPLETED:
+                awaiting_preimage = (
+                    payment.details and payment.details.is_lightning() and not preimage
+                )
                 return PaymentStatus(
-                    result=PaymentResult.SETTLED, preimage=preimage, fee=fee_amount
+                    result=(
+                        PaymentResult.PENDING
+                        if awaiting_preimage
+                        else PaymentResult.SETTLED
+                    ),
+                    preimage=preimage,
+                    fee=fee_amount,
                 )
             elif payment.status == breez_sdk_spark.PaymentStatus.FAILED:
                 return PaymentStatus(result=PaymentResult.FAILED)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,12 @@ from cashu.mint import migrations as migrations_mint
 from cashu.mint.crud import LedgerCrudSqlite
 from cashu.mint.ledger import Ledger
 
+pytest_plugins = (
+    ["tests.spark_regtest"]
+    if os.getenv("CASHU_SPARK_REGTEST", "").lower() == "true"
+    else []
+)
+
 SERVER_PORT = 3337
 SERVER_ENDPOINT = f"http://localhost:{SERVER_PORT}"
 
@@ -132,7 +138,9 @@ async def ledger():
 
 # # This fixture is used for tests that require API access to the mint
 @pytest.fixture(autouse=True, scope="session")
-def mint():
+def mint(request):
+    if "tests.spark_regtest" in pytest_plugins:
+        request.getfixturevalue("spark_regtest_config")
     config = uvicorn.Config(
         "cashu.mint.app:app",
         port=settings.mint_listen_port,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -264,6 +264,24 @@ def get_real_invoice_routed(sats: int) -> str:
     return run_cmd_json(cmd)["payment_request"]
 
 
+def get_real_invoice_fee_leaf(sats: int) -> str:
+    """Invoice from isolated lnd-4, reachable only through the fee hub."""
+    cmd = [
+        "docker",
+        "exec",
+        "cashu-lnd-4-1",
+        "lncli",
+        "--network=regtest",
+        "--rpcserver=lnd-4:10009",
+    ]
+    destination = run_cmd_json([*cmd, "getinfo"])["identity_pubkey"]
+    _wait_for_route(
+        [*docker_lightning_mint_cli, "queryroutes", "--dest", destination, "--amt", str(sats)],
+        "routes",
+    )
+    return run_cmd_json([*cmd, "addinvoice", str(sats)])["payment_request"]
+
+
 async def pay_if_regtest(bolt11: str) -> None:
     if is_spark_backend and os.getenv("CASHU_SPARK_REGTEST", "").lower() == "true":
         from tests.spark_regtest import pay_regtest_invoice

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,6 +9,7 @@ import time
 from subprocess import PIPE, Popen, TimeoutExpired
 from typing import List, Tuple, Union
 
+import bolt11
 from loguru import logger
 
 from cashu.core.base import Unit
@@ -66,6 +67,7 @@ wallet_class = getattr(wallets_module, settings.mint_backend_bolt11_sat)
 WALLET = wallet_class(unit=Unit.sat)
 is_fake: bool = WALLET.__class__.__name__ == "FakeWallet"
 is_regtest: bool = not is_fake
+is_spark_backend: bool = WALLET.__class__.__name__ == "SparkL2Wallet"
 is_cln_backend: bool = WALLET.__class__.__name__ in [
     "CLNRestWallet",
     "CoreLightningRestWallet",
@@ -73,6 +75,19 @@ is_cln_backend: bool = WALLET.__class__.__name__ in [
 is_github_actions = os.getenv("GITHUB_ACTIONS") == "true"
 is_postgres = settings.mint_database.startswith("postgres")
 SLEEP_TIME = 1 if not is_github_actions else 2
+
+
+async def wait_for_result(check, predicate, timeout=30):
+    """Wait for a real backend's asynchronous state change, with a deadline."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    result = None
+    while (remaining := deadline - asyncio.get_running_loop().time()) > 0:
+        result = await asyncio.wait_for(check(), remaining)
+        if predicate(result):
+            return result
+        await asyncio.sleep(min(0.1, remaining))
+    raise AssertionError(f"Timed out waiting for backend state: {result}")
+
 
 docker_lightning_cli = [
     "docker",
@@ -158,6 +173,16 @@ def get_hold_invoice(sats: int) -> Tuple[str, dict]:
     return preimage.hex(), json
 
 
+async def wait_for_hold_invoice(invoice: str) -> None:
+    """Do not settle/cancel until LND has accepted the outgoing HTLC."""
+    payment_hash = bolt11.decode(invoice).payment_hash
+    cmd = [*docker_lightning_cli, "lookupinvoice", payment_hash]
+    await wait_for_result(
+        lambda: asyncio.to_thread(run_cmd_json, cmd),
+        lambda invoice: invoice["state"] == "ACCEPTED",
+    )
+
+
 def settle_invoice(preimage: str) -> str:
     cmd = docker_lightning_cli.copy()
     cmd.extend(["settleinvoice", preimage])
@@ -240,6 +265,11 @@ def get_real_invoice_routed(sats: int) -> str:
 
 
 async def pay_if_regtest(bolt11: str) -> None:
+    if is_spark_backend and os.getenv("CASHU_SPARK_REGTEST", "").lower() == "true":
+        from tests.spark_regtest import pay_regtest_invoice
+
+        await pay_regtest_invoice(bolt11)
+        return
     if is_regtest:
         pay_real_invoice(bolt11)
     if is_fake:

--- a/tests/lightning/test_lightning_backends_mocked.py
+++ b/tests/lightning/test_lightning_backends_mocked.py
@@ -744,6 +744,113 @@ async def test_spark_wraps_invoice_in_sdk_payment_request(operation):
     sdk.send_payment.assert_not_awaited()
 
 
+def _spark_lightning_payment(status, preimage=None, payment_hash="a" * 64):
+    import breez_sdk_spark as breez
+
+    return breez.Payment(
+        id="sdk-payment-uuid",
+        payment_type=breez.PaymentType.SEND,
+        status=status,
+        amount=64,
+        fees=7,
+        timestamp=1,
+        method=breez.PaymentMethod.LIGHTNING,
+        conversion_details=None,
+        details=breez.PaymentDetails.LIGHTNING(
+            description=None,
+            invoice="lnbcrt1test",
+            destination_pubkey="",
+            htlc_details=breez.SparkHtlcDetails(
+                payment_hash=payment_hash,
+                preimage=preimage,
+                expiry_time=0,
+                status=(
+                    breez.SparkHtlcStatus.PREIMAGE_SHARED
+                    if preimage
+                    else breez.SparkHtlcStatus.WAITING_FOR_PREIMAGE
+                ),
+            ),
+            lnurl_pay_info=None,
+            lnurl_withdraw_info=None,
+            lnurl_receive_metadata=None,
+            conversion_info=None,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["pay", "status"])
+async def test_spark_completed_transfer_waits_for_lightning_preimage(operation):
+    import breez_sdk_spark as breez
+
+    from cashu.lightning.sparkl2 import SparkL2Wallet
+
+    wallet = SparkL2Wallet(Unit.sat)
+    sdk = AsyncMock()
+    wallet.sdk = sdk
+    payment = _spark_lightning_payment(breez.PaymentStatus.COMPLETED)
+    sdk.send_payment.return_value = SimpleNamespace(payment=payment)
+    sdk.get_payment.return_value = SimpleNamespace(payment=payment)
+    sdk.prepare_send_payment.return_value = SimpleNamespace(
+        payment_method=SimpleNamespace(
+            is_bolt11_invoice=lambda: True,
+            lightning_fee_sats=7,
+            spark_transfer_fee_sats=0,
+        )
+    )
+
+    if operation == "pay":
+        result = await wallet.pay_invoice(_quote("lnbcrt1test"), 7000)
+        assert result.checking_id == payment.id
+    else:
+        result = await wallet.get_payment_status(payment.id)
+    assert result.pending
+    assert result.preimage is None
+
+    payment.details.htlc_details.preimage = "b" * 64
+    settled = await wallet.get_payment_status(payment.id)
+    assert settled.settled
+    assert settled.preimage == "b" * 64
+    assert settled.fee == Amount(Unit.sat, 7)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["PENDING", "FAILED", "COMPLETED"])
+async def test_spark_checks_payment_by_quote_hash_after_reconnecting(state):
+    import breez_sdk_spark as breez
+
+    from cashu.lightning.sparkl2 import SparkL2Wallet
+
+    # A new backend instance has no in-memory mapping from BOLT11 hash to UUID.
+    wallet = SparkL2Wallet(Unit.sat)
+    sdk = AsyncMock()
+    wallet.sdk = sdk
+    preimage = "b" * 64 if state == "COMPLETED" else None
+    payment = _spark_lightning_payment(
+        getattr(breez.PaymentStatus, state), preimage=preimage
+    )
+    unrelated = _spark_lightning_payment(
+        breez.PaymentStatus.COMPLETED, preimage="c" * 64, payment_hash="d" * 64
+    )
+    sdk.list_payments.return_value = SimpleNamespace(payments=[unrelated, payment])
+
+    status = await wallet.get_payment_status("a" * 64)
+
+    assert (
+        status.result
+        == {
+            "PENDING": PaymentResult.PENDING,
+            "FAILED": PaymentResult.FAILED,
+            "COMPLETED": PaymentResult.SETTLED,
+        }[state]
+    )
+    assert status.preimage == preimage
+    request = sdk.list_payments.call_args.args[0]
+    assert request.type_filter == [breez.PaymentType.SEND]
+    assert request.sort_ascending is False
+    sdk.get_payment.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_spark_pay_invoice_rejects_non_bolt11():
     from cashu.lightning.sparkl2 import SparkL2Wallet

--- a/tests/lightning/test_lightning_backends_mocked.py
+++ b/tests/lightning/test_lightning_backends_mocked.py
@@ -2,6 +2,7 @@ import base64
 import json
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
@@ -669,6 +670,78 @@ async def test_lndrest_get_payment_quote_uses_mpp_amount(monkeypatch):
     quote = await wallet.get_payment_quote(request)
     assert quote.amount == Amount(Unit.sat, 2)
     assert quote.fee == Amount(Unit.sat, fee_reserve(1500) // 1000)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["pay", "status"])
+@pytest.mark.parametrize("unit", [Unit.sat, Unit.msat])
+async def test_spark_returns_payment_fees_in_wallet_unit(operation, unit):
+    import breez_sdk_spark as breez
+
+    from cashu.lightning.sparkl2 import SparkL2Wallet
+
+    wallet = SparkL2Wallet(unit=unit)
+    sdk = AsyncMock()
+    wallet.sdk = sdk
+    # UniFFI decodes u128 values to Python integers despite the str annotation.
+    payment = breez.Payment(
+        id="payment-id",
+        payment_type=breez.PaymentType.SEND,
+        status=breez.PaymentStatus.COMPLETED,
+        amount=1,
+        fees=7,
+        timestamp=0,
+        method=breez.PaymentMethod.LIGHTNING,
+        details=None,
+        conversion_details=None,
+    )
+    sdk.get_payment.return_value = SimpleNamespace(payment=payment)
+    sdk.send_payment.return_value = SimpleNamespace(payment=payment)
+    sdk.prepare_send_payment.return_value = SimpleNamespace(
+        payment_method=SimpleNamespace(
+            is_bolt11_invoice=lambda: True,
+            lightning_fee_sats=7,
+            spark_transfer_fee_sats=0,
+        )
+    )
+
+    if operation == "pay":
+        result = await wallet.pay_invoice(_quote("lnbcrt1test"), fee_limit_msat=7000)
+    else:
+        result = await wallet.get_payment_status(payment.id)
+
+    assert result.settled
+    assert result.fee == Amount(Unit.sat, 7).to(unit)
+    assert isinstance(result.fee.amount, int)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["quote", "pay"])
+async def test_spark_wraps_invoice_in_sdk_payment_request(operation):
+    from breez_sdk_spark import PaymentRequest
+
+    from cashu.lightning.sparkl2 import SparkL2Wallet
+
+    wallet = SparkL2Wallet(unit=Unit.sat)
+    sdk = AsyncMock()
+    sdk.prepare_send_payment.side_effect = RuntimeError("stop after preparation")
+    wallet.sdk = sdk
+    invoice = "lnbcrt1test"
+
+    if operation == "pay":
+        result = await wallet.pay_invoice(_quote(invoice), fee_limit_msat=1000)
+        assert result.failed
+    else:
+        with pytest.raises(Exception, match="stop after preparation"):
+            await wallet.get_payment_quote(
+                PostMeltQuoteRequest(unit="sat", request=invoice)
+            )
+
+    sdk.prepare_send_payment.assert_awaited_once()
+    request = sdk.prepare_send_payment.call_args.args[0]
+    assert isinstance(request.payment_request, PaymentRequest.INPUT)
+    assert request.payment_request.input == invoice
+    sdk.send_payment.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/lightning/test_spark_regtest.py
+++ b/tests/lightning/test_spark_regtest.py
@@ -7,16 +7,12 @@ and event delivery use the installed Breez SDK and the local network.
 
 import asyncio
 import copy
-import hashlib
-import json
 import os
 from contextlib import suppress
-from pathlib import Path
 from uuid import uuid4
 
 import bolt11
 import breez_sdk_spark as breez
-import httpx
 import pytest
 import pytest_asyncio
 from mnemonic import Mnemonic
@@ -26,6 +22,16 @@ from cashu.core.models import PostMeltQuoteRequest
 from cashu.core.settings import settings
 from cashu.lightning.base import PaymentResult
 from cashu.lightning.sparkl2 import SparkL2Wallet
+from tests.spark import (
+    TIMEOUT,
+    assert_preimage,
+    connect_spark,
+    lightning,
+    local_spark_config,
+    wait_balance,
+    wait_invoice,
+    wait_payment,
+)
 
 pytestmark = [
     pytest.mark.asyncio,
@@ -35,181 +41,22 @@ pytestmark = [
     ),
 ]
 
-TIMEOUT = 120
-SSP_URL = "http://127.0.0.1:5000"
-ESPLORA_URL = "http://127.0.0.1:30000"
-
 
 @pytest.fixture(scope="session", autouse=True)
 def mint():
     """These backend tests do not need the parent conftest's HTTP mint server."""
 
 
-async def compose(service, *args):
-    regtest_dir = Path(
-        os.getenv("CASHU_REGTEST_DIR", str(Path.home() / "cashu-regtest"))
-    ).expanduser()
-    compose_file = regtest_dir / "docker-compose.yml"
-    assert compose_file.is_file(), f"cashu-regtest not found at {regtest_dir}"
-    process = await asyncio.create_subprocess_exec(
-        "docker",
-        "compose",
-        "--profile",
-        "spark",
-        "-p",
-        "cashu",
-        "-f",
-        str(compose_file),
-        "exec",
-        "-T",
-        service,
-        *args,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    try:
-        stdout, stderr = await asyncio.wait_for(process.communicate(), TIMEOUT)
-    except BaseException:
-        if process.returncode is None:
-            process.kill()
-        await process.communicate()
-        raise
-    assert process.returncode == 0, (
-        f"{service} {args[0]} failed: {stderr.decode()}. "
-        "Start cashu-regtest with ./start.sh --spark first."
-    )
-    return stdout.decode().strip()
-
-
-async def lightning(peer, *args):
-    if peer == "lnd":
-        output = await compose(
-            "lnd-1", "lncli", "--network=regtest", "--rpcserver=lnd-1:10009", *args
-        )
-    else:
-        output = await compose(
-            "clightning-1", "lightning-cli", "--network=regtest", "-N", "none", *args
-        )
-    return json.loads(output)
-
-
-async def wait_for(label, check):
-    """Bound both individual RPCs and the total wait for eventual settlement."""
-    deadline = asyncio.get_running_loop().time() + TIMEOUT
-    last = None
-    while (remaining := deadline - asyncio.get_running_loop().time()) > 0:
-        last = await asyncio.wait_for(check(), remaining)
-        if last:
-            return last
-        await asyncio.sleep(min(1, remaining))
-    pytest.fail(f"Timed out waiting for {label}: {last}")
-
-
-async def wait_balance(wallet, sats):
-    expected = Amount(Unit.sat, sats).to(wallet.unit)
-
-    async def check():
-        status = await wallet.status()
-        assert not status.error_message, status.error_message
-        return status.balance == expected
-
-    await wait_for(f"Spark balance {expected}", check)
-
-
-async def wait_invoice(wallet, checking_id):
-    async def check():
-        status = await wallet.get_invoice_status(checking_id)
-        assert not status.failed, status.error_message
-        return status if status.settled else None
-
-    return await wait_for(f"incoming payment {checking_id}", check)
-
-
-async def wait_payment(wallet, checking_id):
-    async def check():
-        status = await wallet.get_payment_status(checking_id)
-        assert not status.failed, status.error_message
-        # The SDK can report completion before its cached preimage is updated.
-        return status if status.settled and status.preimage else None
-
-    return await wait_for(f"outgoing payment {checking_id}", check)
-
-
-def assert_preimage(preimage, payment_hash):
-    assert preimage
-    assert hashlib.sha256(bytes.fromhex(preimage)).hexdigest() == payment_hash
-
-
 @pytest_asyncio.fixture
 async def spark_wallet_factory(monkeypatch, tmp_path):
-    # Discover fixture identities and trust the generated operator certificates.
-    # Do not use the default config's public SSP or sync service on regtest.
-    try:
-        async with httpx.AsyncClient(timeout=10, trust_env=False) as client:
-            response = await client.get(f"{SSP_URL}/identity")
-            response.raise_for_status()
-            identity = response.json()["identityPublicKey"]
-            response = await client.get(f"{ESPLORA_URL}/blocks/tip/height")
-            response.raise_for_status()
-            assert int(response.text) > 0
-    except httpx.HTTPError as exc:
-        pytest.fail(
-            "Spark regtest services are unavailable. Run ./start.sh --spark in "
-            f"cashu-regtest first. {exc}",
-            pytrace=False,
-        )
-
-    regtest_dir = Path(
-        os.getenv("CASHU_REGTEST_DIR", str(Path.home() / "cashu-regtest"))
-    ).expanduser()
-    operators = json.loads((regtest_dir / "spark/operators.json").read_text())
-    config = breez.default_config(breez.Network.REGTEST)
-    config.api_key = None
-    config.lnurl_domain = None
-    config.real_time_sync_server_url = None
-    config.use_default_external_input_parsers = False
-    config.prefer_spark_over_lightning = False
-    config.sync_interval_secs = 2
-    config.leaf_optimization_config.auto_enabled = False
-    config.token_optimization_config.auto_enabled = False
-    assert config.spark_config is not None
-    config.spark_config.coordinator_identifier = f"{1:064x}"
-    config.spark_config.threshold = 2
-    config.spark_config.signing_operators = [
-        breez.SparkSigningOperator(
-            id=operator["id"],
-            identifier=f"{operator['id'] + 1:064x}",
-            address=f"https://localhost:{8535 + operator['id']}",
-            identity_public_key=operator["identity_public_key"],
-            ca_cert_pem=await compose(
-                f"spark-operator-{operator['id']}", "cat", operator["cert_path"]
-            ),
-        )
-        for operator in operators
-    ]
-    config.spark_config.ssp_config = breez.SparkSspConfig(
-        base_url=SSP_URL,
-        identity_public_key=identity,
-        schema_endpoint="graphql/spark/rc",
-    )
+    config = await local_spark_config()
 
     def local_config(network):
         assert network == breez.Network.REGTEST
         return copy.deepcopy(config)
 
-    async def connect(request):
-        # UniFFI retains a global loop. Pytest creates a new one for each case,
-        # and these async builder methods run before build() resets that loop.
-        breez.uniffi_set_event_loop(asyncio.get_running_loop())
-        builder = breez.SdkBuilder(config=request.config, seed=request.seed)
-        await builder.with_default_storage(request.storage_dir)
-        await builder.with_rest_chain_service(
-            ESPLORA_URL, breez.ChainApiType.ESPLORA, None
-        )
-        return await builder.build()
-
     monkeypatch.setattr(breez, "default_config", local_config)
-    monkeypatch.setattr(breez, "connect", connect)
+    monkeypatch.setattr(breez, "connect", connect_spark)
     monkeypatch.setattr(settings, "mint_spark_network", "REGTEST")
     monkeypatch.setattr(settings, "mint_spark_api_key", None)
     monkeypatch.setattr(settings, "mint_spark_mnemonic", Mnemonic("english").generate())
@@ -348,3 +195,5 @@ async def test_spark_lightning_round_trip(spark_wallet_factory, unit, peer):
     restored = await wait_payment(reopened, payment.checking_id)
     assert restored.preimage == settled.preimage
     assert restored.fee == settled.fee
+    restored_by_hash = await wait_payment(reopened, payment_quote.checking_id)
+    assert restored_by_hash == restored

--- a/tests/lightning/test_spark_regtest.py
+++ b/tests/lightning/test_spark_regtest.py
@@ -1,0 +1,350 @@
+"""Real Spark payments against ``cashu-regtest/start.sh --spark``.
+
+Run with CASHU_SPARK_REGTEST=true; see CONTRIBUTING.md for setup.
+Only SDK connection configuration is replaced. Payments, storage, polling,
+and event delivery use the installed Breez SDK and the local network.
+"""
+
+import asyncio
+import copy
+import hashlib
+import json
+import os
+from contextlib import suppress
+from pathlib import Path
+from uuid import uuid4
+
+import bolt11
+import breez_sdk_spark as breez
+import httpx
+import pytest
+import pytest_asyncio
+from mnemonic import Mnemonic
+
+from cashu.core.base import Amount, MeltQuote, MeltQuoteState, Unit
+from cashu.core.models import PostMeltQuoteRequest
+from cashu.core.settings import settings
+from cashu.lightning.base import PaymentResult
+from cashu.lightning.sparkl2 import SparkL2Wallet
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.skipif(
+        os.getenv("CASHU_SPARK_REGTEST", "").lower() != "true",
+        reason="requires CASHU_SPARK_REGTEST=true and cashu-regtest/start.sh --spark",
+    ),
+]
+
+TIMEOUT = 120
+SSP_URL = "http://127.0.0.1:5000"
+ESPLORA_URL = "http://127.0.0.1:30000"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mint():
+    """These backend tests do not need the parent conftest's HTTP mint server."""
+
+
+async def compose(service, *args):
+    regtest_dir = Path(
+        os.getenv("CASHU_REGTEST_DIR", str(Path.home() / "cashu-regtest"))
+    ).expanduser()
+    compose_file = regtest_dir / "docker-compose.yml"
+    assert compose_file.is_file(), f"cashu-regtest not found at {regtest_dir}"
+    process = await asyncio.create_subprocess_exec(
+        "docker",
+        "compose",
+        "--profile",
+        "spark",
+        "-p",
+        "cashu",
+        "-f",
+        str(compose_file),
+        "exec",
+        "-T",
+        service,
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), TIMEOUT)
+    except BaseException:
+        if process.returncode is None:
+            process.kill()
+        await process.communicate()
+        raise
+    assert process.returncode == 0, (
+        f"{service} {args[0]} failed: {stderr.decode()}. "
+        "Start cashu-regtest with ./start.sh --spark first."
+    )
+    return stdout.decode().strip()
+
+
+async def lightning(peer, *args):
+    if peer == "lnd":
+        output = await compose(
+            "lnd-1", "lncli", "--network=regtest", "--rpcserver=lnd-1:10009", *args
+        )
+    else:
+        output = await compose(
+            "clightning-1", "lightning-cli", "--network=regtest", "-N", "none", *args
+        )
+    return json.loads(output)
+
+
+async def wait_for(label, check):
+    """Bound both individual RPCs and the total wait for eventual settlement."""
+    deadline = asyncio.get_running_loop().time() + TIMEOUT
+    last = None
+    while (remaining := deadline - asyncio.get_running_loop().time()) > 0:
+        last = await asyncio.wait_for(check(), remaining)
+        if last:
+            return last
+        await asyncio.sleep(min(1, remaining))
+    pytest.fail(f"Timed out waiting for {label}: {last}")
+
+
+async def wait_balance(wallet, sats):
+    expected = Amount(Unit.sat, sats).to(wallet.unit)
+
+    async def check():
+        status = await wallet.status()
+        assert not status.error_message, status.error_message
+        return status.balance == expected
+
+    await wait_for(f"Spark balance {expected}", check)
+
+
+async def wait_invoice(wallet, checking_id):
+    async def check():
+        status = await wallet.get_invoice_status(checking_id)
+        assert not status.failed, status.error_message
+        return status if status.settled else None
+
+    return await wait_for(f"incoming payment {checking_id}", check)
+
+
+async def wait_payment(wallet, checking_id):
+    async def check():
+        status = await wallet.get_payment_status(checking_id)
+        assert not status.failed, status.error_message
+        # The SDK can report completion before its cached preimage is updated.
+        return status if status.settled and status.preimage else None
+
+    return await wait_for(f"outgoing payment {checking_id}", check)
+
+
+def assert_preimage(preimage, payment_hash):
+    assert preimage
+    assert hashlib.sha256(bytes.fromhex(preimage)).hexdigest() == payment_hash
+
+
+@pytest_asyncio.fixture
+async def spark_wallet_factory(monkeypatch, tmp_path):
+    # Discover fixture identities and trust the generated operator certificates.
+    # Do not use the default config's public SSP or sync service on regtest.
+    try:
+        async with httpx.AsyncClient(timeout=10, trust_env=False) as client:
+            response = await client.get(f"{SSP_URL}/identity")
+            response.raise_for_status()
+            identity = response.json()["identityPublicKey"]
+            response = await client.get(f"{ESPLORA_URL}/blocks/tip/height")
+            response.raise_for_status()
+            assert int(response.text) > 0
+    except httpx.HTTPError as exc:
+        pytest.fail(
+            "Spark regtest services are unavailable. Run ./start.sh --spark in "
+            f"cashu-regtest first. {exc}",
+            pytrace=False,
+        )
+
+    regtest_dir = Path(
+        os.getenv("CASHU_REGTEST_DIR", str(Path.home() / "cashu-regtest"))
+    ).expanduser()
+    operators = json.loads((regtest_dir / "spark/operators.json").read_text())
+    config = breez.default_config(breez.Network.REGTEST)
+    config.api_key = None
+    config.lnurl_domain = None
+    config.real_time_sync_server_url = None
+    config.use_default_external_input_parsers = False
+    config.prefer_spark_over_lightning = False
+    config.sync_interval_secs = 2
+    config.leaf_optimization_config.auto_enabled = False
+    config.token_optimization_config.auto_enabled = False
+    assert config.spark_config is not None
+    config.spark_config.coordinator_identifier = f"{1:064x}"
+    config.spark_config.threshold = 2
+    config.spark_config.signing_operators = [
+        breez.SparkSigningOperator(
+            id=operator["id"],
+            identifier=f"{operator['id'] + 1:064x}",
+            address=f"https://localhost:{8535 + operator['id']}",
+            identity_public_key=operator["identity_public_key"],
+            ca_cert_pem=await compose(
+                f"spark-operator-{operator['id']}", "cat", operator["cert_path"]
+            ),
+        )
+        for operator in operators
+    ]
+    config.spark_config.ssp_config = breez.SparkSspConfig(
+        base_url=SSP_URL,
+        identity_public_key=identity,
+        schema_endpoint="graphql/spark/rc",
+    )
+
+    def local_config(network):
+        assert network == breez.Network.REGTEST
+        return copy.deepcopy(config)
+
+    async def connect(request):
+        # UniFFI retains a global loop. Pytest creates a new one for each case,
+        # and these async builder methods run before build() resets that loop.
+        breez.uniffi_set_event_loop(asyncio.get_running_loop())
+        builder = breez.SdkBuilder(config=request.config, seed=request.seed)
+        await builder.with_default_storage(request.storage_dir)
+        await builder.with_rest_chain_service(
+            ESPLORA_URL, breez.ChainApiType.ESPLORA, None
+        )
+        return await builder.build()
+
+    monkeypatch.setattr(breez, "default_config", local_config)
+    monkeypatch.setattr(breez, "connect", connect)
+    monkeypatch.setattr(settings, "mint_spark_network", "REGTEST")
+    monkeypatch.setattr(settings, "mint_spark_api_key", None)
+    monkeypatch.setattr(settings, "mint_spark_mnemonic", Mnemonic("english").generate())
+    monkeypatch.setattr(settings, "cashu_dir", str(tmp_path))
+    wallets = []
+
+    async def create(unit):
+        wallet = SparkL2Wallet(unit=unit)
+        wallets.append(wallet)
+        status = await asyncio.wait_for(wallet.status(), TIMEOUT)
+        assert not status.error_message, status.error_message
+        assert wallet.sdk is not None
+        return wallet
+
+    yield create
+
+    for wallet in wallets:
+        if wallet.sdk is not None:
+            await asyncio.wait_for(wallet.sdk.disconnect(), TIMEOUT)
+            wallet.sdk = None
+
+
+@pytest.mark.parametrize("unit", [Unit.sat, Unit.msat], ids=lambda unit: unit.name)
+@pytest.mark.parametrize("peer", ["lnd", "cln"])
+async def test_spark_lightning_round_trip(spark_wallet_factory, unit, peer):
+    wallet = await spark_wallet_factory(unit)
+    await wait_balance(wallet, 0)
+    missing = await wallet.get_payment_status(str(uuid4()))
+    assert missing.result == PaymentResult.UNKNOWN
+
+    # Receive through Nutshell, including msat -> sat rounding and the listener.
+    # This also funds the isolated wallet for the outgoing half of the test.
+    receive_sats = 20_001
+    requested = Amount(unit, receive_sats if unit == Unit.sat else 20_000_001)
+    memo = f"nutshell-spark-{uuid4()}"
+    invoice = await wallet.create_invoice(requested, memo=memo)
+    assert invoice.ok, invoice.error_message
+    assert invoice.payment_request
+    assert invoice.checking_id
+    decoded = bolt11.decode(invoice.payment_request)
+    assert decoded.currency == "bcrt"
+    assert decoded.amount_msat == receive_sats * 1000
+    assert decoded.description == memo
+    assert decoded.payment_hash == invoice.checking_id
+    unpaid = await wallet.get_invoice_status(invoice.checking_id)
+    assert unpaid.result in (PaymentResult.UNKNOWN, PaymentResult.PENDING)
+
+    stream = wallet.paid_invoices_stream()
+    event = asyncio.create_task(stream.__anext__())
+    try:
+        if peer == "lnd":
+            received = await lightning(
+                peer,
+                "payinvoice",
+                "--force",
+                "--json",
+                "--fee_limit=100",
+                invoice.payment_request,
+            )
+            assert received["status"] == "SUCCEEDED", received
+        else:
+            received = await lightning(peer, "pay", invoice.payment_request)
+            assert received["status"] == "complete", received
+        assert received["payment_hash"] == invoice.checking_id
+        assert_preimage(received["payment_preimage"], invoice.checking_id)
+        assert await asyncio.wait_for(event, TIMEOUT) == invoice.checking_id
+    finally:
+        event.cancel()
+        with suppress(asyncio.CancelledError):
+            await event
+        await stream.aclose()
+    await wait_invoice(wallet, invoice.checking_id)
+    await wait_balance(wallet, receive_sats)
+
+    # Send to the same Lightning peer, verifying quote units and actual fees.
+    send_sats = 3000
+    if peer == "lnd":
+        outgoing = await lightning(peer, "addinvoice", str(send_sats))
+        request = outgoing["payment_request"]
+    else:
+        outgoing = await lightning(peer, "invoice", str(send_sats * 1000), memo, memo)
+        request = outgoing["bolt11"]
+    payment_hash = bolt11.decode(request).payment_hash
+    payment_quote = await wallet.get_payment_quote(
+        PostMeltQuoteRequest(request=request, unit=unit.name)
+    )
+    assert payment_quote.checking_id == payment_hash
+    assert payment_quote.amount == Amount(Unit.sat, send_sats).to(unit)
+    assert payment_quote.fee.unit == unit
+    assert payment_quote.fee.amount >= 0
+    quote = MeltQuote(
+        quote=str(uuid4()),
+        method="bolt11",
+        unit=unit.name,
+        state=MeltQuoteState.unpaid,
+        request=request,
+        checking_id=payment_quote.checking_id,
+        amount=payment_quote.amount.amount,
+        fee_reserve=payment_quote.fee.amount,
+    )
+    fee_limit_msat = payment_quote.fee.to(Unit.msat).amount
+    payment = await asyncio.wait_for(wallet.pay_invoice(quote, fee_limit_msat), TIMEOUT)
+    assert payment.result in (PaymentResult.SETTLED, PaymentResult.PENDING), payment
+    assert payment.checking_id
+    settled = await wait_payment(wallet, payment.checking_id)
+    assert_preimage(settled.preimage, payment_hash)
+    assert settled.fee is not None
+    assert settled.fee.unit == unit
+    assert 0 <= settled.fee.to(Unit.msat).amount <= fee_limit_msat
+    if payment.settled:
+        if payment.preimage is not None:
+            assert payment.preimage == settled.preimage
+        assert payment.fee == settled.fee
+
+    if peer == "lnd":
+        peer_invoice = await lightning(peer, "lookupinvoice", payment_hash)
+        assert peer_invoice["state"] == "SETTLED"
+        assert int(peer_invoice["amt_paid_sat"]) == send_sats
+        assert peer_invoice["r_preimage"] == settled.preimage
+    else:
+        peer_invoice = (await lightning(peer, "listinvoices", memo))["invoices"][0]
+        assert peer_invoice["status"] == "paid"
+        assert peer_invoice["amount_received_msat"] == send_sats * 1000
+        assert peer_invoice["payment_preimage"] == settled.preimage
+
+    remaining_sats = receive_sats - send_sats - settled.fee.to(Unit.sat).amount
+    await wait_balance(wallet, remaining_sats)
+
+    # Reopen the same seed/storage to verify persisted backend status and fees.
+    assert wallet.sdk is not None
+    await wallet.sdk.disconnect()
+    wallet.sdk = None
+    reopened = await spark_wallet_factory(unit)
+    await wait_balance(reopened, remaining_sats)
+    await wait_invoice(reopened, invoice.checking_id)
+    restored = await wait_payment(reopened, payment.checking_id)
+    assert restored.preimage == settled.preimage
+    assert restored.fee == settled.fee

--- a/tests/mint/test_mint_api.py
+++ b/tests/mint/test_mint_api.py
@@ -25,6 +25,7 @@ from tests.helpers import (
     is_cln_backend,
     is_fake,
     is_regtest,
+    is_spark_backend,
     pay_if_regtest,
 )
 
@@ -380,8 +381,8 @@ async def test_melt_quote_external(ledger: Ledger, wallet: Wallet):
     result = response.json()
     assert result["quote"]
     assert result["amount"] == 64
-    # external invoice, fee should be 2
-    assert result["fee_reserve"] == 2
+    # Spark uses the local SSP's exact (zero) swap fee.
+    assert result["fee_reserve"] == (0 if is_spark_backend else 2)
 
 
 @pytest.mark.asyncio
@@ -451,7 +452,7 @@ async def test_melt_external(ledger: Ledger, wallet: Wallet):
 
     quote = await wallet.melt_quote(invoice_payment_request)
     assert quote.amount == 62
-    assert quote.fee_reserve == 2
+    assert quote.fee_reserve == (0 if is_spark_backend else 2)
 
     keep, send = await wallet.swap_to_send(wallet.proofs, 64)
     inputs_payload = [p.to_dict() for p in send]
@@ -495,6 +496,10 @@ async def test_melt_external(ledger: Ledger, wallet: Wallet):
 @pytest.mark.skipif(
     is_fake,
     reason="only works on regtest",
+)
+@pytest.mark.skipif(
+    is_spark_backend,
+    reason="cashu-regtest open-ssp does not support nonzero swap fees",
 )
 async def test_melt_external_with_routing_fee(ledger: Ledger, wallet: Wallet):
     mint_quote = await wallet.request_mint(64)
@@ -553,6 +558,10 @@ async def test_melt_external_with_routing_fee(ledger: Ledger, wallet: Wallet):
 @pytest.mark.skipif(
     is_cln_backend,
     reason="CLN pathfinding is randomized, the exact fee is not deterministic",
+)
+@pytest.mark.skipif(
+    is_spark_backend,
+    reason="cashu-regtest open-ssp does not support nonzero swap fees",
 )
 async def test_melt_external_routing_fee_rounding(ledger: Ledger, wallet: Wallet):
     mint_quote = await wallet.request_mint(1024)

--- a/tests/mint/test_mint_api.py
+++ b/tests/mint/test_mint_api.py
@@ -3,7 +3,7 @@ import httpx
 import pytest
 import pytest_asyncio
 
-from cashu.core.base import MeltQuoteState, MintQuoteState
+from cashu.core.base import MeltQuoteState, Method, MintQuoteState, Unit
 from cashu.core.models import (
     GetInfoResponse,
     MintMethodSetting,
@@ -21,6 +21,7 @@ from cashu.wallet.crud import bump_secret_derivation
 from cashu.wallet.wallet import Wallet
 from tests.helpers import (
     get_real_invoice,
+    get_real_invoice_fee_leaf,
     get_real_invoice_routed,
     is_cln_backend,
     is_fake,
@@ -89,7 +90,11 @@ async def test_api_keys(ledger: Ledger):
             for keyset in ledger.keysets.values()
         ]
     }
-    assert response.json() == expected
+    result = response.json()
+    # PostgreSQL can return the same keysets in a different order.
+    result["keysets"].sort(key=lambda keyset: keyset["id"])
+    expected["keysets"].sort(key=lambda keyset: keyset["id"])
+    assert result == expected
 
 
 @pytest.mark.asyncio
@@ -569,8 +574,8 @@ async def test_melt_external_routing_fee_rounding(ledger: Ledger, wallet: Wallet
     await wallet.mint(1024, quote_id=mint_quote.quote)
     assert wallet.balance == 1024
 
-    # external invoice that the mint can only pay through a routing node
-    invoice_payment_request = get_real_invoice_routed(1000)
+    # The isolated fee leaf prevents LDK from offering a cheaper, whole-sat route.
+    invoice_payment_request = get_real_invoice_fee_leaf(1000)
 
     quote = await wallet.melt_quote(invoice_payment_request)
     assert quote.amount == 1000
@@ -599,15 +604,23 @@ async def test_melt_external_routing_fee_rounding(ledger: Ledger, wallet: Wallet
     resp_quote = PostMeltQuoteResponse(**response.json())
     assert resp_quote.state == MeltQuoteState.paid.value
 
-    # the routing fee for 1000 sat is 1001 msat (1000 msat base fee + 1 ppm)
-    # which the mint must round up to 2 sat when it accounts the fee
     melt_quote = await ledger.crud.get_melt_quote(quote_id=quote.quote, db=ledger.db)
     assert melt_quote, "No melt quote in db"
-    assert melt_quote.fee_paid == 2, "Fee not rounded up to the next sat"
+
+    # Verify rounding against LND's settled fee, independently of path selection.
+    payment = await ledger.backends[Method.bolt11][Unit.sat].get_payment_status(
+        melt_quote.checking_id
+    )
+    assert payment.settled
+    assert payment.fee is not None and payment.fee.unit == Unit.msat
+    whole_sats, remainder_msat = divmod(payment.fee.amount, 1000)
+    assert remainder_msat > 0, "Route must charge a fractional sat to test rounding"
+    rounded_fee = whole_sats + 1
+    assert melt_quote.fee_paid == rounded_fee, "Fee not rounded up to the next sat"
 
     # we get back the fee reserve minus the rounded up fee
     change_sat = sum([c.amount for c in resp_quote.change or []])
-    assert change_sat == 18, "Wrong change returned"
+    assert change_sat == quote.fee_reserve - rounded_fee, "Wrong change returned"
 
 
 @pytest.mark.asyncio

--- a/tests/mint/test_mint_init.py
+++ b/tests/mint/test_mint_init.py
@@ -5,7 +5,7 @@ import bolt11
 import pytest
 import pytest_asyncio
 
-from cashu.core.base import MeltQuote, MeltQuoteState, Method, Proof, Unit
+from cashu.core.base import Amount, MeltQuote, MeltQuoteState, Method, Proof, Unit
 from cashu.core.crypto.aes import AESCipher
 from cashu.core.db import Database
 from cashu.core.settings import settings
@@ -23,6 +23,8 @@ from tests.helpers import (
     is_regtest,
     pay_if_regtest,
     settle_invoice,
+    wait_for_hold_invoice,
+    wait_for_result,
 )
 
 SEED = "TEST_PRIVATE_KEY"
@@ -260,6 +262,21 @@ async def test_startup_fakewallet_pending_quote_unknown(ledger: Ledger):
     assert states[0].pending
 
 
+async def start_unrecorded_melt(ledger, quote, proofs):
+    """Send through the real backend without recording its result in the mint.
+
+    This simulates a mint stopping after submitting a payment: startup must
+    recover using the quote's persisted checking ID and the backend's history.
+    """
+    pending_quote = await ledger._prepare_melt(proofs=proofs, quote=quote.quote)
+    backend = ledger.backends[Method.bolt11][Unit.sat]
+    return asyncio.create_task(
+        backend.pay_invoice(
+            pending_quote, Amount(Unit.sat, quote.fee_reserve).to(Unit.msat).amount
+        )
+    )
+
+
 @pytest.mark.asyncio
 @pytest.mark.skipif(is_fake, reason="only regtest")
 async def test_startup_regtest_pending_quote_pending(wallet: Wallet, ledger: Ledger):
@@ -277,14 +294,8 @@ async def test_startup_regtest_pending_quote_pending(wallet: Wallet, ledger: Led
     quote = await wallet.melt_quote(invoice_payment_request)
     total_amount = quote.amount + quote.fee_reserve
     _, send_proofs = await wallet.swap_to_send(wallet.proofs, total_amount)
-    asyncio.create_task(
-        wallet.melt(
-            proofs=send_proofs,
-            invoice=invoice_payment_request,
-            fee_reserve_sat=quote.fee_reserve,
-            quote_id=quote.quote,
-        )
-    )
+    task = await start_unrecorded_melt(ledger, quote, send_proofs)
+    await wait_for_hold_invoice(invoice_payment_request)
     await asyncio.sleep(SLEEP_TIME)
 
     # run startup routine
@@ -302,6 +313,7 @@ async def test_startup_regtest_pending_quote_pending(wallet: Wallet, ledger: Led
 
     # only now settle the invoice
     settle_invoice(preimage=preimage)
+    await asyncio.wait_for(task, 90)
 
 
 @pytest.mark.asyncio
@@ -321,23 +333,26 @@ async def test_startup_regtest_pending_quote_success(wallet: Wallet, ledger: Led
     quote = await wallet.melt_quote(invoice_payment_request)
     total_amount = quote.amount + quote.fee_reserve
     _, send_proofs = await wallet.swap_to_send(wallet.proofs, total_amount)
-    asyncio.create_task(
-        wallet.melt(
-            proofs=send_proofs,
-            invoice=invoice_payment_request,
-            fee_reserve_sat=quote.fee_reserve,
-            quote_id=quote.quote,
-        )
-    )
+    task = await start_unrecorded_melt(ledger, quote, send_proofs)
+    await wait_for_hold_invoice(invoice_payment_request)
     await asyncio.sleep(SLEEP_TIME)
     # expect that proofs are pending
     states = await ledger.db_read.get_proofs_states([p.Y for p in send_proofs])
     assert all([s.pending for s in states])
 
     settle_invoice(preimage=preimage)
+    await asyncio.wait_for(task, 90)
     await asyncio.sleep(SLEEP_TIME)
 
-    # run startup routine
+    await wait_for_result(
+        lambda: ledger.backends[Method.bolt11][Unit.sat].get_payment_status(
+            bolt11.decode(invoice_payment_request).payment_hash
+        ),
+        lambda status: status.settled,
+    )
+    # The payment has finished, but its result has not been recorded by the mint.
+    pending = await ledger.crud.get_melt_quote(quote_id=quote.quote, db=ledger.db)
+    assert pending and pending.pending
     await ledger._check_pending_proofs_and_melt_quotes()
 
     # expect that no melt quote is pending
@@ -371,14 +386,8 @@ async def test_startup_regtest_pending_quote_failure(wallet: Wallet, ledger: Led
     quote = await wallet.melt_quote(invoice_payment_request)
     total_amount = quote.amount + quote.fee_reserve
     _, send_proofs = await wallet.swap_to_send(wallet.proofs, total_amount)
-    asyncio.create_task(
-        wallet.melt(
-            proofs=send_proofs,
-            invoice=invoice_payment_request,
-            fee_reserve_sat=quote.fee_reserve,
-            quote_id=quote.quote,
-        )
-    )
+    task = await start_unrecorded_melt(ledger, quote, send_proofs)
+    await wait_for_hold_invoice(invoice_payment_request)
     await asyncio.sleep(SLEEP_TIME)
 
     # expect that proofs are pending
@@ -386,9 +395,18 @@ async def test_startup_regtest_pending_quote_failure(wallet: Wallet, ledger: Led
     assert all([s.pending for s in states])
 
     cancel_invoice(preimage_hash=preimage_hash)
+    await asyncio.wait_for(task, 90)
     await asyncio.sleep(SLEEP_TIME)
 
-    # run startup routine
+    await wait_for_result(
+        lambda: ledger.backends[Method.bolt11][Unit.sat].get_payment_status(
+            bolt11.decode(invoice_payment_request).payment_hash
+        ),
+        lambda status: status.failed,
+    )
+    # The payment has finished, but its result has not been recorded by the mint.
+    pending = await ledger.crud.get_melt_quote(quote_id=quote.quote, db=ledger.db)
+    assert pending and pending.pending
     await ledger._check_pending_proofs_and_melt_quotes()
 
     # expect that no melt quote is pending
@@ -425,14 +443,8 @@ async def test_startup_regtest_pending_quote_unknown(wallet: Wallet, ledger: Led
     quote = await wallet.melt_quote(invoice_payment_request)
     total_amount = quote.amount + quote.fee_reserve
     _, send_proofs = await wallet.swap_to_send(wallet.proofs, total_amount)
-    asyncio.create_task(
-        wallet.melt(
-            proofs=send_proofs,
-            invoice=invoice_payment_request,
-            fee_reserve_sat=quote.fee_reserve,
-            quote_id=quote.quote,
-        )
-    )
+    task = await start_unrecorded_melt(ledger, quote, send_proofs)
+    await wait_for_hold_invoice(invoice_payment_request)
     await asyncio.sleep(SLEEP_TIME)
 
     # expect that proofs are pending
@@ -469,6 +481,7 @@ async def test_startup_regtest_pending_quote_unknown(wallet: Wallet, ledger: Led
 
     # clean up
     cancel_invoice(preimage_hash=preimage_hash)
+    await asyncio.wait_for(task, 90)
 
 
 @pytest.mark.asyncio

--- a/tests/mint/test_mint_regtest.py
+++ b/tests/mint/test_mint_regtest.py
@@ -17,9 +17,12 @@ from tests.helpers import (
     get_real_invoice,
     get_real_invoice_cln,
     is_fake,
+    is_spark_backend,
     pay_if_regtest,
     pay_real_invoice,
     settle_invoice,
+    wait_for_hold_invoice,
+    wait_for_result,
 )
 
 
@@ -48,14 +51,18 @@ async def test_lightning_create_invoice(ledger: Ledger):
     status = await ledger.backends[Method.bolt11][Unit.sat].get_invoice_status(
         invoice.checking_id
     )
-    assert status.pending
+    # Spark's payment history does not include unpaid receive requests.
+    assert status.unknown if is_spark_backend else status.pending
 
     # settle the invoice
     await pay_if_regtest(invoice.payment_request)
 
     # TEST 3: check the invoice status
-    status = await ledger.backends[Method.bolt11][Unit.sat].get_invoice_status(
-        invoice.checking_id
+    status = await wait_for_result(
+        lambda: ledger.backends[Method.bolt11][Unit.sat].get_invoice_status(
+            invoice.checking_id
+        ),
+        lambda status: status.settled,
     )
     assert status.settled
 
@@ -75,7 +82,8 @@ async def test_lightning_create_invoice_balance_change(ledger: Ledger):
     status = await ledger.backends[Method.bolt11][Unit.sat].get_invoice_status(
         invoice.checking_id
     )
-    assert status.pending
+    # Spark's payment history does not include unpaid receive requests.
+    assert status.unknown if is_spark_backend else status.pending
 
     status = await ledger.backends[Method.bolt11][Unit.sat].status()
     balance_before = status.balance
@@ -87,12 +95,18 @@ async def test_lightning_create_invoice_balance_change(ledger: Ledger):
     await asyncio.sleep(SLEEP_TIME)
 
     # TEST 3: check the invoice status
-    status = await ledger.backends[Method.bolt11][Unit.sat].get_invoice_status(
-        invoice.checking_id
+    status = await wait_for_result(
+        lambda: ledger.backends[Method.bolt11][Unit.sat].get_invoice_status(
+            invoice.checking_id
+        ),
+        lambda status: status.settled,
     )
     assert status.settled
 
-    status = await ledger.backends[Method.bolt11][Unit.sat].status()
+    status = await wait_for_result(
+        ledger.backends[Method.bolt11][Unit.sat].status,
+        lambda status: status.balance == balance_before + invoice_amount,
+    )
     balance_after = status.balance
 
     assert balance_after == balance_before + invoice_amount
@@ -126,14 +140,16 @@ async def test_lightning_pay_invoice(ledger: Ledger):
         fee_reserve=0,
     )
     payment = await ledger.backends[Method.bolt11][Unit.sat].pay_invoice(quote, 1000)
-    assert payment.settled
-    assert payment.preimage
+    assert payment.settled or payment.pending
     assert payment.checking_id
     assert not payment.error_message
 
     # TEST 2: check the payment status
-    status = await ledger.backends[Method.bolt11][Unit.sat].get_payment_status(
-        payment.checking_id
+    status = await wait_for_result(
+        lambda: ledger.backends[Method.bolt11][Unit.sat].get_payment_status(
+            payment.checking_id
+        ),
+        lambda status: status.settled and status.preimage,
     )
     assert status.settled
     assert status.preimage
@@ -178,7 +194,8 @@ async def test_lightning_pay_invoice_failure(ledger: Ledger):
     assert payment.failed
     assert not payment.preimage
     assert payment.error_message
-    assert not payment.checking_id
+    # Some backends retain an ID for the failed attempt (needed for recovery).
+    checking_id = payment.checking_id or checking_id
 
     # TEST 3: check the payment status
     status = await ledger.backends[Method.bolt11][Unit.sat].get_payment_status(
@@ -224,12 +241,16 @@ async def test_lightning_pay_invoice_pending_success(ledger: Ledger):
     await asyncio.sleep(SLEEP_TIME)
 
     # check the payment status
-    status = await ledger.backends[Method.bolt11][Unit.sat].get_payment_status(
-        quote.checking_id
+    status = await wait_for_result(
+        lambda: ledger.backends[Method.bolt11][Unit.sat].get_payment_status(
+            quote.checking_id
+        ),
+        lambda status: status.pending,
     )
     assert status.pending
 
     # settle the invoice
+    await wait_for_hold_invoice(str(invoice_dict["payment_request"]))
     settle_invoice(preimage=preimage)
     await asyncio.sleep(SLEEP_TIME)
 
@@ -303,12 +324,16 @@ async def test_lightning_pay_invoice_pending_failure(ledger: Ledger):
     await asyncio.sleep(SLEEP_TIME)
 
     # check the payment status
-    status = await ledger.backends[Method.bolt11][Unit.sat].get_payment_status(
-        quote.checking_id
+    status = await wait_for_result(
+        lambda: ledger.backends[Method.bolt11][Unit.sat].get_payment_status(
+            quote.checking_id
+        ),
+        lambda status: status.pending,
     )
     assert status.pending
 
     # cancel the invoice
+    await wait_for_hold_invoice(str(invoice_dict["payment_request"]))
     cancel_invoice(payment_hash)
     await asyncio.sleep(SLEEP_TIME)
 
@@ -362,7 +387,7 @@ async def test_regtest_pending_quote(wallet: Wallet, ledger: Ledger):
     quote = await wallet.melt_quote(invoice_payment_request)
     total_amount = quote.amount + quote.fee_reserve
     _, send_proofs = await wallet.swap_to_send(wallet.proofs, total_amount)
-    asyncio.create_task(ledger.melt(proofs=send_proofs, quote=quote.quote))
+    task = asyncio.create_task(ledger.melt(proofs=send_proofs, quote=quote.quote))
     # asyncio.create_task(
     #     wallet.melt(
     #         proofs=send_proofs,
@@ -384,8 +409,13 @@ async def test_regtest_pending_quote(wallet: Wallet, ledger: Ledger):
     assert all([s.pending for s in states])
 
     # only now settle the invoice
+    await wait_for_hold_invoice(str(invoice_dict["payment_request"]))
     settle_invoice(preimage=preimage)
-    await asyncio.sleep(SLEEP_TIME)
+    await asyncio.wait_for(task, 90)
+    await wait_for_result(
+        lambda: ledger.get_melt_quote(quote_id=quote.quote),
+        lambda quote: quote.paid,
+    )
 
     # expect that proofs are now spent
     states = await ledger.db_read.get_proofs_states([p.Y for p in send_proofs])

--- a/tests/spark.py
+++ b/tests/spark.py
@@ -1,0 +1,177 @@
+"""Connection and RPC helpers for the local cashu-regtest Spark stack."""
+
+import asyncio
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import breez_sdk_spark as breez
+import httpx
+import pytest
+
+from cashu.core.base import Amount, Unit
+
+TIMEOUT = 120
+SSP_URL = "http://127.0.0.1:5000"
+ESPLORA_URL = "http://127.0.0.1:30000"
+
+
+async def compose(service, *args):
+    regtest_dir = Path(
+        os.getenv("CASHU_REGTEST_DIR", str(Path.home() / "cashu-regtest"))
+    ).expanduser()
+    compose_file = regtest_dir / "docker-compose.yml"
+    assert compose_file.is_file(), f"cashu-regtest not found at {regtest_dir}"
+    process = await asyncio.create_subprocess_exec(
+        "docker",
+        "compose",
+        "--profile",
+        "spark",
+        "-p",
+        "cashu",
+        "-f",
+        str(compose_file),
+        "exec",
+        "-T",
+        service,
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), TIMEOUT)
+    except BaseException:
+        if process.returncode is None:
+            process.kill()
+        await process.communicate()
+        raise
+    assert process.returncode == 0, (
+        f"{service} {args[0]} failed: {stderr.decode()}. "
+        "Start cashu-regtest with ./start.sh --spark first."
+    )
+    return stdout.decode().strip()
+
+
+async def lightning(peer, *args):
+    if peer == "lnd":
+        output = await compose(
+            "lnd-1", "lncli", "--network=regtest", "--rpcserver=lnd-1:10009", *args
+        )
+    else:
+        output = await compose(
+            "clightning-1", "lightning-cli", "--network=regtest", "-N", "none", *args
+        )
+    return json.loads(output)
+
+
+async def wait_for(label, check):
+    """Bound both individual RPCs and the total wait for eventual settlement."""
+    deadline = asyncio.get_running_loop().time() + TIMEOUT
+    last = None
+    while (remaining := deadline - asyncio.get_running_loop().time()) > 0:
+        last = await asyncio.wait_for(check(), remaining)
+        if last:
+            return last
+        await asyncio.sleep(min(1, remaining))
+    pytest.fail(f"Timed out waiting for {label}: {last}")
+
+
+async def wait_balance(wallet, sats):
+    expected = Amount(Unit.sat, sats).to(wallet.unit)
+
+    async def check():
+        status = await wallet.status()
+        assert not status.error_message, status.error_message
+        return status.balance == expected
+
+    await wait_for(f"Spark balance {expected}", check)
+
+
+async def wait_invoice(wallet, checking_id):
+    async def check():
+        status = await wallet.get_invoice_status(checking_id)
+        assert not status.failed, status.error_message
+        return status if status.settled else None
+
+    return await wait_for(f"incoming payment {checking_id}", check)
+
+
+async def wait_payment(wallet, checking_id):
+    async def check():
+        status = await wallet.get_payment_status(checking_id)
+        assert not status.failed, status.error_message
+        # The SDK can report completion before its cached preimage is updated.
+        return status if status.settled and status.preimage else None
+
+    return await wait_for(f"outgoing payment {checking_id}", check)
+
+
+def assert_preimage(preimage, payment_hash):
+    assert preimage
+    assert hashlib.sha256(bytes.fromhex(preimage)).hexdigest() == payment_hash
+
+
+async def local_spark_config():
+    # Discover fixture identities and trust the generated operator certificates.
+    # Do not use the default config's public SSP or sync service on regtest.
+    try:
+        async with httpx.AsyncClient(timeout=10, trust_env=False) as client:
+            response = await client.get(f"{SSP_URL}/identity")
+            response.raise_for_status()
+            identity = response.json()["identityPublicKey"]
+            response = await client.get(f"{ESPLORA_URL}/blocks/tip/height")
+            response.raise_for_status()
+            assert int(response.text) > 0
+    except httpx.HTTPError as exc:
+        pytest.fail(
+            "Spark regtest services are unavailable. Run ./start.sh --spark in "
+            f"cashu-regtest first. {exc}",
+            pytrace=False,
+        )
+
+    regtest_dir = Path(
+        os.getenv("CASHU_REGTEST_DIR", str(Path.home() / "cashu-regtest"))
+    ).expanduser()
+    operators = json.loads((regtest_dir / "spark/operators.json").read_text())
+    config = breez.default_config(breez.Network.REGTEST)
+    config.api_key = None
+    config.lnurl_domain = None
+    config.real_time_sync_server_url = None
+    config.use_default_external_input_parsers = False
+    config.prefer_spark_over_lightning = False
+    config.sync_interval_secs = 2
+    config.leaf_optimization_config.auto_enabled = False
+    config.token_optimization_config.auto_enabled = False
+    assert config.spark_config is not None
+    config.spark_config.coordinator_identifier = f"{1:064x}"
+    config.spark_config.threshold = 2
+    config.spark_config.signing_operators = [
+        breez.SparkSigningOperator(
+            id=operator["id"],
+            identifier=f"{operator['id'] + 1:064x}",
+            address=f"https://localhost:{8535 + operator['id']}",
+            identity_public_key=operator["identity_public_key"],
+            ca_cert_pem=await compose(
+                f"spark-operator-{operator['id']}", "cat", operator["cert_path"]
+            ),
+        )
+        for operator in operators
+    ]
+    config.spark_config.ssp_config = breez.SparkSspConfig(
+        base_url=SSP_URL,
+        identity_public_key=identity,
+        schema_endpoint="graphql/spark/rc",
+    )
+
+    return config
+
+
+async def connect_spark(request):
+    # UniFFI retains a global loop. Pytest creates a new one for each case,
+    # and these async builder methods run before build() resets that loop.
+    breez.uniffi_set_event_loop(asyncio.get_running_loop())
+    builder = breez.SdkBuilder(config=request.config, seed=request.seed)
+    await builder.with_default_storage(request.storage_dir)
+    await builder.with_rest_chain_service(ESPLORA_URL, breez.ChainApiType.ESPLORA, None)
+    return await builder.build()

--- a/tests/spark_regtest.py
+++ b/tests/spark_regtest.py
@@ -1,0 +1,167 @@
+"""Run the shared mint/wallet regtests with the real local Spark backend."""
+
+import asyncio
+import copy
+import os
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+_clients = []
+_receive_requests = set()
+
+
+async def pay_regtest_invoice(invoice):
+    """Fund a shared-suite invoice and wait until its receiving wallet sees it."""
+    import bolt11
+    import httpx
+
+    from cashu.core.base import Unit
+    from cashu.core.db import Database
+    from cashu.core.settings import settings
+    from cashu.lightning.sparkl2 import SparkL2Wallet
+    from cashu.mint.crud import LedgerCrudSqlite
+    from tests.helpers import wait_for_result
+    from tests.spark import lightning
+
+    db = Database("mint", settings.mint_database)
+    try:
+        quote = await LedgerCrudSqlite().get_mint_quote(request=invoice, db=db)
+    finally:
+        await db.engine.dispose()
+
+    # Mixed-unit tests use FakeWallet for USD alongside the real sat backend.
+    if (
+        quote is not None
+        and quote.unit == Unit.usd.name
+        and settings.mint_backend_bolt11_usd == "FakeWallet"
+    ):
+        await asyncio.sleep(settings.fakewallet_delay_incoming_payment or 0)
+        return
+
+    payment = await lightning("lnd", "payinvoice", "--force", "--json", invoice)
+    assert payment["status"] == "SUCCEEDED", payment
+    wallet = None
+    if invoice in _receive_requests:
+        import breez_sdk_spark as breez
+
+        breez.uniffi_set_event_loop(asyncio.get_running_loop())
+        wallet = SparkL2Wallet(Unit.sat)
+        wallet.sdk = _clients[0]
+    payment_hash = bolt11.decode(invoice).payment_hash
+    async with httpx.AsyncClient(timeout=10, trust_env=False) as client:
+
+        async def received():
+            if wallet is not None:
+                status = await wallet.get_invoice_status(payment_hash)
+                return status.settled
+            if quote is not None:
+                response = await client.get(
+                    f"{settings.mint_url}/v1/mint/quote/bolt11/{quote.quote}"
+                )
+                response.raise_for_status()
+                return response.json()["state"] in ("PAID", "ISSUED")
+            return False
+
+        await wait_for_result(received, bool)
+
+
+@pytest.fixture(scope="session")
+def spark_regtest_config():
+    from cashu.core.settings import settings
+
+    if os.getenv("CASHU_SPARK_REGTEST", "").lower() != "true":
+        yield None
+        return
+    if settings.mint_backend_bolt11_sat != "SparkL2Wallet":
+        yield None
+        return
+
+    import breez_sdk_spark as breez
+    from mnemonic import Mnemonic
+
+    from tests.spark import connect_spark, local_spark_config
+
+    # Configure endpoints before the mint forks; no SDK is connected in the
+    # parent until the mint process has started its own event loop.
+    config = asyncio.run(local_spark_config())
+    clients = _clients
+    state = {"clients": clients, "funded": False}
+    parent_pid = os.getpid()
+    process_seed = None
+
+    def default_config(network):
+        assert network == breez.Network.REGTEST
+        return copy.deepcopy(config)
+
+    async def connect(request):
+        nonlocal process_seed
+        if clients:
+            return clients[0]
+        # Each process owns its wallet and cache so its SDK can deliver incoming
+        # payment events without another instance claiming the same transfers.
+        if os.getpid() != parent_pid:
+            if process_seed is None:
+                process_seed = breez.Seed.MNEMONIC(
+                    mnemonic=Mnemonic("english").generate(), passphrase=None
+                )
+            request.seed = process_seed
+        request.storage_dir = str(Path(request.storage_dir) / f"process-{os.getpid()}")
+        sdk = await connect_spark(request)
+
+        # Record ownership while forwarding the receive operation unchanged.
+        # The two processes share mint quotes, but have separate Spark wallets.
+        receive_payment = sdk.receive_payment
+
+        async def receive(request):
+            response = await receive_payment(request)
+            _receive_requests.add(response.payment_request)
+            return response
+
+        sdk.receive_payment = receive
+        clients.append(sdk)
+        return sdk
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(breez, "default_config", default_config)
+        patch.setattr(breez, "connect", connect)
+        patch.setattr(settings, "mint_spark_network", "REGTEST")
+        patch.setattr(settings, "mint_spark_api_key", None)
+        patch.setattr(settings, "mint_spark_mnemonic", Mnemonic("english").generate())
+        yield state
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def spark_regtest_clients(spark_regtest_config, mint):
+    if spark_regtest_config is None:
+        yield
+        return
+
+    from cashu.core.base import Amount, Unit
+    from cashu.lightning.sparkl2 import SparkL2Wallet
+    from tests.spark import TIMEOUT, lightning, wait_balance
+
+    clients = spark_regtest_config["clients"]
+    try:
+        if not spark_regtest_config["funded"]:
+            # Like the funded LND/CLN regtest nodes, the shared Spark backend
+            # must be able to pay invoices before an individual test mints.
+            wallet = SparkL2Wallet(Unit.sat)
+            invoice = await wallet.create_invoice(Amount(Unit.sat, 10_000))
+            assert invoice.ok, invoice.error_message
+            result = await lightning(
+                "lnd", "payinvoice", "--force", "--json", invoice.payment_request
+            )
+            assert result["status"] == "SUCCEEDED", result
+            await wait_balance(wallet, 10_000)
+            spark_regtest_config["funded"] = True
+        yield
+    finally:
+        # CLI tests can run their own loop between fixture setup and teardown.
+        import breez_sdk_spark as breez
+
+        breez.uniffi_set_event_loop(asyncio.get_running_loop())
+        for sdk in clients:
+            await asyncio.wait_for(sdk.disconnect(), TIMEOUT)
+        clients.clear()

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -33,6 +33,7 @@ from tests.helpers import (
     is_fake,
     is_github_actions,
     is_regtest,
+    is_spark_backend,
     pay_if_regtest,
 )
 
@@ -53,18 +54,6 @@ async def assert_err(f, msg: Union[str, CashuError]):
             raise Exception(f"Expected error: {msg}, got: {error_message}")
         return
     raise Exception(f"Expected error: {msg}, got no error")
-
-
-async def assert_err_multiple(f, msgs: List[str]):
-    """Compute f() and expect an error message 'msg'."""
-    try:
-        await f
-    except Exception as exc:
-        for msg in msgs:
-            if msg in str(exc.args[0]):
-                return
-        raise Exception(f"Expected error: {msgs}, got: {exc.args[0]}")
-    raise Exception(f"Expected error: {msgs}, got no error")
 
 
 def assert_amt(proofs: List[Proof], expected: int):
@@ -316,12 +305,12 @@ async def test_melt(wallet1: Wallet):
     quote = await wallet1.melt_quote(invoice_payment_request)
     total_amount = quote.amount + quote.fee_reserve
 
-    if is_regtest:
-        # we expect a fee reserve of 2 sat for regtest
+    if is_regtest and not is_spark_backend:
+        # LND and CLN reserve 2 sats for routing.
         assert total_amount == 66
         assert quote.fee_reserve == 2
-    if is_fake:
-        # we expect a fee reserve of 0 sat for fake
+    if is_fake or is_spark_backend:
+        # Internal payments and the local Spark SSP have zero fees.
         assert total_amount == 64
         assert quote.fee_reserve == 0
 
@@ -338,7 +327,7 @@ async def test_melt(wallet1: Wallet):
         quote_id=quote.quote,
     )
 
-    if is_regtest:
+    if is_regtest and quote.fee_reserve:
         assert melt_response.change, "No change returned"
         assert len(melt_response.change) == 1, "More than one change returned"
         # NOTE: we assume that we will get a token back from the same keyset as the ones we melted
@@ -376,6 +365,10 @@ async def test_melt(wallet1: Wallet):
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(is_fake, reason="only works on regtest")
+@pytest.mark.skipif(
+    is_spark_backend,
+    reason="cashu-regtest open-ssp does not support nonzero swap fees",
+)
 async def test_melt_routed_invoice(wallet1: Wallet):
     topup_mint_quote = await wallet1.request_mint(128)
     await pay_if_regtest(topup_mint_quote.request)
@@ -493,12 +486,17 @@ async def test_split_race_condition(wallet1: Wallet):
     # run two splits in parallel
     import asyncio
 
-    await assert_err_multiple(
-        asyncio.gather(
-            wallet1.split(wallet1.proofs, 20),
-            wallet1.split(wallet1.proofs, 20),
-        ),
-        ["proofs are pending", "already spent"],
+    # Await both attempts: the losing split can fail before the winning split
+    # releases its SQLite transaction, which otherwise leaks into the next test.
+    results = await asyncio.gather(
+        wallet1.split(wallet1.proofs, 20),
+        wallet1.split(wallet1.proofs, 20),
+        return_exceptions=True,
+    )
+    errors = [result for result in results if isinstance(result, Exception)]
+    assert len(errors) == 1, results
+    assert any(
+        message in str(errors[0]) for message in ("proofs are pending", "already spent")
     )
 
 

--- a/tests/wallet/test_wallet_regtest.py
+++ b/tests/wallet/test_wallet_regtest.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import suppress
 
 import bolt11
 import pytest
@@ -16,6 +17,8 @@ from tests.helpers import (
     is_fake,
     pay_if_regtest,
     settle_invoice,
+    wait_for_hold_invoice,
+    wait_for_result,
 )
 
 
@@ -40,14 +43,14 @@ async def test_regtest_pending_quote(wallet: Wallet, ledger: Ledger):
     assert wallet.balance == 64
 
     # create hodl invoice
-    preimage, invoice_dict = get_hold_invoice(16)
+    preimage, invoice_dict = get_hold_invoice(15)
     invoice_payment_request = str(invoice_dict["payment_request"])
 
     # wallet pays the invoice
     quote = await wallet.melt_quote(invoice_payment_request)
     total_amount = quote.amount + quote.fee_reserve
     _, send_proofs = await wallet.swap_to_send(wallet.proofs, total_amount)
-    asyncio.create_task(
+    task = asyncio.create_task(
         wallet.melt(
             proofs=send_proofs,
             invoice=invoice_payment_request,
@@ -60,12 +63,18 @@ async def test_regtest_pending_quote(wallet: Wallet, ledger: Ledger):
     states = await wallet.check_proof_state(send_proofs)
     assert all([s.pending for s in states.states])
 
+    await wait_for_hold_invoice(str(invoice_dict["payment_request"]))
     settle_invoice(preimage=preimage)
+    await wait_for_result(
+        lambda: wallet.check_proof_state(send_proofs),
+        lambda response: all(state.spent for state in response.states),
+    )
 
     await asyncio.sleep(SLEEP_TIME)
 
     states = await wallet.check_proof_state(send_proofs)
     assert all([s.spent for s in states.states])
+    await asyncio.wait_for(task, 90)
 
 
 @pytest.mark.asyncio
@@ -78,7 +87,7 @@ async def test_regtest_failed_quote(wallet: Wallet, ledger: Ledger):
     assert wallet.balance == 64
 
     # create hodl invoice
-    preimage, invoice_dict = get_hold_invoice(16)
+    preimage, invoice_dict = get_hold_invoice(15)
     invoice_payment_request = str(invoice_dict["payment_request"])
     invoice_obj = bolt11.decode(invoice_payment_request)
     preimage_hash = invoice_obj.payment_hash
@@ -87,7 +96,7 @@ async def test_regtest_failed_quote(wallet: Wallet, ledger: Ledger):
     quote = await wallet.melt_quote(invoice_payment_request)
     total_amount = quote.amount + quote.fee_reserve
     _, send_proofs = await wallet.swap_to_send(wallet.proofs, total_amount)
-    asyncio.create_task(
+    task = asyncio.create_task(
         wallet.melt(
             proofs=send_proofs,
             invoice=invoice_payment_request,
@@ -100,12 +109,19 @@ async def test_regtest_failed_quote(wallet: Wallet, ledger: Ledger):
     states = await wallet.check_proof_state(send_proofs)
     assert all([s.pending for s in states.states])
 
+    await wait_for_hold_invoice(str(invoice_dict["payment_request"]))
     cancel_invoice(preimage_hash=preimage_hash)
+    await wait_for_result(
+        lambda: wallet.check_proof_state(send_proofs),
+        lambda response: all(state.unspent for state in response.states),
+    )
 
     await asyncio.sleep(SLEEP_TIME)
 
     states = await wallet.check_proof_state(send_proofs)
     assert all([s.unspent for s in states.states])
+    with pytest.raises(Exception, match="could not pay invoice"):
+        await asyncio.wait_for(task, 90)
 
 
 @pytest.mark.asyncio
@@ -121,7 +137,7 @@ async def test_regtest_get_melt_quote_melt_fail_restore_pending_batch_check(
     assert wallet.balance == 64
 
     # create hodl invoice
-    preimage, invoice_dict = get_hold_invoice(16)
+    preimage, invoice_dict = get_hold_invoice(15)
     invoice_payment_request = str(invoice_dict["payment_request"])
     invoice_obj = bolt11.decode(invoice_payment_request)
     preimage_hash = invoice_obj.payment_hash
@@ -137,7 +153,7 @@ async def test_regtest_get_melt_quote_melt_fail_restore_pending_batch_check(
     proofs_db = await get_proofs(db=wallet.db, melt_id=quote.quote)
     assert all([p.reserved for p in proofs_db])
 
-    asyncio.create_task(
+    task = asyncio.create_task(
         wallet.melt(
             proofs=send_proofs,
             invoice=invoice_payment_request,
@@ -151,7 +167,12 @@ async def test_regtest_get_melt_quote_melt_fail_restore_pending_batch_check(
     assert all([s.pending for s in states.states])
 
     # fail the payment, melt will unset the proofs as reserved
+    await wait_for_hold_invoice(str(invoice_dict["payment_request"]))
     cancel_invoice(preimage_hash=preimage_hash)
+    await wait_for_result(
+        lambda: wallet.check_proof_state(send_proofs),
+        lambda response: all(state.unspent for state in response.states),
+    )
 
     await asyncio.sleep(SLEEP_TIME)
 
@@ -161,6 +182,8 @@ async def test_regtest_get_melt_quote_melt_fail_restore_pending_batch_check(
 
     proofs_db_later = await get_proofs(db=wallet.db, melt_id=quote.quote)
     assert all([p.reserved is False for p in proofs_db_later])
+    with pytest.raises(Exception, match="could not pay invoice"):
+        await asyncio.wait_for(task, 90)
 
 
 @pytest.mark.asyncio
@@ -176,7 +199,7 @@ async def test_regtest_get_melt_quote_wallet_crash_melt_fail_restore_pending_bat
     assert wallet.balance == 64
 
     # create hodl invoice
-    preimage, invoice_dict = get_hold_invoice(16)
+    preimage, invoice_dict = get_hold_invoice(15)
     invoice_payment_request = str(invoice_dict["payment_request"])
     invoice_obj = bolt11.decode(invoice_payment_request)
     preimage_hash = invoice_obj.payment_hash
@@ -187,7 +210,7 @@ async def test_regtest_get_melt_quote_wallet_crash_melt_fail_restore_pending_bat
     _, send_proofs = await wallet.swap_to_send(
         wallet.proofs, total_amount, set_reserved=True
     )
-    assert len(send_proofs) == 2
+    assert len(send_proofs) > 1
 
     task = asyncio.create_task(
         wallet.melt(
@@ -201,11 +224,13 @@ async def test_regtest_get_melt_quote_wallet_crash_melt_fail_restore_pending_bat
 
     # verify that the proofs are reserved
     proofs_db = await get_proofs(db=wallet.db, melt_id=quote.quote)
-    assert len(proofs_db) == 2
+    assert len(proofs_db) == len(send_proofs)
     assert all([p.reserved for p in proofs_db])
 
     # simulate a and kill the task
     task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
 
     await asyncio.sleep(SLEEP_TIME)
 
@@ -213,7 +238,12 @@ async def test_regtest_get_melt_quote_wallet_crash_melt_fail_restore_pending_bat
     assert all([s.pending for s in states.states])
 
     # fail the payment, melt will unset the proofs as reserved
+    await wait_for_hold_invoice(str(invoice_dict["payment_request"]))
     cancel_invoice(preimage_hash=preimage_hash)
+    await wait_for_result(
+        lambda: wallet.check_proof_state(send_proofs),
+        lambda response: all(state.unspent for state in response.states),
+    )
 
     await asyncio.sleep(SLEEP_TIME)
 
@@ -242,7 +272,7 @@ async def test_regtest_wallet_crash_melt_succeed_restore_pending_batch_check(
     assert wallet.balance == 64
 
     # create hodl invoice
-    preimage, invoice_dict = get_hold_invoice(16)
+    preimage, invoice_dict = get_hold_invoice(15)
     invoice_payment_request = str(invoice_dict["payment_request"])
     # invoice_obj = bolt11.decode(invoice_payment_request)
     # preimage_hash = invoice_obj.payment_hash
@@ -270,6 +300,8 @@ async def test_regtest_wallet_crash_melt_succeed_restore_pending_batch_check(
 
     # simulate a and kill the task
     task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
     await asyncio.sleep(SLEEP_TIME)
     # verify that the proofs are still reserved
     proofs_db = await get_proofs(db=wallet.db, melt_id=quote.quote)
@@ -280,7 +312,12 @@ async def test_regtest_wallet_crash_melt_succeed_restore_pending_batch_check(
     assert all([s.pending for s in states.states])
 
     # succeed the payment
+    await wait_for_hold_invoice(str(invoice_dict["payment_request"]))
     settle_invoice(preimage=preimage)
+    await wait_for_result(
+        lambda: wallet.check_proof_state(send_proofs),
+        lambda response: all(state.spent for state in response.states),
+    )
 
     await asyncio.sleep(SLEEP_TIME)
 


### PR DESCRIPTION
Run the shared Spark mint/wallet suites and four direct sat/msat round trips against LND and CLN using the real Breez SDK and local cashu-regtest stack. Add Spark CI jobs for SQLite and PostgreSQL, pin the regtest revision, and allow time for cold source builds.

Fix SDK payment-request handling, payment-hash lookup during recovery, and settlement before the Lightning preimage is available. Cover held payments and crash recovery. Stabilize LND fee-rounding and keyset-order assertions for the expanded environment.

Local validation: 460 mint tests passed across split runs, 297 wallet tests, four direct cases, and 13 shared Spark cases against PostgreSQL. Another 120 LND API/regtest checks passed across REST/RPC and both databases. Workflow lint, `make format`, and `make check` passed.

Three nonzero-fee Spark cases remain skipped pending upstream SSP support; MPP uses existing capability skips.
