### PR TITLE
ci: pin regtest setup and update fee-rounding test

### DIFF
--- a/.github/workflows/regtest-mint.yml
+++ b/.github/workflows/regtest-mint.yml
@@ -29,7 +29,8 @@ env:
 jobs:
   regtest-mint:
     runs-on: ${{ inputs.os-version }}
-    timeout-minutes: 20
+    # Allow startup plus the full mint suite on slower runners.
+    timeout-minutes: 30
     steps:
       - name: Start PostgreSQL service
         if: contains(inputs.mint-database, 'postgres')

--- a/.github/workflows/regtest-mint.yml
+++ b/.github/workflows/regtest-mint.yml
@@ -23,10 +23,8 @@ permissions:
   contents: read
 
 env:
-  # Prebuilt cashu-regtest stack (bitcoind, 3x LND, 3x CLN, LNbits). Pinned to
-  # a tag whose docker-compose exposes the node ports on the host (3010, 3001,
-  # 8081, 10009, 5001) with RPC ports consistent with its own scripts.
-  REGTEST_IMAGE: ghcr.io/callebtc/cashu-regtest-environment:sha-bde3931fe27e32b8f83b2adbb65a8460c2f32ef5
+  # This revision uses CLN 26.06.7 (with xpay) and pulls prebuilt service images.
+  REGTEST_REF: 7eb3515b9fb41f477f831cedd28e1ad9ae6c521d
 
 jobs:
   regtest-mint:
@@ -46,36 +44,20 @@ jobs:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
 
+      - name: Checkout Regtest
+        uses: actions/checkout@v6
+        with:
+          repository: callebtc/cashu-regtest
+          ref: ${{ env.REGTEST_REF }}
+          path: regtest
+          persist-credentials: false
+
       - name: Setup Regtest
+        working-directory: regtest
         run: |
-          mkdir -p regtest/data
-          # The container runs `docker compose` against the host daemon from
-          # /regtest, so the stack's ./data bind mounts resolve to /regtest/data
-          # on the runner. Point that at the workspace copy the tests read.
-          sudo ln -sfn "$PWD/regtest" /regtest
-          docker run -d --name regtest-environment \
-            --network host \
-            --volume /var/run/docker.sock:/var/run/docker.sock \
-            --volume "$PWD/regtest/data:/regtest/data" \
-            "$REGTEST_IMAGE"
-          # The container entrypoint bootstraps the stack and runs its
-          # acceptance checks; wait for them before running the tests.
-          ready=false
-          for i in $(seq 1 120); do
-            if [ "$(docker inspect -f '{{.State.Status}}' regtest-environment)" != "running" ]; then
-              break
-            fi
-            if docker logs regtest-environment 2>&1 | grep -q "all tests passed"; then
-              ready=true
-              break
-            fi
-            sleep 5
-          done
-          if [ "$ready" != "true" ]; then
-            docker logs --tail 200 regtest-environment
-            exit 1
-          fi
-          sudo chmod -R 777 regtest
+          chmod -R 777 .
+          # start.sh pulls the published images, starts Compose, and checks payments.
+          bash ./start.sh
 
       - name: Run Tests
         env:
@@ -112,6 +94,6 @@ jobs:
       - name: Stop Regtest
         if: always()
         run: |
-          docker exec regtest-environment docker compose down --volumes || true
-          docker rm -f regtest-environment || true
-          sudo rm -f /regtest
+          if [ -f regtest/docker-compose.yml ]; then
+            docker compose --project-directory regtest -p cashu down --volumes
+          fi

--- a/.github/workflows/regtest-mint.yml
+++ b/.github/workflows/regtest-mint.yml
@@ -23,7 +23,6 @@ permissions:
   contents: read
 
 env:
-  # This revision uses CLN 26.06.7 (with xpay) and pulls prebuilt service images.
   REGTEST_REF: 7eb3515b9fb41f477f831cedd28e1ad9ae6c521d
 
 jobs:

--- a/.github/workflows/regtest-mint.yml
+++ b/.github/workflows/regtest-mint.yml
@@ -22,10 +22,16 @@ on:
 permissions:
   contents: read
 
+env:
+  # Prebuilt cashu-regtest stack (bitcoind, 3x LND, 3x CLN, LNbits). Pinned to
+  # a tag whose docker-compose exposes the node ports on the host (3010, 3001,
+  # 8081, 10009, 5001) with RPC ports consistent with its own scripts.
+  REGTEST_IMAGE: ghcr.io/callebtc/cashu-regtest-environment:sha-bde3931fe27e32b8f83b2adbb65a8460c2f32ef5
+
 jobs:
   regtest-mint:
     runs-on: ${{ inputs.os-version }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Start PostgreSQL service
         if: contains(inputs.mint-database, 'postgres')
@@ -42,10 +48,34 @@ jobs:
 
       - name: Setup Regtest
         run: |
-          git clone https://github.com/callebtc/cashu-regtest-enviroment.git regtest
-          cd regtest
-          chmod -R 777 .
-          bash ./start.sh
+          mkdir -p regtest/data
+          # The container runs `docker compose` against the host daemon from
+          # /regtest, so the stack's ./data bind mounts resolve to /regtest/data
+          # on the runner. Point that at the workspace copy the tests read.
+          sudo ln -sfn "$PWD/regtest" /regtest
+          docker run -d --name regtest-environment \
+            --network host \
+            --volume /var/run/docker.sock:/var/run/docker.sock \
+            --volume "$PWD/regtest/data:/regtest/data" \
+            "$REGTEST_IMAGE"
+          # The container entrypoint bootstraps the stack and runs its
+          # acceptance checks; wait for them before running the tests.
+          ready=false
+          for i in $(seq 1 120); do
+            if [ "$(docker inspect -f '{{.State.Status}}' regtest-environment)" != "running" ]; then
+              break
+            fi
+            if docker logs regtest-environment 2>&1 | grep -q "all tests passed"; then
+              ready=true
+              break
+            fi
+            sleep 5
+          done
+          if [ "$ready" != "true" ]; then
+            docker logs --tail 200 regtest-environment
+            exit 1
+          fi
+          sudo chmod -R 777 regtest
 
       - name: Run Tests
         env:
@@ -78,3 +108,10 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Stop Regtest
+        if: always()
+        run: |
+          docker exec regtest-environment docker compose down --volumes || true
+          docker rm -f regtest-environment || true
+          sudo rm -f /regtest

--- a/.github/workflows/regtest-wallet.yml
+++ b/.github/workflows/regtest-wallet.yml
@@ -23,7 +23,6 @@ permissions:
   contents: read
 
 env:
-  # This revision uses CLN 26.06.7 (with xpay) and pulls prebuilt service images.
   REGTEST_REF: 7eb3515b9fb41f477f831cedd28e1ad9ae6c521d
 
 jobs:

--- a/.github/workflows/regtest-wallet.yml
+++ b/.github/workflows/regtest-wallet.yml
@@ -23,10 +23,8 @@ permissions:
   contents: read
 
 env:
-  # Prebuilt cashu-regtest stack (bitcoind, 3x LND, 3x CLN, LNbits). Pinned to
-  # a tag whose docker-compose exposes the node ports on the host (3010, 3001,
-  # 8081, 10009, 5001) with RPC ports consistent with its own scripts.
-  REGTEST_IMAGE: ghcr.io/callebtc/cashu-regtest-environment:sha-bde3931fe27e32b8f83b2adbb65a8460c2f32ef5
+  # This revision uses CLN 26.06.7 (with xpay) and pulls prebuilt service images.
+  REGTEST_REF: 7eb3515b9fb41f477f831cedd28e1ad9ae6c521d
 
 jobs:
   regtest-wallet:
@@ -46,36 +44,20 @@ jobs:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
 
+      - name: Checkout Regtest
+        uses: actions/checkout@v6
+        with:
+          repository: callebtc/cashu-regtest
+          ref: ${{ env.REGTEST_REF }}
+          path: regtest
+          persist-credentials: false
+
       - name: Setup Regtest
+        working-directory: regtest
         run: |
-          mkdir -p regtest/data
-          # The container runs `docker compose` against the host daemon from
-          # /regtest, so the stack's ./data bind mounts resolve to /regtest/data
-          # on the runner. Point that at the workspace copy the tests read.
-          sudo ln -sfn "$PWD/regtest" /regtest
-          docker run -d --name regtest-environment \
-            --network host \
-            --volume /var/run/docker.sock:/var/run/docker.sock \
-            --volume "$PWD/regtest/data:/regtest/data" \
-            "$REGTEST_IMAGE"
-          # The container entrypoint bootstraps the stack and runs its
-          # acceptance checks; wait for them before running the tests.
-          ready=false
-          for i in $(seq 1 120); do
-            if [ "$(docker inspect -f '{{.State.Status}}' regtest-environment)" != "running" ]; then
-              break
-            fi
-            if docker logs regtest-environment 2>&1 | grep -q "all tests passed"; then
-              ready=true
-              break
-            fi
-            sleep 5
-          done
-          if [ "$ready" != "true" ]; then
-            docker logs --tail 200 regtest-environment
-            exit 1
-          fi
-          sudo chmod -R 777 regtest
+          chmod -R 777 .
+          # start.sh pulls the published images, starts Compose, and checks payments.
+          bash ./start.sh
 
       - name: Run Tests
         env:
@@ -112,6 +94,6 @@ jobs:
       - name: Stop Regtest
         if: always()
         run: |
-          docker exec regtest-environment docker compose down --volumes || true
-          docker rm -f regtest-environment || true
-          sudo rm -f /regtest
+          if [ -f regtest/docker-compose.yml ]; then
+            docker compose --project-directory regtest -p cashu down --volumes
+          fi

--- a/.github/workflows/regtest-wallet.yml
+++ b/.github/workflows/regtest-wallet.yml
@@ -22,10 +22,16 @@ on:
 permissions:
   contents: read
 
+env:
+  # Prebuilt cashu-regtest stack (bitcoind, 3x LND, 3x CLN, LNbits). Pinned to
+  # a tag whose docker-compose exposes the node ports on the host (3010, 3001,
+  # 8081, 10009, 5001) with RPC ports consistent with its own scripts.
+  REGTEST_IMAGE: ghcr.io/callebtc/cashu-regtest-environment:sha-bde3931fe27e32b8f83b2adbb65a8460c2f32ef5
+
 jobs:
   regtest-wallet:
     runs-on: ${{ inputs.os-version }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Start PostgreSQL service
         if: contains(inputs.mint-database, 'postgres')
@@ -42,10 +48,34 @@ jobs:
 
       - name: Setup Regtest
         run: |
-          git clone https://github.com/callebtc/cashu-regtest-enviroment.git regtest
-          cd regtest
-          chmod -R 777 .
-          bash ./start.sh
+          mkdir -p regtest/data
+          # The container runs `docker compose` against the host daemon from
+          # /regtest, so the stack's ./data bind mounts resolve to /regtest/data
+          # on the runner. Point that at the workspace copy the tests read.
+          sudo ln -sfn "$PWD/regtest" /regtest
+          docker run -d --name regtest-environment \
+            --network host \
+            --volume /var/run/docker.sock:/var/run/docker.sock \
+            --volume "$PWD/regtest/data:/regtest/data" \
+            "$REGTEST_IMAGE"
+          # The container entrypoint bootstraps the stack and runs its
+          # acceptance checks; wait for them before running the tests.
+          ready=false
+          for i in $(seq 1 120); do
+            if [ "$(docker inspect -f '{{.State.Status}}' regtest-environment)" != "running" ]; then
+              break
+            fi
+            if docker logs regtest-environment 2>&1 | grep -q "all tests passed"; then
+              ready=true
+              break
+            fi
+            sleep 5
+          done
+          if [ "$ready" != "true" ]; then
+            docker logs --tail 200 regtest-environment
+            exit 1
+          fi
+          sudo chmod -R 777 regtest
 
       - name: Run Tests
         env:
@@ -78,3 +108,10 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Stop Regtest
+        if: always()
+        run: |
+          docker exec regtest-environment docker compose down --volumes || true
+          docker rm -f regtest-environment || true
+          sudo rm -f /regtest

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -239,6 +239,24 @@ def get_real_invoice_routed(sats: int) -> str:
     return run_cmd_json(cmd)["payment_request"]
 
 
+def get_real_invoice_fee_leaf(sats: int) -> str:
+    """Invoice from isolated lnd-4, reachable only through the fee hub."""
+    cmd = [
+        "docker",
+        "exec",
+        "cashu-lnd-4-1",
+        "lncli",
+        "--network=regtest",
+        "--rpcserver=lnd-4:10009",
+    ]
+    destination = run_cmd_json([*cmd, "getinfo"])["identity_pubkey"]
+    _wait_for_route(
+        [*docker_lightning_mint_cli, "queryroutes", "--dest", destination, "--amt", str(sats)],
+        "routes",
+    )
+    return run_cmd_json([*cmd, "addinvoice", str(sats)])["payment_request"]
+
+
 async def pay_if_regtest(bolt11: str) -> None:
     if is_regtest:
         pay_real_invoice(bolt11)

--- a/tests/mint/test_mint_api.py
+++ b/tests/mint/test_mint_api.py
@@ -3,7 +3,7 @@ import httpx
 import pytest
 import pytest_asyncio
 
-from cashu.core.base import MeltQuoteState, MintQuoteState
+from cashu.core.base import MeltQuoteState, Method, MintQuoteState, Unit
 from cashu.core.models import (
     GetInfoResponse,
     MintMethodSetting,
@@ -21,6 +21,7 @@ from cashu.wallet.crud import bump_secret_derivation
 from cashu.wallet.wallet import Wallet
 from tests.helpers import (
     get_real_invoice,
+    get_real_invoice_fee_leaf,
     get_real_invoice_routed,
     is_cln_backend,
     is_fake,
@@ -552,7 +553,7 @@ async def test_melt_external_with_routing_fee(ledger: Ledger, wallet: Wallet):
 )
 @pytest.mark.skipif(
     is_cln_backend,
-    reason="CLN pathfinding is randomized, the exact fee is not deterministic",
+    reason="requires an LND mint for the fee-leaf route query",
 )
 async def test_melt_external_routing_fee_rounding(ledger: Ledger, wallet: Wallet):
     mint_quote = await wallet.request_mint(1024)
@@ -560,8 +561,8 @@ async def test_melt_external_routing_fee_rounding(ledger: Ledger, wallet: Wallet
     await wallet.mint(1024, quote_id=mint_quote.quote)
     assert wallet.balance == 1024
 
-    # external invoice that the mint can only pay through a routing node
-    invoice_payment_request = get_real_invoice_routed(1000)
+    # The isolated fee leaf prevents LDK from offering a cheaper, whole-sat route.
+    invoice_payment_request = get_real_invoice_fee_leaf(1000)
 
     quote = await wallet.melt_quote(invoice_payment_request)
     assert quote.amount == 1000
@@ -590,15 +591,23 @@ async def test_melt_external_routing_fee_rounding(ledger: Ledger, wallet: Wallet
     resp_quote = PostMeltQuoteResponse(**response.json())
     assert resp_quote.state == MeltQuoteState.paid.value
 
-    # the routing fee for 1000 sat is 1001 msat (1000 msat base fee + 1 ppm)
-    # which the mint must round up to 2 sat when it accounts the fee
     melt_quote = await ledger.crud.get_melt_quote(quote_id=quote.quote, db=ledger.db)
     assert melt_quote, "No melt quote in db"
-    assert melt_quote.fee_paid == 2, "Fee not rounded up to the next sat"
+
+    # Verify rounding against LND's settled fee, independently of path selection.
+    payment = await ledger.backends[Method.bolt11][Unit.sat].get_payment_status(
+        melt_quote.checking_id
+    )
+    assert payment.settled
+    assert payment.fee is not None and payment.fee.unit == Unit.msat
+    whole_sats, remainder_msat = divmod(payment.fee.amount, 1000)
+    assert remainder_msat > 0, "Route must charge a fractional sat to test rounding"
+    rounded_fee = whole_sats + 1
+    assert melt_quote.fee_paid == rounded_fee, "Fee not rounded up to the next sat"
 
     # we get back the fee reserve minus the rounded up fee
     change_sat = sum([c.amount for c in resp_quote.change or []])
-    assert change_sat == 18, "Wrong change returned"
+    assert change_sat == quote.fee_reserve - rounded_fee, "Wrong change returned"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The regtest workflows follow upstream's default branch, so the test network can change independently of Nutshell. Pin the `callebtc/cashu-regtest` checkout to `7eb3515b9fb41f477f831cedd28e1ad9ae6c521d`, a tested revision with CLN 26.06.7 and support for `xpay`.

CI still checks out the regtest repository and runs `start.sh` to initialize the network and channels and run upstream acceptance checks before the Nutshell tests. Image pulling is handled by the upstream script, which uses published service images where available and can fall back to source builds.

Changes:

- Replace the unpinned `git clone` in both workflows with an explicit checkout of the pinned revision.
- Always tear down the `cashu` Compose project after each regtest job, including its network and volumes.
- Increase the mint timeout from 10 to 30 minutes and the wallet timeout from 10 to 20 minutes to allow setup and tests to finish on slower runners.
- Update the fee-rounding test and its invoice helper for the expanded network. A cheaper route can charge an exact whole-satoshi fee, invalidating the old fixed-fee assumption. Use the isolated fee-testing node, require a fractional-satoshi fee, and verify rounding and returned change against LND's settled fee.

Validation:

- [Full CI run](https://github.com/cashubtc/nutshell/actions/runs/34493665695) passed on `672120a1`: all 21 jobs, including all 12 regtest matrix jobs.
- Local mint API tests passed with LND REST and LND RPC on SQLite and PostgreSQL: 88 passed, 4 skipped.
- `make format` and `make check` passed. Upstream startup checks and removal of the Compose containers, network, and volumes were also verified locally.
