### PR TITLE
fix(ci): run Keycloak auth integration tests

### DIFF
--- a/.github/workflows/tests_keycloak_auth.yml
+++ b/.github/workflows/tests_keycloak_auth.yml
@@ -66,22 +66,6 @@ jobs:
         run: |
           poetry run pytest tests/wallet/test_wallet_auth.py -v -rs --cov=cashu.mint --cov-report=xml
 
-      - name: Verify auth tests executed
-        run: |
-          python - <<'PY'
-          import xml.etree.ElementTree as ET
-
-          test_cases = ET.parse("junit.xml").findall(".//testcase")
-          assert test_cases, "No auth tests were collected"
-          skipped = [
-              case.attrib["name"]
-              for case in test_cases
-              if case.find("skipped") is not None
-          ]
-          assert not skipped, f"Auth tests were skipped: {skipped}"
-          print(f"Verified {len(test_cases)} auth tests executed without skips")
-          PY
-
       - name: Stop and clean up Docker Compose
         if: always()
         run: |

--- a/.github/workflows/tests_keycloak_auth.yml
+++ b/.github/workflows/tests_keycloak_auth.yml
@@ -64,9 +64,26 @@ jobs:
           MINT_AUTH_OICD_DISCOVERY_URL: http://localhost:8080/realms/nutshell/.well-known/openid-configuration
           MINT_AUTH_OICD_CLIENT_ID: cashu-client
         run: |
-          poetry run pytest tests/wallet/test_wallet_auth.py -v --cov=mint --cov-report=xml
+          poetry run pytest tests/wallet/test_wallet_auth.py -v -rs --cov=cashu.mint --cov-report=xml
+
+      - name: Verify auth tests executed
+        run: |
+          python - <<'PY'
+          import xml.etree.ElementTree as ET
+
+          test_cases = ET.parse("junit.xml").findall(".//testcase")
+          assert test_cases, "No auth tests were collected"
+          skipped = [
+              case.attrib["name"]
+              for case in test_cases
+              if case.find("skipped") is not None
+          ]
+          assert not skipped, f"Auth tests were skipped: {skipped}"
+          print(f"Verified {len(test_cases)} auth tests executed without skips")
+          PY
 
       - name: Stop and clean up Docker Compose
+        if: always()
         run: |
           docker compose -f tests/keycloak_data/docker-compose-restore.yml down
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
 
 import httpx
@@ -54,7 +55,7 @@ settings.mint_lnd_enable_mpp = True
 settings.mint_clnrest_enable_mpp = True
 settings.mint_input_fee_ppk = 0
 settings.db_connection_pool = True
-settings.mint_require_auth = False
+# Preserve mint_require_auth from the environment for the Keycloak integration job.
 settings.mint_watchdog_enabled = False
 
 settings.mint_rpc_server_enable = True
@@ -130,9 +131,8 @@ async def ledger():
     await ledger.shutdown_ledger()
 
 
-# # This fixture is used for tests that require API access to the mint
-@pytest.fixture(autouse=True, scope="session")
-def mint():
+@contextmanager
+def start_mint_server():
     config = uvicorn.Config(
         "cashu.mint.app:app",
         port=settings.mint_listen_port,
@@ -176,3 +176,14 @@ def mint():
 
     yield server
     server.stop()
+    server.join(timeout=10)
+    if server.is_alive():
+        server.kill()
+        server.join()
+
+
+# This fixture is used for tests that require API access to the mint.
+@pytest.fixture(autouse=True, scope="session")
+def mint():
+    with start_mint_server() as server:
+        yield server

--- a/tests/wallet/test_wallet_auth.py
+++ b/tests/wallet/test_wallet_auth.py
@@ -17,8 +17,15 @@ from cashu.core.errors import (
 from cashu.core.settings import settings
 from cashu.wallet.auth.auth import WalletAuth
 from cashu.wallet.wallet import Wallet
-from tests.conftest import SERVER_ENDPOINT
+from tests.conftest import SERVER_ENDPOINT, start_mint_server
 from tests.helpers import assert_err
+
+
+@pytest.fixture(autouse=True)
+def mint():
+    # Each test needs a fresh per-user rate limit in the mint process.
+    with start_mint_server() as server:
+        yield server
 
 
 @pytest_asyncio.fixture(scope="function")


### PR DESCRIPTION
The Keycloak CI jobs set `MINT_REQUIRE_AUTH=TRUE`, but the shared test setup overwrites it with `False`, causing all eight auth integration tests to skip. Preserve the environment setting so the tests execute.

Give each auth test a fresh mint process so earlier tests cannot consume the rate-limit test's quota. Correct the coverage target to `cashu.mint` and ensure Docker Compose cleanup runs when tests fail.

Validation:

- Keycloak 25.0.6 integration tests: **8 passed, 0 skipped** with each of the SQLite and PostgreSQL mint databases.
- Auth unit, middleware, mint API, and wallet regressions with auth disabled: **82 passed, 13 expected skips**.
- Mint startup smoke test with `MUTATION_TESTING=true`: **1 passed**.
- `make format` and `make check` pass.
