### PR TITLE
fix(mint): unblock mutation tests with RPC state cleanup

### DIFF
--- a/cashu/mint/management_rpc/management_rpc.py
+++ b/cashu/mint/management_rpc/management_rpc.py
@@ -60,7 +60,10 @@ class MintManagementRPC(management_pb2_grpc.MintServicer):
 
     async def AddUrl(self, request, context):
         logger.debug("gRPC AddUrl has been called")
-        if settings.mint_info_urls and request.url not in settings.mint_info_urls:
+        if (
+            settings.mint_info_urls is not None
+            and request.url not in settings.mint_info_urls
+        ):
             settings.mint_info_urls.append(request.url)
         elif settings.mint_info_urls is None:
             settings.mint_info_urls = [request.url]

--- a/cashu/mint/startup.py
+++ b/cashu/mint/startup.py
@@ -141,5 +141,8 @@ async def start_management_rpc():
 
 
 async def shutdown_management_rpc():
+    global rpc_server
     if rpc_server:
         await management_rpc.shutdown(rpc_server)
+        # Release the stopped server and its native gRPC resources.
+        rpc_server = None

--- a/tests/mint/test_mint_management_rpc_server.py
+++ b/tests/mint/test_mint_management_rpc_server.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -51,6 +52,56 @@ def test_get_info_serializes_mint_info():
     assert response.name == "Mint"
     assert response.long_description == "long"
     assert not hasattr(response, "nuts")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("initial_urls", [None, [], ["https://existing.example"]])
+async def test_add_url(initial_urls, monkeypatch):
+    monkeypatch.setattr(
+        settings,
+        "mint_info_urls",
+        None if initial_urls is None else initial_urls.copy(),
+    )
+    expected_urls = [*(initial_urls or []), "https://new.example"]
+    request = SimpleNamespace(url="https://new.example")
+    rpc = _rpc_with_ledger()
+
+    await rpc.AddUrl(request, None)
+
+    assert settings.mint_info_urls == expected_urls
+    with pytest.raises(Exception, match="URL already in mint_info_urls"):
+        await rpc.AddUrl(request, None)
+    assert settings.mint_info_urls == expected_urls
+
+
+@pytest.mark.asyncio
+async def test_add_url_after_removing_last_url(monkeypatch):
+    monkeypatch.setattr(settings, "mint_info_urls", ["https://old.example"])
+    rpc = _rpc_with_ledger()
+
+    await rpc.RemoveUrl(SimpleNamespace(url="https://old.example"), None)
+    assert settings.mint_info_urls == []
+
+    await rpc.AddUrl(SimpleNamespace(url="https://new.example"), None)
+    assert settings.mint_info_urls == ["https://new.example"]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_management_rpc_releases_server(monkeypatch):
+    from cashu.mint import startup
+
+    server = object()
+    shutdown = AsyncMock()
+    monkeypatch.setattr(startup, "rpc_server", server)
+    monkeypatch.setattr(startup.management_rpc, "shutdown", shutdown)
+
+    await startup.shutdown_management_rpc()
+
+    shutdown.assert_awaited_once_with(server)
+    assert startup.rpc_server is None
+
+    await startup.shutdown_management_rpc()
+    shutdown.assert_awaited_once_with(server)
 
 
 @pytest.mark.asyncio

--- a/tests/mint/test_mint_management_rpc_server.py
+++ b/tests/mint/test_mint_management_rpc_server.py
@@ -7,6 +7,7 @@ import pytest
 from cashu.core.base import MeltQuote, MeltQuoteState, MintQuote, MintQuoteState, Unit
 from cashu.core.mint_info import MintInfo
 from cashu.core.settings import settings
+from cashu.mint import startup
 from cashu.mint.management_rpc import management_rpc as rpc_module
 
 
@@ -88,8 +89,6 @@ async def test_add_url_after_removing_last_url(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_shutdown_management_rpc_releases_server(monkeypatch):
-    from cashu.mint import startup
-
     server = object()
     shutdown = AsyncMock()
     monkeypatch.setattr(startup, "rpc_server", server)


### PR DESCRIPTION
Mutation profiles stop during statistics collection when an earlier RPC test removes the final mint URL: `AddUrl` rejects the resulting empty list as a duplicate. Accept empty lists while preserving duplicate rejection, and add regression coverage for adding a URL after removing the last one.

Once that failure was fixed, actual mutant execution exposed a second blocker: shutdown retained the stopped RPC server and its native gRPC resources, causing crashes when Mutmut forked workers. Clear the server reference after successful shutdown and verify that repeated shutdown does not stop the same server again.

Refs #1146. This addresses execution blockers remaining after #1136.

### Validation

- `make format` and `make check` passed, including mypy across 128 source files.
- RPC, RPC server, and CLI tests with `MUTATION_TESTING=true` and `GITHUB_ACTIONS=true`: 45 passed.
- Full Mutmut statistics collection with the CI test selection: 951 passed, 65 skipped. The subsequently added shutdown regression also passed during incremental statistics collection.
- Actual `AddUrl` mutation run with the final code and no diagnostic plugins: all 14 mutants evaluated; 9 killed and 5 survived with one worker.
- A two-worker pilot also completed without native crashes.

### Remaining validation

Parallel workers produced different kill counts from the serial run, so mutation-score consistency needs separate investigation. The five complete weekly profiles have not been rerun.
